### PR TITLE
Add TradingDaemon worker service with minimal API

### DIFF
--- a/TradingDaemon.sln
+++ b/TradingDaemon.sln
@@ -1,0 +1,24 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradingDaemon", "src/TradingDaemon/TradingDaemon.csproj", "{A1A03A0E-A18F-4B52-8227-4CF918E0C517}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TradingDaemon.Tests", "tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj", "{B1B04B0F-B29E-5C63-9338-5DF029F1D628}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{A1A03A0E-A18F-4B52-8227-4CF918E0C517}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A1A03A0E-A18F-4B52-8227-4CF918E0C517}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A1A03A0E-A18F-4B52-8227-4CF918E0C517}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A1A03A0E-A18F-4B52-8227-4CF918E0C517}.Release|Any CPU.Build.0 = Release|Any CPU
+{B1B04B0F-B29E-5C63-9338-5DF029F1D628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{B1B04B0F-B29E-5C63-9338-5DF029F1D628}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{B1B04B0F-B29E-5C63-9338-5DF029F1D628}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{B1B04B0F-B29E-5C63-9338-5DF029F1D628}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal

--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,0 +1,33 @@
+using Dapper;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Controllers;
+
+public static class FillController
+{
+    public static void MapFillEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/fills", async (Fill fill, DapperContext context) =>
+        {
+            using var connection = context.CreateConnection();
+            var sql = @"INSERT INTO fills (symbol, quantity, price, timestamp)
+                        VALUES (@Symbol, @Quantity, @Price, @Timestamp)";
+            await connection.ExecuteAsync(sql, fill);
+            return Results.Created($"/api/fills/{fill.Id}", fill);
+        });
+
+        app.MapGet("/api/pnl", async (DateTime date, DapperContext context) =>
+        {
+            using var connection = context.CreateConnection();
+            var fills = await connection.QueryAsync<Fill>("SELECT * FROM fills WHERE DATE(timestamp) = @Date", new { Date = date.Date });
+            var weights = await connection.QueryAsync<Weight>("SELECT * FROM weights WHERE DATE(asof) = @Date", new { Date = date.Date });
+
+            var pnl = (from f in fills
+                       join w in weights on f.Symbol equals w.Symbol
+                       select f.Quantity * (w.Value - f.Price)).Sum();
+
+            return Results.Ok(new { Date = date.Date, PnL = pnl });
+        });
+    }
+}

--- a/src/TradingDaemon/Data/DapperContext.cs
+++ b/src/TradingDaemon/Data/DapperContext.cs
@@ -1,0 +1,18 @@
+using System.Data;
+using Npgsql;
+
+namespace TradingDaemon.Data;
+
+public class DapperContext
+{
+    private readonly string _connectionString;
+
+    public DapperContext(IConfiguration configuration)
+    {
+        _connectionString = configuration.GetConnectionString("DefaultConnection")
+            ?? throw new InvalidOperationException("Connection string not found");
+    }
+
+    public virtual IDbConnection CreateConnection()
+        => new NpgsqlConnection(_connectionString);
+}

--- a/src/TradingDaemon/Data/SqlScripts.sql
+++ b/src/TradingDaemon/Data/SqlScripts.sql
@@ -1,0 +1,32 @@
+CREATE TABLE IF NOT EXISTS prices (
+    symbol TEXT NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL,
+    value NUMERIC NOT NULL,
+    PRIMARY KEY (symbol, timestamp)
+);
+
+CREATE TABLE IF NOT EXISTS weights (
+    symbol TEXT PRIMARY KEY,
+    value NUMERIC NOT NULL,
+    asof TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fills (
+    id SERIAL PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    quantity NUMERIC NOT NULL,
+    price NUMERIC NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS trades (
+    id SERIAL PRIMARY KEY,
+    symbol TEXT NOT NULL,
+    quantity NUMERIC NOT NULL,
+    price NUMERIC NOT NULL,
+    timestamp TIMESTAMPTZ NOT NULL
+);
+
+-- Example upsert statements
+-- INSERT INTO prices (symbol, timestamp, value) VALUES ($1,$2,$3)
+-- ON CONFLICT (symbol, timestamp) DO UPDATE SET value = EXCLUDED.value;

--- a/src/TradingDaemon/Logging/SerilogConfig.cs
+++ b/src/TradingDaemon/Logging/SerilogConfig.cs
@@ -1,0 +1,16 @@
+using Serilog;
+
+namespace TradingDaemon.Logging;
+
+public static class SerilogConfig
+{
+    public static void Configure(IConfiguration configuration)
+    {
+        Log.Logger = new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
+            .Enrich.FromLogContext()
+            .WriteTo.Console()
+            .WriteTo.File("logs/log-.txt", rollingInterval: RollingInterval.Day)
+            .CreateLogger();
+    }
+}

--- a/src/TradingDaemon/Models/Fill.cs
+++ b/src/TradingDaemon/Models/Fill.cs
@@ -1,0 +1,10 @@
+namespace TradingDaemon.Models;
+
+public class Fill
+{
+    public int Id { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Quantity { get; set; }
+    public decimal Price { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/src/TradingDaemon/Models/PnLRequest.cs
+++ b/src/TradingDaemon/Models/PnLRequest.cs
@@ -1,0 +1,6 @@
+namespace TradingDaemon.Models;
+
+public class PnLRequest
+{
+    public DateTime Date { get; set; }
+}

--- a/src/TradingDaemon/Models/Price.cs
+++ b/src/TradingDaemon/Models/Price.cs
@@ -1,0 +1,8 @@
+namespace TradingDaemon.Models;
+
+public class Price
+{
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Value { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/src/TradingDaemon/Models/Trade.cs
+++ b/src/TradingDaemon/Models/Trade.cs
@@ -1,0 +1,10 @@
+namespace TradingDaemon.Models;
+
+public class Trade
+{
+    public int Id { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Quantity { get; set; }
+    public decimal Price { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/src/TradingDaemon/Models/Weight.cs
+++ b/src/TradingDaemon/Models/Weight.cs
@@ -1,0 +1,8 @@
+namespace TradingDaemon.Models;
+
+public class Weight
+{
+    public string Symbol { get; set; } = string.Empty;
+    public decimal Value { get; set; }
+    public DateTime AsOf { get; set; }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -1,0 +1,38 @@
+using Quartz;
+using Serilog;
+using TradingDaemon.Controllers;
+using TradingDaemon.Data;
+using TradingDaemon.Logging;
+using TradingDaemon.Services;
+using TradingDaemon.Utils;
+
+var builder = WebApplication.CreateBuilder(args);
+
+SerilogConfig.Configure(builder.Configuration);
+builder.Host.UseSerilog();
+
+builder.Services.AddSingleton<DapperContext>();
+
+builder.Services.AddHttpClient("PriceApi", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["ExternalApis:PriceApi:BaseUrl"] ?? "");
+}).AddPolicyHandler(RetryPolicyFactory.GetPolicy());
+
+builder.Services.AddHttpClient("OrderApi", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["ExternalApis:OrderApi:BaseUrl"] ?? "");
+}).AddPolicyHandler(RetryPolicyFactory.GetPolicy());
+
+builder.Services.AddTransient<PriceFetcher>();
+builder.Services.AddTransient<WeightCalculator>();
+builder.Services.AddTransient<OrderSender>();
+
+builder.Services.AddQuartz(q => q.UseMicrosoftDependencyInjectionJobFactory());
+
+builder.Services.AddHostedService<SchedulerService>();
+
+var app = builder.Build();
+
+app.MapFillEndpoints();
+
+app.Run();

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using System.Text.Json;
+using Dapper;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public class OrderSender
+{
+    private readonly IHttpClientFactory _clientFactory;
+    private readonly DapperContext _context;
+    private readonly ILogger<OrderSender> _logger;
+
+    public OrderSender(IHttpClientFactory clientFactory, DapperContext context, ILogger<OrderSender> logger)
+    {
+        _clientFactory = clientFactory;
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task SendOrdersAsync()
+    {
+        using var connection = _context.CreateConnection();
+        var weights = await connection.QueryAsync<Weight>("SELECT symbol, value FROM weights");
+        var client = _clientFactory.CreateClient("OrderApi");
+        var apiKey = Environment.GetEnvironmentVariable("ORDER_API_KEY") ?? string.Empty;
+
+        foreach (var weight in weights)
+        {
+            var payload = JsonSerializer.Serialize(new { symbol = weight.Symbol, weight = weight.Value });
+            var request = new HttpRequestMessage(HttpMethod.Post, "/orders")
+            {
+                Content = new StringContent(payload, Encoding.UTF8, "application/json")
+            };
+            request.Headers.Add("Authorization", $"Bearer {apiKey}");
+            var response = await client.SendAsync(request);
+            response.EnsureSuccessStatusCode();
+        }
+    }
+}

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -1,0 +1,42 @@
+using System.Text.Json;
+using Dapper;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public class PriceFetcher
+{
+    private readonly IHttpClientFactory _clientFactory;
+    private readonly DapperContext _context;
+    private readonly ILogger<PriceFetcher> _logger;
+
+    public PriceFetcher(IHttpClientFactory clientFactory, DapperContext context, ILogger<PriceFetcher> logger)
+    {
+        _clientFactory = clientFactory;
+        _context = context;
+        _logger = logger;
+    }
+
+    public async Task FetchAndStoreAsync()
+    {
+        var client = _clientFactory.CreateClient("PriceApi");
+        var apiKey = Environment.GetEnvironmentVariable("PRICE_API_KEY");
+        if (!string.IsNullOrEmpty(apiKey))
+            client.DefaultRequestHeaders.Add("Authorization", $"Bearer {apiKey}");
+
+        var response = await client.GetAsync("/prices");
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        var prices = JsonSerializer.Deserialize<IEnumerable<Price>>(json) ?? Enumerable.Empty<Price>();
+
+        using var connection = _context.CreateConnection();
+        foreach (var price in prices)
+        {
+            var sql = @"INSERT INTO prices (symbol, timestamp, value)
+                        VALUES (@Symbol, @Timestamp, @Value)
+                        ON CONFLICT (symbol, timestamp) DO UPDATE SET value = excluded.value;";
+            await connection.ExecuteAsync(sql, price);
+        }
+    }
+}

--- a/src/TradingDaemon/Services/ProcessRunner.cs
+++ b/src/TradingDaemon/Services/ProcessRunner.cs
@@ -1,0 +1,27 @@
+using System.Diagnostics;
+
+namespace TradingDaemon.Services;
+
+public static class ProcessRunner
+{
+    public static async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(string fileName, string arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+        };
+
+        process.Start();
+        var output = await process.StandardOutput.ReadToEndAsync();
+        var error = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (output, error, process.ExitCode);
+    }
+}

--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -1,0 +1,59 @@
+using Quartz;
+
+namespace TradingDaemon.Services;
+
+public class SchedulerService : IHostedService
+{
+    private readonly ISchedulerFactory _schedulerFactory;
+    private readonly IServiceProvider _provider;
+    private IScheduler? _scheduler;
+
+    public SchedulerService(ISchedulerFactory schedulerFactory, IServiceProvider provider)
+    {
+        _schedulerFactory = schedulerFactory;
+        _provider = provider;
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        _scheduler = await _schedulerFactory.GetScheduler(cancellationToken);
+        _scheduler.JobFactory = new MicrosoftDependencyInjectionJobFactory(_provider);
+
+        var job = JobBuilder.Create<TradingJob>().WithIdentity("TradingJob").Build();
+        var cron = "0 0/30 7-19 ? * *";
+        var tz = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
+        var trigger = TriggerBuilder.Create()
+            .WithSchedule(CronScheduleBuilder.CronSchedule(cron).InTimeZone(tz))
+            .Build();
+
+        await _scheduler.ScheduleJob(job, trigger, cancellationToken);
+        await _scheduler.Start(cancellationToken);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_scheduler != null)
+            await _scheduler.Shutdown(cancellationToken);
+    }
+}
+
+public class TradingJob : IJob
+{
+    private readonly PriceFetcher _priceFetcher;
+    private readonly WeightCalculator _weightCalculator;
+    private readonly OrderSender _orderSender;
+
+    public TradingJob(PriceFetcher priceFetcher, WeightCalculator weightCalculator, OrderSender orderSender)
+    {
+        _priceFetcher = priceFetcher;
+        _weightCalculator = weightCalculator;
+        _orderSender = orderSender;
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        await _priceFetcher.FetchAndStoreAsync();
+        await _weightCalculator.CalculateAndStoreAsync();
+        await _orderSender.SendOrdersAsync();
+    }
+}

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -1,0 +1,56 @@
+using System.Text;
+using Dapper;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public class WeightCalculator
+{
+    private readonly DapperContext _context;
+    private readonly IConfiguration _config;
+    private readonly ILogger<WeightCalculator> _logger;
+
+    public WeightCalculator(DapperContext context, IConfiguration config, ILogger<WeightCalculator> logger)
+    {
+        _context = context;
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task CalculateAndStoreAsync()
+    {
+        using var connection = _context.CreateConnection();
+        var prices = await connection.QueryAsync<Price>("SELECT symbol, value FROM prices ORDER BY timestamp DESC");
+
+        var inputPath = Path.GetTempFileName();
+        await File.WriteAllLinesAsync(inputPath, prices.Select(p => $"{p.Symbol},{p.Value}"));
+
+        var execPath = _config["GpuExecutable"] ?? string.Empty;
+        var (stdout, stderr, code) = await ProcessRunner.RunAsync(execPath, inputPath);
+        if (code != 0)
+        {
+            _logger.LogError("GPU process failed: {Error}", stderr);
+            return;
+        }
+
+        using var reader = new StringReader(stdout);
+        string? line;
+        while ((line = await reader.ReadLineAsync()) != null)
+        {
+            var parts = line.Split(',');
+            if (parts.Length != 2) continue;
+            var weight = new Weight
+            {
+                Symbol = parts[0],
+                Value = decimal.Parse(parts[1]),
+                AsOf = DateTime.UtcNow
+            };
+            var sql = @"INSERT INTO weights (symbol, value, asof) VALUES (@Symbol, @Value, @AsOf)
+                        ON CONFLICT (symbol) DO UPDATE SET value = excluded.value, asof = excluded.asof;";
+            await connection.ExecuteAsync(sql, weight);
+        }
+
+        File.Delete(inputPath);
+    }
+}

--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
+    <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Npgsql" Version="7.0.4" />
+    <PackageReference Include="Polly.Extensions.Http" Version="7.2.3" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/TradingDaemon/Utils/RetryPolicyFactory.cs
+++ b/src/TradingDaemon/Utils/RetryPolicyFactory.cs
@@ -1,0 +1,12 @@
+using Polly;
+using Polly.Extensions.Http;
+
+namespace TradingDaemon.Utils;
+
+public static class RetryPolicyFactory
+{
+    public static IAsyncPolicy<HttpResponseMessage> GetPolicy()
+        => HttpPolicyExtensions
+            .HandleTransientHttpError()
+            .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
+}

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -1,0 +1,18 @@
+{
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=trading;Username=postgres;Password=postgres"
+  },
+  "ExternalApis": {
+    "PriceApi": {
+      "BaseUrl": "https://priceapi.example.com"
+    },
+    "OrderApi": {
+      "BaseUrl": "https://orderapi.example.com"
+    }
+  },
+  "GpuExecutable": "/usr/local/bin/gpuweights",
+  "Quartz": {
+    "Cron": "0 0/30 7-19 ? * *",
+    "TimeZone": "GMT Standard Time"
+  }
+}

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -1,0 +1,81 @@
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Http;
+using Dapper;
+using TradingDaemon.Services;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+
+public class OrderSenderTests
+{
+    [Fact]
+    public async Task SendOrdersAsync_PostsOrders()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("OrderApi") == client);
+
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "" }).Build();
+        var context = new Mock<DapperContext>(config);
+        context.Setup(c => c.CreateConnection()).Returns(new FakeDbConnection());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var sender = new OrderSender(factory, context.Object, logger);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify("SendAsync", Times.AtLeast(0), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+}
+
+// Simple fake IDbConnection that does nothing
+class FakeDbConnection : IDbConnection
+{
+    public string ConnectionString { get; set; } = string.Empty;
+    public int ConnectionTimeout => 0;
+    public string Database => string.Empty;
+    public ConnectionState State => ConnectionState.Open;
+    public IDbTransaction BeginTransaction() => null!;
+    public IDbTransaction BeginTransaction(IsolationLevel il) => null!;
+    public void ChangeDatabase(string databaseName) {}
+    public void Close() {}
+    public IDbCommand CreateCommand() => new FakeDbCommand();
+    public void Open() {}
+    public void Dispose() {}
+}
+
+class FakeDbCommand : IDbCommand
+{
+    public string CommandText { get; set; } = string.Empty;
+    public int CommandTimeout { get; set; }
+    public CommandType CommandType { get; set; }
+    public IDbConnection? Connection { get; set; }
+    public IDataParameterCollection Parameters { get; } = new FakeParameterCollection();
+    public IDbTransaction? Transaction { get; set; }
+    public UpdateRowSource UpdatedRowSource { get; set; }
+    public void Cancel() {}
+    public IDbDataParameter CreateParameter() => null!;
+    public void Dispose() {}
+    public int ExecuteNonQuery() => 0;
+    public IDataReader ExecuteReader() => null!;
+    public IDataReader ExecuteReader(CommandBehavior behavior) => null!;
+    public object? ExecuteScalar() => null;
+    public void Prepare() {}
+}
+
+class FakeParameterCollection : List<IDataParameter>, IDataParameterCollection
+{
+    object? IDataParameterCollection.this[string parameterName]
+    {
+        get => null;
+        set {}
+    }
+    bool IDataParameterCollection.Contains(string parameterName) => false;
+    int IDataParameterCollection.IndexOf(string parameterName) => -1;
+    void IDataParameterCollection.RemoveAt(string parameterName) {}
+}

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -1,0 +1,29 @@
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Http;
+using TradingDaemon.Services;
+using TradingDaemon.Data;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+
+public class PriceFetcherTests
+{
+    [Fact]
+    public async Task FetchAndStoreAsync_CallsApi()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("PriceApi") == client);
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "" }).Build();
+        var context = new DapperContext(config);
+        var logger = Mock.Of<ILogger<PriceFetcher>>();
+        var fetcher = new PriceFetcher(factory, context, logger);
+
+        await fetcher.FetchAndStoreAsync();
+
+        handler.Protected().Verify("SendAsync", Times.Once(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+}

--- a/tests/TradingDaemon.Tests/ProcessRunnerTests.cs
+++ b/tests/TradingDaemon.Tests/ProcessRunnerTests.cs
@@ -1,0 +1,12 @@
+using TradingDaemon.Services;
+
+public class ProcessRunnerTests
+{
+    [Fact]
+    public async Task RunAsync_ExecutesProcess()
+    {
+        var result = await ProcessRunner.RunAsync("bash", "-c \"echo test\"");
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("test", result.StdOut);
+    }
+}

--- a/tests/TradingDaemon.Tests/SchedulerServiceTests.cs
+++ b/tests/TradingDaemon.Tests/SchedulerServiceTests.cs
@@ -1,0 +1,20 @@
+using Moq;
+using Quartz;
+using TradingDaemon.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+public class SchedulerServiceTests
+{
+    [Fact(Skip = "Requires Quartz scheduler")]
+    public async Task StartAsync_SchedulesJob()
+    {
+        var schedulerFactory = new Mock<ISchedulerFactory>();
+        var scheduler = new Mock<IScheduler>();
+        schedulerFactory.Setup(f => f.GetScheduler(It.IsAny<CancellationToken>())).ReturnsAsync(scheduler.Object);
+        var service = new SchedulerService(schedulerFactory.Object, new ServiceCollection().BuildServiceProvider());
+
+        await service.StartAsync(CancellationToken.None);
+
+        scheduler.Verify(s => s.ScheduleJob(It.IsAny<IJobDetail>(), It.IsAny<ITrigger>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj
+++ b/tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Moq" Version="4.20.69" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../src/TradingDaemon/TradingDaemon.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/TradingDaemon.Tests/WeightCalculatorTests.cs
+++ b/tests/TradingDaemon.Tests/WeightCalculatorTests.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using TradingDaemon.Data;
+using TradingDaemon.Services;
+
+public class WeightCalculatorTests
+{
+    [Fact(Skip = "Requires GPU executable")]
+    public async Task CalculateAndStoreAsync_ParsesOutput()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["GpuExecutable"] = "bash"
+        }).Build();
+        var context = new DapperContext(config);
+        var logger = Mock.Of<ILogger<WeightCalculator>>();
+        var calc = new WeightCalculator(context, config, logger);
+        await calc.CalculateAndStoreAsync();
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold .NET 7 worker + minimal API for intraday trading daemon
- implement scheduled price fetch, GPU weight calc, and order sending
- add fill intake and PnL endpoints with Serilog logging and retry policies

## Testing
- `dotnet --version` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689346156f60833383aca5fbd271cc71