### PR TITLE
Replace deprecated Polly.Extensions.Http usage

### DIFF
--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -8,7 +8,8 @@
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Npgsql" Version="7.0.4" />
-    <PackageReference Include="Polly.Extensions.Http" Version="7.2.3" />
+      <PackageReference Include="Polly" Version="7.2.3" />
+      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/src/TradingDaemon/Utils/RetryPolicyFactory.cs
+++ b/src/TradingDaemon/Utils/RetryPolicyFactory.cs
@@ -1,12 +1,15 @@
 using Polly;
-using Polly.Extensions.Http;
+using System.Net;
 
 namespace TradingDaemon.Utils;
 
 public static class RetryPolicyFactory
 {
     public static IAsyncPolicy<HttpResponseMessage> GetPolicy()
-        => HttpPolicyExtensions
-            .HandleTransientHttpError()
+        => Policy<HttpResponseMessage>
+            .Handle<HttpRequestException>()
+            .OrResult(response =>
+                response.StatusCode == HttpStatusCode.RequestTimeout ||
+                (int)response.StatusCode >= 500)
             .WaitAndRetryAsync(3, attempt => TimeSpan.FromSeconds(Math.Pow(2, attempt)));
 }


### PR DESCRIPTION
## Summary
- remove Polly.Extensions.Http usage and use core Polly with manual HTTP transient error handling
- depend on Polly and Microsoft.Extensions.Http.Polly packages instead of deprecated library

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68937d478dd48333b650499d4a8da0a2