### PR TITLE
Fix Quartz job factory compile error

### DIFF
--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -5,19 +5,16 @@ namespace TradingDaemon.Services;
 public class SchedulerService : IHostedService
 {
     private readonly ISchedulerFactory _schedulerFactory;
-    private readonly IServiceProvider _provider;
     private IScheduler? _scheduler;
 
-    public SchedulerService(ISchedulerFactory schedulerFactory, IServiceProvider provider)
+    public SchedulerService(ISchedulerFactory schedulerFactory)
     {
         _schedulerFactory = schedulerFactory;
-        _provider = provider;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _scheduler = await _schedulerFactory.GetScheduler(cancellationToken);
-        _scheduler.JobFactory = new MicrosoftDependencyInjectionJobFactory(_provider);
 
         var job = JobBuilder.Create<TradingJob>().WithIdentity("TradingJob").Build();
         var cron = "0 0/30 7-19 ? * *";


### PR DESCRIPTION
## Summary
- remove explicit MicrosoftDependencyInjectionJobFactory usage in SchedulerService and rely on AddQuartz configuration

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689380bea7088333b0b0f06f50581b5f