### PR TITLE
Add Swagger support to TradingDaemon

### DIFF
--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -30,8 +30,16 @@ builder.Services.AddTransient<OrderSender>();
 builder.Services.AddQuartz(q => q.UseMicrosoftDependencyInjectionJobFactory());
 
 builder.Services.AddHostedService<SchedulerService>();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
 
 var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
 
 app.MapFillEndpoints();
 

--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -13,5 +13,6 @@
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
- add Swashbuckle.AspNetCore package
- enable Swagger services and middleware for development

## Testing
- `dotnet test` *(fails: command not found)*
- `dotnet run --project src/TradingDaemon/TradingDaemon.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6894674ee7048333ba4a231534402eeb