### PR TITLE
chore: bump Npgsql to 7.0.5

### DIFF
--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -7,7 +7,7 @@
   <ItemGroup>
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-    <PackageReference Include="Npgsql" Version="7.0.4" />
+      <PackageReference Include="Npgsql" Version="7.0.5" />
       <PackageReference Include="Polly" Version="8.6.2" />
       <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />


### PR DESCRIPTION
## Summary
- use the latest patched Npgsql release in TradingDaemon project

## Testing
- `dotnet restore` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh ...` *(fails: CONNECT tunnel 403)*

------
https://chatgpt.com/codex/tasks/task_e_689472da2d54833399b5f6faf3329a71