### PR TITLE
feat: allow manual GPU job trigger

### DIFF
--- a/src/TradingDaemon/Controllers/TradingController.cs
+++ b/src/TradingDaemon/Controllers/TradingController.cs
@@ -1,0 +1,17 @@
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class TradingController
+{
+    public static void MapTradingEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/trading/run", async (PriceFetcher priceFetcher, WeightCalculator weightCalculator, OrderSender orderSender) =>
+        {
+            await priceFetcher.FetchAndStoreAsync();
+            await weightCalculator.CalculateAndStoreAsync();
+            await orderSender.SendOrdersAsync();
+            return Results.Ok(new { Status = "Completed" });
+        });
+    }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -1,4 +1,3 @@
-using Quartz;
 using Serilog;
 using TradingDaemon.Controllers;
 using TradingDaemon.Data;
@@ -27,9 +26,6 @@ builder.Services.AddTransient<PriceFetcher>();
 builder.Services.AddTransient<WeightCalculator>();
 builder.Services.AddTransient<OrderSender>();
 
-builder.Services.AddQuartz(q => q.UseMicrosoftDependencyInjectionJobFactory());
-
-builder.Services.AddHostedService<SchedulerService>();
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
@@ -46,5 +42,6 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapFillEndpoints();
+app.MapTradingEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary
- remove quartz scheduler that ran GPU job automatically
- add Swagger endpoint to trigger trading sequence manually

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden for package repos)*

------
https://chatgpt.com/codex/tasks/task_e_6894874b7ce083338b83502e0c4336b2