### PR TITLE
Use ODBC Driver 17 and disable encryption for SQL export

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -55,7 +55,7 @@ def get_conn_from_secret(
 
     driver = quote_plus(data.get("driver", default_driver))
     return (
-        f"mssql+pyodbc://{user}:{password}@{host}:{port}/{db}?driver={driver}"
+        f"mssql+pyodbc://{user}:{password}@{host}:{port}/{db}?driver={driver}&Encrypt=no"
     )
 
 def parse_range(value: str) -> tuple[int, int]:
@@ -164,7 +164,7 @@ cli.add_argument(
 )
 cli.add_argument(
     "--driver",
-    default="ODBC Driver 18 for SQL Server",
+    default="ODBC Driver 17 for SQL Server",
     help="ODBC driver name to use when connecting via pyodbc",
 )
 cli.add_argument("--offset", type=int, default=0)


### PR DESCRIPTION
## Summary
- use ODBC Driver 17 as default for SQL export script
- disable SQL Server encryption in connection string

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6899f576dbd48333bc2fdacad4d2dd67