### PR TITLE
Make export script timeframe configurable

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -103,7 +103,7 @@ def read_price_bars(
     security_id: int,
     start: str | None,
     session: str,
-    timeframe: int = 30,
+    timeframe: int = 60,
 ) -> pd.DataFrame:
     params = {"sid": security_id, "tf": timeframe}
     sql = (
@@ -147,6 +147,12 @@ cli.add_argument(
     help="ODBC driver name to use when connecting via pyodbc",
 )
 cli.add_argument("--start")
+cli.add_argument(
+    "--timeframe",
+    type=int,
+    default=60,
+    help="Bar timeframe in minutes (TimeframeMinute)",
+)
 args = cli.parse_args()
 
 conn_str = args.conn or get_conn_from_secret(args.secret_name, args.region, args.driver)
@@ -173,13 +179,13 @@ for real_sid in universe_ids:
     sec_ids.append(sid)
     print("→", real_sid)
 
-    df_raw = read_price_bars(engine, real_sid, args.start, args.session)
+    df_raw = read_price_bars(engine, real_sid, args.start, args.session, args.timeframe)
     check_long_gaps(df_raw["timestamp"], 5)
     if df_raw.empty:
         continue
 
     raw = df_raw.set_index("timestamp")["close"]
-    flat = raw.resample("30T").ffill()
+    flat = raw.resample(f"{args.timeframe}T").ffill()
     all_ts.update(raw.index)
 
     frame(sid, flat).to_csv(OUT["A"], mode="a", header=False, index=False)


### PR DESCRIPTION
## Summary
- add `--timeframe` option to export script with default 60 minutes
- use chosen timeframe when querying and resampling price bars

## Testing
- `python -m py_compile scripts/export_prices_rds.py`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a03ab824083339d5a3716099ad33e