### PR TITLE
Fix export session time filtering for European data

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -150,7 +150,8 @@ def read_price_bars(
     lo = start.hour * 60 + start.minute
     hi = end.hour * 60 + end.minute
     mask = minutes.between(lo, hi)
-    df = df[mask]
+    df = df[mask].copy()
+    df["timestamp"] = ts[mask]
     return df
 
 # ---------- CLI ----------


### PR DESCRIPTION
## Summary
- ensure timestamps are converted to session timezone before filtering/serializing

## Testing
- `python -m py_compile scripts/export_prices_rds.py`
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689a22a3669083339dcae3d9f8da2516