### PR TITLE
Run price export script before weight calculation

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -11,6 +11,10 @@
     }
   },
   "GpuExecutable": "/usr/local/bin/gpuweights",
+  "PriceExport": {
+    "PythonExecutable": "python3",
+    "Universe": "EUUS"
+  },
   "Quartz": {
     "Cron": "0 0/30 7-19 ? * *",
     "TimeZone": "GMT Standard Time"


### PR DESCRIPTION
## Summary
- Execute `export_prices_rds.py` via Python before fetching prices in weight calculation
- Add configurable Python executable and universe settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689ddd3cbc4c8333a94056cb2f621aaa