### PR TITLE
Log external process output and enable streaming

### DIFF
--- a/src/TradingDaemon/Services/ProcessRunner.cs
+++ b/src/TradingDaemon/Services/ProcessRunner.cs
@@ -1,10 +1,15 @@
 using System.Diagnostics;
+using System.Text;
 
 namespace TradingDaemon.Services;
 
 public static class ProcessRunner
 {
-    public static async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(string fileName, string arguments)
+    public static async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(
+        string fileName,
+        string arguments,
+        Action<string>? onOutput = null,
+        Action<string>? onError = null)
     {
         var process = new Process
         {
@@ -17,11 +22,43 @@ public static class ProcessRunner
             }
         };
 
-        process.Start();
-        var output = await process.StandardOutput.ReadToEndAsync();
-        var error = await process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
+        var stdOut = new StringBuilder();
+        var stdErr = new StringBuilder();
+        var outTcs = new TaskCompletionSource<bool>();
+        var errTcs = new TaskCompletionSource<bool>();
 
-        return (output, error, process.ExitCode);
+        process.OutputDataReceived += (sender, e) =>
+        {
+            if (e.Data == null)
+            {
+                outTcs.TrySetResult(true);
+            }
+            else
+            {
+                stdOut.AppendLine(e.Data);
+                onOutput?.Invoke(e.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (sender, e) =>
+        {
+            if (e.Data == null)
+            {
+                errTcs.TrySetResult(true);
+            }
+            else
+            {
+                stdErr.AppendLine(e.Data);
+                onError?.Invoke(e.Data);
+            }
+        };
+
+        process.Start();
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await Task.WhenAll(process.WaitForExitAsync(), outTcs.Task, errTcs.Task);
+
+        return (stdOut.ToString(), stdErr.ToString(), process.ExitCode);
     }
 }

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -28,6 +28,8 @@ public class WeightCalculator
         var scriptArgs = string.IsNullOrEmpty(universe) ? scriptPath : $"{scriptPath} --universe {universe} --session {tradingSession}";
 
         var (pyOut, pyErr, pyCode) = await ProcessRunner.RunAsync(pythonExec, scriptArgs);
+        _logger.LogInformation("Price export script stdout: {StdOut}", pyOut);
+        _logger.LogInformation("Price export script stderr: {StdErr}", pyErr);
         if (pyCode != 0)
         {
             _logger.LogError("Price export script failed: {Error}", pyErr);

--- a/tests/TradingDaemon.Tests/ProcessRunnerTests.cs
+++ b/tests/TradingDaemon.Tests/ProcessRunnerTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Xunit;
 using TradingDaemon.Services;
 
@@ -9,5 +10,17 @@ public class ProcessRunnerTests
         var result = await ProcessRunner.RunAsync("bash", "-c \"echo test\"");
         Assert.Equal(0, result.ExitCode);
         Assert.Contains("test", result.StdOut);
+    }
+
+    [Fact]
+    public async Task RunAsync_StreamsOutput()
+    {
+        var outs = new List<string>();
+        var errs = new List<string>();
+        var result = await ProcessRunner.RunAsync("bash", "-c \"echo out; echo err >&2\"", outs.Add, errs.Add);
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("out", outs);
+        Assert.Contains("err", errs);
     }
 }


### PR DESCRIPTION
## Summary
- Log stdout and stderr from price export script for easier debugging
- Allow `ProcessRunner.RunAsync` to stream output via callbacks
- Add tests to cover streaming behaviour

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689de710130c8333ad555d07a5277d91