### PR TITLE
Save price exports under IntradayFX directory

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -228,7 +228,9 @@ for row in members_df.itertuples(index=False):
     if pd.isna(end):
         end = pd.Timestamp.max.tz_localize("UTC")
     membership_by_real_sid.setdefault(row.SecurityId, []).append((start, end))
-output_dir = pathlib.Path("src/TradingDaemon/Data/Universes") / universe_name
+# Save exported price files to a fixed Windows directory for downstream processes
+# that expect universes to reside under ``C:\IntradayFX``.
+output_dir = pathlib.Path(r"C:\IntradayFX") / universe_name
 output_dir.mkdir(parents=True, exist_ok=True)
 OUT = {k: output_dir / f"{k}.txt" for k in "ABCDEFGHI"}
 for path in OUT.values():


### PR DESCRIPTION
## Summary
- export_prices_rds now writes output files to `C:\IntradayFX\{Universe}` so downstream tools can find them in a fixed location

## Testing
- `python -m py_compile scripts/export_prices_rds.py`
- `dotnet test` *(fails: command not found; `apt-get update` failed to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_689f0964788c8333ae3f5885dc4a1e1d