### PR TITLE
Normalize start date filter to UTC

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -207,7 +207,10 @@ cli.add_argument(
     default="ODBC Driver 17 for SQL Server",
     help="ODBC driver name to use when connecting via pyodbc",
 )
-cli.add_argument("--start")
+cli.add_argument(
+    "--start",
+    help="Start date in America/New_York timezone (bars from this date onward)",
+)
 cli.add_argument(
     "--timeframe",
     type=int,
@@ -219,15 +222,25 @@ args = cli.parse_args()
 conn_str = args.conn or get_conn_from_secret(args.secret_name, args.region, args.driver)
 engine = sa.create_engine(conn_str)
 
+start_filter = None
+if args.start:
+    start_dt = pd.Timestamp(args.start)
+    if start_dt.tzinfo is None:
+        start_dt = start_dt.tz_localize("America/New_York")
+    else:
+        start_dt = start_dt.tz_convert("America/New_York")
+    start_dt = start_dt.normalize()
+    start_filter = start_dt.tz_convert("UTC").strftime("%Y-%m-%d %H:%M:%S")
+
 universe_id, universe_name, members_df = get_universe_info(engine, args.universe)
 universe_ids = members_df["SecurityId"].unique().tolist()
 membership_by_real_sid: dict[int, List[tuple[pd.Timestamp, pd.Timestamp]]] = {}
 for row in members_df.itertuples(index=False):
-    start = pd.to_datetime(row.EffectiveFromUtc, utc=True)
+    start_member = pd.to_datetime(row.EffectiveFromUtc, utc=True)
     end = pd.to_datetime(row.EffectiveToUtc, utc=True, errors="coerce")
     if pd.isna(end):
         end = pd.Timestamp.max.tz_localize("UTC")
-    membership_by_real_sid.setdefault(row.SecurityId, []).append((start, end))
+    membership_by_real_sid.setdefault(row.SecurityId, []).append((start_member, end))
 # Save exported price files to a fixed Windows directory for downstream processes
 # that expect universes to reside under ``C:\IntradayFX``.
 output_dir = pathlib.Path(r"C:\IntradayFX") / universe_name
@@ -252,7 +265,7 @@ for real_sid in universe_ids:
     print("→", real_sid)
 
     df_raw = read_price_bars(
-        engine, real_sid, args.start, args.session, args.timeframe
+        engine, real_sid, start_filter, args.session, args.timeframe
     )
     check_long_gaps(df_raw["timestamp"], 5)
     if df_raw.empty:
@@ -260,7 +273,7 @@ for real_sid in universe_ids:
         continue
 
     df_flat = read_flat_bars(
-        engine, real_sid, args.start, args.session, args.timeframe
+        engine, real_sid, start_filter, args.session, args.timeframe
     )
     if df_flat.empty:
         print(f"Skipping {real_sid}: no flat bars")


### PR DESCRIPTION
## Summary
- treat `--start` as a date and let `--session` control intraday hours
- normalize the start date in New York and convert to UTC before querying

## Testing
- `python -m py_compile scripts/export_prices_rds.py && echo 'py_compile success'`
- `dotnet test` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689f3f4a502c83338775d62be2926db2