### PR TITLE
Use shared historical data directory

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -241,9 +241,9 @@ for row in members_df.itertuples(index=False):
     if pd.isna(end):
         end = pd.Timestamp.max.tz_localize("UTC")
     membership_by_real_sid.setdefault(row.SecurityId, []).append((start_member, end))
-# Save exported price files to a fixed Windows directory for downstream processes
-# that expect universes to reside under ``C:\IntradayFX``.
-output_dir = pathlib.Path(r"C:\IntradayFX") / universe_name
+# Save exported price files to a fixed directory for downstream processes
+# that expect universes to reside under ``/home/data/historical_data``.
+output_dir = pathlib.Path("/home/data/historical_data") / f"Univ{universe_id}"
 output_dir.mkdir(parents=True, exist_ok=True)
 OUT = {k: output_dir / f"{k}.txt" for k in "ABCDEFGHI"}
 for path in OUT.values():

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -48,7 +48,7 @@ public class WeightCalculator
             return;
         }
 
-        var exportDir = Path.Combine(@"C:\IntradayFX", universe);
+        var exportDir = Path.Combine("/home/data/historical_data", universe);
         foreach (var name in new[] {"A", "H", "I"})
         {
             var path = Path.Combine(exportDir, $"{name}.txt");


### PR DESCRIPTION
## Summary
- write exported pricing files under /home/data/historical_data/Univ{UniverseID}
- update weight calculator to read pricing files from the new location

## Testing
- `python -m py_compile scripts/export_prices_rds.py`
- `dotnet test` *(fails: command not found; attempted `apt-get update` but repository access was forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689f45f021e0833391b64225751dba0c