### PR TITLE
feat: store aggregated weights in database

### DIFF
--- a/src/TradingDaemon/Data/DapperContext.cs
+++ b/src/TradingDaemon/Data/DapperContext.cs
@@ -1,5 +1,9 @@
 using System.Data;
-using Npgsql;
+using Amazon;
+using Amazon.SecretsManager;
+using Amazon.SecretsManager.Model;
+using Microsoft.Data.SqlClient;
+using System.Text.Json;
 
 namespace TradingDaemon.Data;
 
@@ -9,10 +13,30 @@ public class DapperContext
 
     public DapperContext(IConfiguration configuration)
     {
-        _connectionString = configuration.GetConnectionString("DefaultConnection")
-            ?? throw new InvalidOperationException("Connection string not found");
+        var conn = configuration.GetConnectionString("DefaultConnection");
+        if (!string.IsNullOrWhiteSpace(conn))
+        {
+            _connectionString = conn;
+            return;
+        }
+
+        var secretName = "qq-intraday-credentials";
+        var region = configuration["AWS:Region"] ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "us-east-1";
+
+        using var client = new AmazonSecretsManagerClient(RegionEndpoint.GetBySystemName(region));
+        var request = new GetSecretValueRequest { SecretId = secretName };
+        var response = client.GetSecretValueAsync(request).GetAwaiter().GetResult();
+        var secretJson = response.SecretString ?? throw new InvalidOperationException("Secret string is empty");
+        var doc = JsonDocument.Parse(secretJson).RootElement;
+        var host = doc.GetProperty("host").GetString();
+        var username = doc.GetProperty("username").GetString();
+        var password = doc.GetProperty("password").GetString();
+        var dbname = doc.TryGetProperty("dbname", out var dbEl) ? dbEl.GetString() : string.Empty;
+        var port = doc.TryGetProperty("port", out var portEl) ? portEl.GetInt32() : 1433;
+
+        _connectionString = $"Server={host},{port};Database={dbname};User Id={username};Password={password};Encrypt=True;TrustServerCertificate=True;";
     }
 
     public virtual IDbConnection CreateConnection()
-        => new NpgsqlConnection(_connectionString);
+        => new SqlConnection(_connectionString);
 }

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -29,9 +29,11 @@ public class PriceFetcher
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         var prices = JsonSerializer.Deserialize<IEnumerable<Price>>(json) ?? Enumerable.Empty<Price>();
+        var priceList = prices.ToList();
+        if (priceList.Count == 0) return;
 
         using var connection = _context.CreateConnection();
-        foreach (var price in prices)
+        foreach (var price in priceList)
         {
             var sql = @"INSERT INTO prices (symbol, timestamp, value)
                         VALUES (@Symbol, @Timestamp, @Value)

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -117,9 +118,28 @@ public class WeightCalculator
             if (File.Exists(weightsFile))
             {
                 var lines = await File.ReadAllLinesAsync(weightsFile);
+                using var connection = _context.CreateConnection();
+                await connection.OpenAsync();
                 foreach (var line in lines)
                 {
                     _logger.LogInformation("[aggregated-weights] {Line}", line);
+                    var parts = line.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+                    if (parts.Length < 2 || !decimal.TryParse(parts[1], NumberStyles.Any, CultureInfo.InvariantCulture, out var val))
+                        continue;
+                    var weight = new Weight
+                    {
+                        Symbol = parts[0],
+                        Value = val,
+                        AsOf = DateTime.UtcNow
+                    };
+                    var sql = @"MERGE INTO weights AS target
+USING (SELECT @Symbol AS symbol, @Value AS value, @AsOf AS asof) AS source
+ON target.symbol = source.symbol
+WHEN MATCHED THEN
+    UPDATE SET value = source.value, asof = source.asof
+WHEN NOT MATCHED THEN
+    INSERT (symbol, value, asof) VALUES (source.symbol, source.value, source.asof);";
+                    await connection.ExecuteAsync(sql, weight);
                 }
             }
             else

--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -8,9 +8,10 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Quartz.Extensions.Hosting" Version="3.6.2" />
     <PackageReference Include="Dapper" Version="2.0.123" />
-      <PackageReference Include="Npgsql" Version="9.0.3" />
-      <PackageReference Include="Polly" Version="8.6.2" />
-      <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
+    <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.300.35" />
+    <PackageReference Include="Polly" Version="8.6.2" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -22,7 +22,10 @@ public class OrderSenderTests
         var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("OrderApi") == client);
 
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "" }).Build();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = "Server=localhost;Database=test;User Id=test;Password=test;"
+        }).Build();
         var context = new Mock<DapperContext>(config);
         context.Setup(c => c.CreateConnection()).Returns(new FakeDbConnection());
 

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -18,7 +18,10 @@ public class PriceFetcherTests
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("[]") });
         var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("PriceApi") == client);
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?> { ["ConnectionStrings:DefaultConnection"] = "" }).Build();
+        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            ["ConnectionStrings:DefaultConnection"] = "Server=localhost;Database=test;User Id=test;Password=test;"
+        }).Build();
         var context = new DapperContext(config);
         var logger = Mock.Of<ILogger<PriceFetcher>>();
         var fetcher = new PriceFetcher(factory, context, logger);

--- a/tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj
+++ b/tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj
@@ -8,7 +8,6 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.19" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
     <PackageReference Include="Moq" Version="4.20.69" />
-    <PackageReference Include="Npgsql" Version="9.0.3" />
     <PackageReference Include="Polly" Version="8.6.2" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0" />


### PR DESCRIPTION
## Summary
- fetch DB credentials from secret manager and build SQL Server connection
- upsert aggregated weights into the weights table
- adjust tests to avoid calling secret manager

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f7d7d2148333b77816ba9e3a62ef