### PR TITLE
Send weights to theoretical weight table

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -2,6 +2,7 @@
   "ConnectionStrings": {
     "DefaultConnection": "Host=localhost;Port=5432;Database=trading;Username=postgres;Password=postgres"
   },
+  "ModelId": 0,
   "ExternalApis": {
     "PriceApi": {
       "BaseUrl": "https://priceapi.example.com"


### PR DESCRIPTION
## Summary
- persist aggregated weights in `model.TheoreticalWeight` table
- register a `ModelRun` and link weights to the run
- configure `ModelId` in application settings

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fef764ec8333909a2bc51d42ea3e