### PR TITLE
fix: use SQL Server connection string

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "DefaultConnection": "Host=localhost;Port=5432;Database=trading;Username=postgres;Password=postgres"
+    "DefaultConnection": "Server=localhost;Database=trading;User Id=postgres;Password=postgres;TrustServerCertificate=True;"
   },
   "ModelId": 0,
   "ExternalApis": {


### PR DESCRIPTION
## Summary
- use `Server` keyword in connection string for SqlConnection

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a60286ead8833385b36deede0f59c5