### PR TITLE
Log only inserted aggregated weight lines

### DIFF
--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -146,13 +146,13 @@ END";
 
                     foreach (var line in lines.Skip(1))
                     {
-                        _logger.LogInformation("[aggregated-weights] {Line}", line);
                         var parts = line.Split(delimiter, StringSplitOptions.TrimEntries);
                         if (parts.Length <= 1 ||
                             !DateTime.TryParse(parts[0], CultureInfo.InvariantCulture,
                                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var barTimeUtc))
                             continue;
 
+                        var inserted = false;
                         for (var i = 1; i < parts.Length && i - 1 < securityIds.Length; i++)
                         {
                             var securityId = securityIds[i - 1];
@@ -169,7 +169,13 @@ END";
                                 Weight = val
                             };
 
-                            await connection.ExecuteAsync(sql, record);
+                            var rows = await connection.ExecuteAsync(sql, record);
+                            if (rows > 0) inserted = true;
+                        }
+
+                        if (inserted)
+                        {
+                            _logger.LogInformation("[aggregated-weights] {Line}", line);
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- log aggregated weight lines only when insert into DB succeeds

## Testing
- `dotnet test` *(fails: bash: command not found: dotnet)*


------
https://chatgpt.com/codex/tasks/task_e_68a60e7a1e8c83338009c3908372651e