### PR TITLE
Avoid duplicate inverse USD pairs

### DIFF
--- a/tests/TradingDaemon.Tests/UsdPairDedupTests.cs
+++ b/tests/TradingDaemon.Tests/UsdPairDedupTests.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Reflection;
+using TradingDaemon.Services;
+using Xunit;
+
+public class UsdPairDedupTests
+{
+    [Fact]
+    public void BuildUsdMap_RemovesInverseDuplicates()
+    {
+        var usdPairs = new List<(long SecurityId, string Ticker)>
+        {
+            (1, "AUDUSD Curncy"),
+            (2, "USDAUD Curncy"),
+            (3, "EURUSD Curncy")
+        };
+
+        var method = typeof(WeightCalculator).GetMethod("BuildUsdMap", BindingFlags.NonPublic | BindingFlags.Static);
+        var usdMap = (Dictionary<(string Base, string Quote), long>)method!.Invoke(null, new object[] { usdPairs })!;
+
+        var hasAudUsd = usdMap.ContainsKey(("AUD", "USD"));
+        var hasUsdAud = usdMap.ContainsKey(("USD", "AUD"));
+        Assert.True(hasAudUsd ^ hasUsdAud);
+        Assert.Equal(2, usdMap.Count);
+    }
+}


### PR DESCRIPTION
## Summary
- prevent double-counting inverse USD pairs when building USD pair map
- test USD pair deduplication logic

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a6e1b87f3c8333bc99e73e2e4f31a4