### PR TITLE
Configure PriceFetcher CSV path via appsettings

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -3,6 +3,7 @@
     "DefaultConnection": ""
   },
   "ModelId": 0,
+  "PriceCsvPath": "sample_prices.csv",
   "ExternalApis": {
     "PriceApi": {
       "BaseUrl": "https://priceapi.example.com"

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -22,11 +22,11 @@ public class PriceFetcherTests
     {
         var tempFile = Path.GetTempFileName();
         File.WriteAllText(tempFile, "Timestamp,123\n");
-        Environment.SetEnvironmentVariable("PRICE_CSV_PATH", tempFile);
 
         var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
         {
-            ["ConnectionStrings:DefaultConnection"] = "Server=localhost;Database=test;User Id=test;Password=test;"
+            ["ConnectionStrings:DefaultConnection"] = "Server=localhost;Database=test;User Id=test;Password=test;",
+            ["PriceCsvPath"] = tempFile
         }).Build();
         var context = new TestDapperContext(config);
         var logger = Mock.Of<ILogger<PriceFetcher>>();


### PR DESCRIPTION
## Summary
- add `PriceCsvPath` setting to appsettings for PriceFetcher
- adjust PriceFetcher test to read CSV path from configuration

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7424d91f083339b8f135d868b2b75