### PR TITLE
Expose price fetch endpoint via Swagger

### DIFF
--- a/src/TradingDaemon/Controllers/PriceController.cs
+++ b/src/TradingDaemon/Controllers/PriceController.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.OpenApi;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class PriceController
+{
+    public static void MapPriceEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/prices/fetch", async (PriceFetcher priceFetcher) =>
+        {
+            await priceFetcher.FetchAndStoreAsync();
+            return Results.Ok(new { Status = "PricesFetched" });
+        })
+        .WithName("FetchPrices")
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Runs the price fetcher";
+            op.Description = "Fetches price data from the configured CSV file and stores it in the database.";
+            return op;
+        });
+    }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -42,6 +42,7 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapFillEndpoints();
+app.MapPriceEndpoints();
 app.MapWeightEndpoints();
 app.MapTradingEndpoints();
 


### PR DESCRIPTION
## Summary
- add endpoint to trigger PriceFetcher
- wire endpoint in Program for swagger exposure

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a744a144f08333a39a88171285098d