### PR TITLE
Include pre-session 9am bar in US flat bar computation

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -114,8 +114,9 @@ public class PriceFetcher
         {
             var ny = TimeZoneInfo.ConvertTimeFromUtc(item.BarTimeUtc, NewYorkZone);
             if (offset != 0) ny = ny.AddMinutes(-offset);
-            var tod = ny.TimeOfDay;
-            if (tod < bounds.Start || tod > bounds.End) continue;
+            var start = ny.TimeOfDay;
+            var end = start.Add(TimeSpan.FromMinutes(minutes - 1));
+            if (start > bounds.End || end < bounds.Start) continue;
             var bucket = new DateTime(ny.Year, ny.Month, ny.Day, ny.Hour, ny.Minute / minutes * minutes, 0);
             if (currentBucket != bucket)
             {

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -1,10 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using TradingDaemon.Data;
+using TradingDaemon.Models;
 using TradingDaemon.Services;
 using Xunit;
 
@@ -33,5 +38,25 @@ public class PriceFetcherTests
         var fetcher = new PriceFetcher(context, logger, config);
 
         await fetcher.FetchAndStoreAsync();
+    }
+
+    [Fact]
+    public void RawNMin_Includes9amBarInUSSession()
+    {
+        var series = new List<HistClose>
+        {
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 0, 0, DateTimeKind.Utc), Close = 1m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 14, 0, 0, DateTimeKind.Utc), Close = 2m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 15, 0, 0, DateTimeKind.Utc), Close = 3m }
+        };
+
+        var method = typeof(PriceFetcher).GetMethod("RawNMin", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (List<(DateTime TimestampUtc, decimal Close)>)method.Invoke(null, new object[] { series, 60, "US", 0 })!;
+
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var times = result.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
+
+        Assert.Contains(new TimeSpan(9, 0, 0), times);
     }
 }


### PR DESCRIPTION
## Summary
- Ensure hourly bar inclusion when its close time falls within US session, preserving 9am bar
- Cover US flat bar behaviour in new unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a832e3cc3483338def86fb1df32411