### PR TITLE
Execute LoadRawFromStage after staging prices

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -59,6 +59,10 @@ public class PriceFetcher
         const string insertSql = "INSERT INTO [Intraday].[mkt].[Stage_HistClose] (SecurityId, BarTimeUtc, Close) VALUES (@SecurityId, @BarTimeUtc, @Close)";
         await connection.ExecuteAsync(insertSql, records);
 
+        // Load newly staged raw bars into the PriceBar table so that subsequent
+        // queries include the latest data.
+        await connection.ExecuteAsync("EXEC mkt.LoadRawFromStage @TimeframeMinute = 60");
+
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only
         // the newly provided data.


### PR DESCRIPTION
## Summary
- execute stored procedure `mkt.LoadRawFromStage` after inserting staged price bars

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a845e46870833399838fe4f179b1cd