### PR TITLE
Load flat bars from staging for each session

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -96,6 +96,13 @@ public class PriceFetcher
         {
             const string insertFlat = "INSERT INTO [Intraday].[dbo].[mkt_FlatBar_Staging] (SecurityId, BarTimeUtc, Close, Session) VALUES (@SecurityId, @BarTimeUtc, @Close, @Session)";
             await connection.ExecuteAsync(insertFlat, flatRecords);
+
+            // Move staged flat bars into the main table for each session.
+            foreach (var session in flatRecords.Select(r => r.Session).Distinct())
+            {
+                await connection.ExecuteAsync(
+                    $"EXEC mkt.LoadFlatFromMinimal @TimeframeMinute = 60, @Session = N'{session}'");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- After inserting flat bar records into staging, execute `mkt.LoadFlatFromMinimal` for each distinct session using the updated `@Session` parameter

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a8495b37f08333a7fce69a8684f972