### PR TITLE
Respect market session boundaries for flattened bars

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -85,12 +85,12 @@ public class PriceFetcher
         {
             var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
             var rawEU = RawNMin(ordered, 60, "EU", 0);
-            var flatEU = Flatten(rawEU)
+            var flatEU = Flatten(rawEU, SessionBounds["EU"].Zone)
                 .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "EU" });
             flatRecords.AddRange(flatEU);
 
             var rawUS = RawNMin(ordered, 60, "US", 0);
-            var flatUS = Flatten(rawUS)
+            var flatUS = Flatten(rawUS, SessionBounds["US"].Zone)
                 .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "US" });
             flatRecords.AddRange(flatUS);
         }
@@ -123,54 +123,58 @@ public class PriceFetcher
         }
     }
 
-    private static readonly Dictionary<string, (TimeSpan Start, TimeSpan End)> SessionBounds = new()
+    private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
-        ["US"] = (TimeSpan.Parse("09:30"), TimeSpan.Parse("15:59")),
-        ["EU"] = (TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+        ["US"] = (NewYorkZone, TimeSpan.Parse("09:30"), TimeSpan.Parse("15:59")),
+        ["EU"] = (CentralEuropeZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York");
 
+    private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
+
     private static List<(DateTime TimestampUtc, decimal Close)> RawNMin(List<HistClose> series, int minutes, string session, int offset)
     {
         var bounds = SessionBounds[session];
+        var zone = bounds.Zone;
         var result = new List<(DateTime, decimal)>();
         DateTime? currentBucket = null;
         decimal lastClose = 0;
         foreach (var item in series.OrderBy(s => s.BarTimeUtc))
         {
-            var ny = TimeZoneInfo.ConvertTimeFromUtc(item.BarTimeUtc, NewYorkZone);
-            if (offset != 0) ny = ny.AddMinutes(-offset);
-            var start = ny.TimeOfDay;
+            var local = TimeZoneInfo.ConvertTimeFromUtc(item.BarTimeUtc, zone);
+            if (offset != 0) local = local.AddMinutes(-offset);
+            var start = local.TimeOfDay;
             var end = start.Add(TimeSpan.FromMinutes(minutes - 1));
             if (start > bounds.End || end < bounds.Start) continue;
-            var bucket = new DateTime(ny.Year, ny.Month, ny.Day, ny.Hour, ny.Minute / minutes * minutes, 0);
+            var bucket = new DateTime(local.Year, local.Month, local.Day, local.Hour, local.Minute / minutes * minutes, 0);
             if (currentBucket != bucket)
             {
                 if (currentBucket.HasValue)
-                    result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), NewYorkZone), lastClose));
+                    result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), zone), lastClose));
                 currentBucket = bucket;
             }
             lastClose = item.Close;
         }
         if (currentBucket.HasValue)
-            result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), NewYorkZone), lastClose));
+            result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), zone), lastClose));
         return result;
     }
 
-    private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw)
+    private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)
     {
         if (raw.Count == 0) return new();
         var times = raw.Select(r => r.TimestampUtc).ToList();
         var px = raw.Select(r => r.Close).ToList();
-        var nyTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, NewYorkZone)).ToList();
+        var localTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, zone)).ToList();
         var ret = new decimal[px.Count];
         for (int i = 1; i < px.Count; i++)
         {
             var prev = px[i - 1];
             ret[i] = prev != 0 ? (px[i] - prev) / prev : 0m;
-            if (nyTimes[i].Date != nyTimes[i - 1].Date)
+            if (localTimes[i].Date != localTimes[i - 1].Date)
                 ret[i] = 0m;
         }
         var flat = new decimal[px.Count];


### PR DESCRIPTION
## Summary
- scope flattening and raw bar generation to session-specific time zones
- ensure EU bars only cover 02:00-09:00 CET window
- add test for EU session boundary handling

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a853bec3f08333986159b088d8b327