### PR TITLE
Add report generation endpoint

### DIFF
--- a/src/TradingDaemon/Controllers/ReportController.cs
+++ b/src/TradingDaemon/Controllers/ReportController.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.OpenApi;
+using TradingDaemon.Models;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class ReportController
+{
+    public static void MapReportEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/reports/run", async (ReportRequest request, ReportRunner runner) =>
+        {
+            var (_, err, exitCode) = await runner.RunAsync(request);
+            if (exitCode != 0)
+            {
+                return Results.Problem(err, statusCode: 500);
+            }
+            return Results.Ok(new { Status = "ReportGenerated" });
+        })
+        .WithName("RunReport")
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Runs the reporting script";
+            op.Description = "Launches the Python reporting script to generate model performance reports.";
+            return op;
+        });
+    }
+}

--- a/src/TradingDaemon/Models/ReportRequest.cs
+++ b/src/TradingDaemon/Models/ReportRequest.cs
@@ -1,0 +1,12 @@
+namespace TradingDaemon.Models;
+
+public class ReportRequest
+{
+    public int ModelId { get; set; }
+    public int Timeframe { get; set; }
+    public string? FromDate { get; set; }
+    public string? ToDate { get; set; }
+    public int? AnnualizeDays { get; set; }
+    public int? TopNPairs { get; set; }
+    public string? OutputDir { get; set; }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -25,6 +25,7 @@ builder.Services.AddHttpClient("OrderApi", client =>
 builder.Services.AddTransient<PriceFetcher>();
 builder.Services.AddTransient<WeightCalculator>();
 builder.Services.AddTransient<OrderSender>();
+builder.Services.AddTransient<ReportRunner>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
@@ -45,5 +46,6 @@ app.MapFillEndpoints();
 app.MapPriceEndpoints();
 app.MapWeightEndpoints();
 app.MapTradingEndpoints();
+app.MapReportEndpoints();
 
 app.Run();

--- a/src/TradingDaemon/Services/ReportRunner.cs
+++ b/src/TradingDaemon/Services/ReportRunner.cs
@@ -1,0 +1,63 @@
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+
+namespace TradingDaemon.Services;
+
+public class ReportRunner
+{
+    private readonly IConfiguration _config;
+    private readonly ILogger<ReportRunner> _logger;
+
+    public ReportRunner(IConfiguration config, ILogger<ReportRunner> logger)
+    {
+        _config = config;
+        _logger = logger;
+    }
+
+    public async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(Models.ReportRequest request)
+    {
+        var pythonExec = _config["Executables:PythonExecutable"] ?? "python3";
+        var scriptPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../scripts/report_model_dwm.py"));
+        var args = new StringBuilder();
+        args.Append(scriptPath);
+        args.Append($" --model-id {request.ModelId} --timeframe {request.Timeframe}");
+        if (!string.IsNullOrWhiteSpace(request.FromDate))
+            args.Append($" --from-date {request.FromDate}");
+        if (!string.IsNullOrWhiteSpace(request.ToDate))
+            args.Append($" --to-date {request.ToDate}");
+        if (request.AnnualizeDays.HasValue)
+            args.Append($" --annualize-days {request.AnnualizeDays.Value}");
+        if (request.TopNPairs.HasValue)
+            args.Append($" --top-n-pairs {request.TopNPairs.Value}");
+        if (!string.IsNullOrWhiteSpace(request.OutputDir))
+            args.Append($" --output-dir {request.OutputDir}");
+
+        var sbOut = new StringBuilder();
+        var sbErr = new StringBuilder();
+        var result = await ProcessRunner.RunAsync(
+            pythonExec,
+            args.ToString(),
+            line =>
+            {
+                _logger.LogInformation("[report] {Line}", line);
+                sbOut.AppendLine(line);
+            },
+            line =>
+            {
+                _logger.LogWarning("[report] {Line}", line);
+                sbErr.AppendLine(line);
+            });
+
+        if (result.ExitCode != 0)
+        {
+            _logger.LogError("Report script failed: {Error}", sbErr.ToString());
+        }
+        else
+        {
+            _logger.LogInformation("Report script completed: {Output}", sbOut.ToString());
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION
## Summary
- add model `ReportRequest` describing reporting parameters
- create `ReportRunner` service to invoke Python reporting script
- expose `/api/reports/run` endpoint for launching reports via Swagger

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1880b4f08333be8ed394c44a29ca