### PR TITLE
Normalize USD pairs to USD as base

### DIFF
--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -385,7 +385,17 @@ END";
             if (pair.Length < 6) continue;
             var baseCcy = pair[..3];
             var quoteCcy = pair.Substring(3, 3);
-            usdMap[(baseCcy, quoteCcy)] = p.SecurityId;
+
+            if (baseCcy == "USD")
+            {
+                // prefer mappings where USD is the base currency
+                usdMap[(baseCcy, quoteCcy)] = p.SecurityId;
+            }
+            else if (quoteCcy == "USD" && !usdMap.ContainsKey(("USD", baseCcy)))
+            {
+                // fall back to inverse pairs if the USD-base pair is missing
+                usdMap[("USD", baseCcy)] = p.SecurityId;
+            }
         }
 
         return usdMap;
@@ -400,19 +410,19 @@ END";
         var baseCcy = pair[..3];
         var quoteCcy = pair.Substring(3, 3);
 
-        if (baseCcy == "USD")
+        if (quoteCcy == "USD")
         {
-            if (usdMap.TryGetValue((quoteCcy, "USD"), out var canonId))
+            if (usdMap.TryGetValue(("USD", baseCcy), out var canonId))
             {
                 return (canonId, -weight);
             }
 
-            return (securityId, weight);
+            return (securityId, -weight);
         }
 
-        if (quoteCcy == "USD")
+        if (baseCcy == "USD")
         {
-            if (usdMap.TryGetValue((baseCcy, quoteCcy), out var canonId))
+            if (usdMap.TryGetValue(("USD", quoteCcy), out var canonId))
             {
                 return (canonId, weight);
             }

--- a/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
+++ b/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 public class UsdPairNormalizationTests
 {
     [Fact]
-    public void BuildUsdMap_PreservesBothDirections()
+    public void BuildUsdMap_UsesUsdAsBase()
     {
         var usdPairs = new List<(long SecurityId, string Ticker)>
         {
@@ -19,9 +19,9 @@ public class UsdPairNormalizationTests
         var method = typeof(WeightCalculator).GetMethod("BuildUsdMap", BindingFlags.NonPublic | BindingFlags.Static);
         var usdMap = (Dictionary<(string Base, string Quote), long>)method!.Invoke(null, new object[] { usdPairs })!;
 
-        Assert.Equal(3, usdMap.Count);
-        Assert.Contains(("AUD", "USD"), usdMap.Keys);
-        Assert.Contains(("USD", "AUD"), usdMap.Keys);
+        Assert.Equal(2, usdMap.Count);
+        Assert.Equal(2L, usdMap[("USD", "AUD")]);
+        Assert.Equal(3L, usdMap[("USD", "EUR")]);
     }
 
     [Fact]
@@ -41,10 +41,10 @@ public class UsdPairNormalizationTests
         var result1 = ((long SecurityId, decimal Weight))normMethod!.Invoke(null, new object[] { 1L, "USDCHF", 1m, usdMap })!;
         var result2 = ((long SecurityId, decimal Weight))normMethod!.Invoke(null, new object[] { 2L, "CHFUSD", 2m, usdMap })!;
 
-        Assert.Equal(2L, result1.SecurityId);
-        Assert.Equal(-1m, result1.Weight);
-        Assert.Equal(2L, result2.SecurityId);
-        Assert.Equal(2m, result2.Weight);
-        Assert.Equal(1m, result1.Weight + result2.Weight);
+        Assert.Equal(1L, result1.SecurityId);
+        Assert.Equal(1m, result1.Weight);
+        Assert.Equal(1L, result2.SecurityId);
+        Assert.Equal(-2m, result2.Weight);
+        Assert.Equal(-1m, result1.Weight + result2.Weight);
     }
 }


### PR DESCRIPTION
## Summary
- prefer USD as base currency when building USD pair map
- normalize USD quote pairs to their USD-base equivalents
- adjust tests for USD-base normalization

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac307512b8833388ff024047d42ac8