### PR TITLE
Ensure raw exports only use flat bar timestamps

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -276,6 +276,9 @@ for real_sid in universe_ids:
     flat = df_flat.set_index("timestamp")["close"]
     all_ts.update(flat.index)
 
+    # Ensure H and I only contain timestamps present in A
+    raw = raw.reindex(flat.index).dropna()
+
     flat_frame = frame(sid, flat)
     print(f"Writing {len(flat_frame)} rows to {OUT['A']}")
     flat_frame.to_csv(OUT["A"], mode="a", header=False, index=False)


### PR DESCRIPTION
## Summary
- filter raw bar data to only include timestamps present in flat bars so H and I align with A

## Testing
- `pytest`
- `flake8` *(fails: command not found)*
- `python -m py_compile scripts/export_prices_rds.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac804be5c48333948872f0ff2cc41a