### PR TITLE
Prefer USD as quote currency

### DIFF
--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -386,15 +386,15 @@ END";
             var baseCcy = pair[..3];
             var quoteCcy = pair.Substring(3, 3);
 
-            if (baseCcy == "USD")
+            if (quoteCcy == "USD")
             {
-                // prefer mappings where USD is the base currency
+                // prefer mappings where USD is the quote currency
                 usdMap[(baseCcy, quoteCcy)] = p.SecurityId;
             }
-            else if (quoteCcy == "USD" && !usdMap.ContainsKey(("USD", baseCcy)))
+            else if (baseCcy == "USD" && !usdMap.ContainsKey((quoteCcy, "USD")))
             {
-                // fall back to inverse pairs if the USD-base pair is missing
-                usdMap[("USD", baseCcy)] = p.SecurityId;
+                // fall back to inverse pairs if the USD-quote pair is missing
+                usdMap[(quoteCcy, "USD")] = p.SecurityId;
             }
         }
 
@@ -412,7 +412,7 @@ END";
 
         if (quoteCcy == "USD")
         {
-            if (usdMap.TryGetValue(("USD", baseCcy), out var canonId))
+            if (usdMap.TryGetValue((baseCcy, "USD"), out var canonId))
             {
                 return (canonId, weight);
             }
@@ -422,9 +422,9 @@ END";
 
         if (baseCcy == "USD")
         {
-            if (usdMap.TryGetValue(("USD", quoteCcy), out var canonId))
+            if (usdMap.TryGetValue((quoteCcy, "USD"), out var canonId))
             {
-                return (canonId, weight);
+                return (canonId, -weight);
             }
 
             return (securityId, -weight);

--- a/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
+++ b/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
@@ -7,7 +7,7 @@ using Xunit;
 public class UsdPairNormalizationTests
 {
     [Fact]
-    public void BuildUsdMap_UsesUsdAsBase()
+    public void BuildUsdMap_UsesUsdAsQuote()
     {
         var usdPairs = new List<(long SecurityId, string Ticker)>
         {
@@ -20,8 +20,8 @@ public class UsdPairNormalizationTests
         var usdMap = (Dictionary<(string Base, string Quote), long>)method!.Invoke(null, new object[] { usdPairs })!;
 
         Assert.Equal(2, usdMap.Count);
-        Assert.Equal(2L, usdMap[("USD", "AUD")]);
-        Assert.Equal(3L, usdMap[("USD", "EUR")]);
+        Assert.Equal(1L, usdMap[("AUD", "USD")]);
+        Assert.Equal(3L, usdMap[("EUR", "USD")]);
     }
 
     [Fact]
@@ -41,10 +41,10 @@ public class UsdPairNormalizationTests
         var result1 = ((long SecurityId, decimal Weight))normMethod!.Invoke(null, new object[] { 1L, "USDCHF", 1m, usdMap })!;
         var result2 = ((long SecurityId, decimal Weight))normMethod!.Invoke(null, new object[] { 2L, "CHFUSD", 2m, usdMap })!;
 
-        Assert.Equal(1L, result1.SecurityId);
-        Assert.Equal(1m, result1.Weight);
-        Assert.Equal(1L, result2.SecurityId);
-        Assert.Equal(-2m, result2.Weight);
-        Assert.Equal(-1m, result1.Weight + result2.Weight);
+        Assert.Equal(2L, result1.SecurityId);
+        Assert.Equal(-1m, result1.Weight);
+        Assert.Equal(2L, result2.SecurityId);
+        Assert.Equal(2m, result2.Weight);
+        Assert.Equal(1m, result1.Weight + result2.Weight);
     }
 }


### PR DESCRIPTION
## Summary
- prefer mappings with USD as the quote currency when building USD pair map
- normalize USD pairs to align with USD quote preference
- update tests for new USD quote orientation

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aecc8bdbe48333955ae512dbd304f0