### PR TITLE
Flip sign for USD quote currency weights

### DIFF
--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -311,6 +311,13 @@ END";
             @"SELECT SecurityId, BloombergTicker FROM core.Security WHERE BloombergTicker LIKE '%USD%'");
 
         var usdMap = BuildUsdMap(usdPairs);
+        var usdQuoteIds = new HashSet<long>(usdPairs
+            .Where(p =>
+            {
+                var pair = p.Ticker.Split(' ')[0];
+                return pair.Length >= 6 && pair.Substring(3, 3) == "USD";
+            })
+            .Select(p => p.SecurityId));
 
         var net = new Dictionary<(long SecurityId, DateTime BarTimeUtc), decimal>();
 
@@ -363,13 +370,14 @@ END";
 
         foreach (var entry in net)
         {
+            var weight = AdjustWeightForUsdQuote(entry.Key.SecurityId, entry.Value, usdQuoteIds);
             var record = new
             {
                 SecurityId = entry.Key.SecurityId,
                 ModelId = modelId,
                 BarTimeUtc = entry.Key.BarTimeUtc,
                 ModelRunId = modelRunId,
-                Weight = entry.Value
+                Weight = weight
             };
 
             await connection.ExecuteAsync(insertSql, record);
@@ -431,6 +439,11 @@ END";
         }
 
         return (securityId, -weight);
+    }
+
+    private static decimal AdjustWeightForUsdQuote(long securityId, decimal weight, HashSet<long> usdQuoteIds)
+    {
+        return usdQuoteIds.Contains(securityId) ? -weight : weight;
     }
 
     private sealed class WeightRow

--- a/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
+++ b/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
@@ -47,4 +47,18 @@ public class UsdPairNormalizationTests
         Assert.Equal(2m, result2.Weight);
         Assert.Equal(1m, result1.Weight + result2.Weight);
     }
+
+    [Fact]
+    public void AdjustWeightForUsdQuote_FlipsSign()
+    {
+        var method = typeof(WeightCalculator).GetMethod(
+            "AdjustWeightForUsdQuote", BindingFlags.NonPublic | BindingFlags.Static);
+        var usdQuoteIds = new HashSet<long> { 1L };
+
+        var flipped = (decimal)method!.Invoke(null, new object[] { 1L, 5m, usdQuoteIds })!;
+        var same = (decimal)method!.Invoke(null, new object[] { 2L, 5m, usdQuoteIds })!;
+
+        Assert.Equal(-5m, flipped);
+        Assert.Equal(5m, same);
+    }
 }


### PR DESCRIPTION
## Summary
- Adjust netted weight insertion to flip sign when the security's quote currency is USD
- Test sign adjustment logic to ensure USD quote pairs are inverted

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aed1d7499883338a180379740274d6