### PR TITLE
Flip netted weight sign for USD base pairs

### DIFF
--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -311,11 +311,11 @@ END";
             @"SELECT SecurityId, BloombergTicker FROM core.Security WHERE BloombergTicker LIKE '%USD%'");
 
         var usdMap = BuildUsdMap(usdPairs);
-        var usdQuoteIds = new HashSet<long>(usdPairs
+        var usdBaseIds = new HashSet<long>(usdPairs
             .Where(p =>
             {
                 var pair = p.Ticker.Split(' ')[0];
-                return pair.Length >= 6 && pair.Substring(3, 3) == "USD";
+                return pair.Length >= 6 && pair[..3] == "USD";
             })
             .Select(p => p.SecurityId));
 
@@ -370,7 +370,7 @@ END";
 
         foreach (var entry in net)
         {
-            var weight = AdjustWeightForUsdQuote(entry.Key.SecurityId, entry.Value, usdQuoteIds);
+            var weight = AdjustWeightForUsdBase(entry.Key.SecurityId, entry.Value, usdBaseIds);
             var record = new
             {
                 SecurityId = entry.Key.SecurityId,
@@ -441,9 +441,9 @@ END";
         return (securityId, -weight);
     }
 
-    private static decimal AdjustWeightForUsdQuote(long securityId, decimal weight, HashSet<long> usdQuoteIds)
+    private static decimal AdjustWeightForUsdBase(long securityId, decimal weight, HashSet<long> usdBaseIds)
     {
-        return usdQuoteIds.Contains(securityId) ? -weight : weight;
+        return usdBaseIds.Contains(securityId) ? -weight : weight;
     }
 
     private sealed class WeightRow

--- a/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
+++ b/tests/TradingDaemon.Tests/UsdPairNormalizationTests.cs
@@ -49,14 +49,14 @@ public class UsdPairNormalizationTests
     }
 
     [Fact]
-    public void AdjustWeightForUsdQuote_FlipsSign()
+    public void AdjustWeightForUsdBase_FlipsSign()
     {
         var method = typeof(WeightCalculator).GetMethod(
-            "AdjustWeightForUsdQuote", BindingFlags.NonPublic | BindingFlags.Static);
-        var usdQuoteIds = new HashSet<long> { 1L };
+            "AdjustWeightForUsdBase", BindingFlags.NonPublic | BindingFlags.Static);
+        var usdBaseIds = new HashSet<long> { 1L };
 
-        var flipped = (decimal)method!.Invoke(null, new object[] { 1L, 5m, usdQuoteIds })!;
-        var same = (decimal)method!.Invoke(null, new object[] { 2L, 5m, usdQuoteIds })!;
+        var flipped = (decimal)method!.Invoke(null, new object[] { 1L, 5m, usdBaseIds })!;
+        var same = (decimal)method!.Invoke(null, new object[] { 2L, 5m, usdBaseIds })!;
 
         Assert.Equal(-5m, flipped);
         Assert.Equal(5m, same);


### PR DESCRIPTION
## Summary
- flip sign of netted weights when USD is the base currency
- rename helper to AdjustWeightForUsdBase and update tests

## Testing
- `dotnet test --no-build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68aed42e4c9c8333bb9af57bc0a4b24c