### PR TITLE
Handle non-numeric pair attribution data

### DIFF
--- a/scripts/report_model_dwm.py
+++ b/scripts/report_model_dwm.py
@@ -1,0 +1,41 @@
+import pandas as pd
+import matplotlib.pyplot as plt
+
+
+def _fig_pair_attrib(df: pd.DataFrame, top_n_pairs: int):
+    """Build a horizontal bar chart of pair attribution.
+
+    The input ``df`` is expected to contain numeric columns representing
+    attribution values.  In production this dataframe is built from several
+    joins and occasionally ends up with only non-numeric data (for example
+    when the dataset is empty or the columns are of type ``object``).  The
+    original implementation blindly forwarded the dataframe to
+    ``pandas.DataFrame.plot`` which raised ``TypeError: no numeric data to
+    plot`` when this happened.
+
+    To make the function robust we now select only numeric columns before
+    plotting and gracefully handle the case where there is nothing to plot by
+    returning an empty figure.
+    """
+
+    fig, ax = plt.subplots()
+
+    if df.empty:
+        ax.set_axis_off()
+        return fig
+
+    numeric_df = df.select_dtypes(include="number")
+    if numeric_df.empty:
+        ax.set_axis_off()
+        return fig
+
+    combined = numeric_df.head(top_n_pairs)
+    combined.plot(kind="barh", ax=ax)
+    return fig
+
+
+if __name__ == "__main__":
+    # Simple smoke test when run directly
+    data = pd.DataFrame({"pair": ["A/B", "C/D"], "value": [1.2, -0.5]})
+    data.set_index("pair", inplace=True)
+    _fig_pair_attrib(data, 5)


### PR DESCRIPTION
## Summary
- add minimal report_model_dwm script and make pair attribution plotting resilient to non-numeric data

## Testing
- `python -m pytest`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aef528e1ec8333b082bbdc0369c826