### PR TITLE
feat: add Wakett API client

### DIFF
--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -1,0 +1,89 @@
+namespace TradingDaemon.Models;
+
+public class WakettPriceResponse
+{
+    public string Ts { get; set; } = string.Empty;
+    public List<WakettPrice> Prices { get; set; } = new();
+}
+
+public class WakettPrice
+{
+    public string Symbol { get; set; } = string.Empty;
+    public decimal? Bid { get; set; }
+    public decimal? Ask { get; set; }
+    public decimal? Mid { get; set; }
+    public decimal? Size { get; set; }
+    public WakettError? Error { get; set; }
+}
+
+public class WakettOrderRequest
+{
+    public string? Ts { get; set; }
+    public double? Aum { get; set; }
+    public List<WakettOrderItem> Orders { get; set; } = new();
+}
+
+public class WakettOrderItem
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public string Code { get; set; } = string.Empty;
+    public WakettOrderSize Size { get; set; } = new();
+}
+
+public class WakettOrderSize
+{
+    public double Value { get; set; }
+    public string Type { get; set; } = string.Empty;
+}
+
+public class WakettOrderResponse
+{
+    public string Ts { get; set; } = string.Empty;
+    public List<WakettOrderResult> Orders { get; set; } = new();
+}
+
+public class WakettOrderResult
+{
+    public string Symbol { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public double? Qt { get; set; }
+    public string Code { get; set; } = string.Empty;
+    public string? OrderID { get; set; }
+    public WakettError? Error { get; set; }
+}
+
+public class WakettTradeRequest
+{
+    public string Account { get; set; } = string.Empty;
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string Strategy { get; set; } = string.Empty;
+}
+
+public class WakettTradeResponse
+{
+    public string Status { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+    public List<WakettTrade> Data { get; set; } = new();
+}
+
+public class WakettTrade
+{
+    public string Portfolio { get; set; } = string.Empty;
+    public string Broker { get; set; } = string.Empty;
+    public string StrategyID { get; set; } = string.Empty;
+    public string Symbol { get; set; } = string.Empty;
+    public string Side { get; set; } = string.Empty;
+    public double Price { get; set; }
+    public double OrderSize { get; set; }
+    public double ExecuteSize { get; set; }
+    public double ExecutePrice { get; set; }
+    public string Event { get; set; } = string.Empty;
+}
+
+public class WakettError
+{
+    public string Code { get; set; } = string.Empty;
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -22,9 +22,15 @@ builder.Services.AddHttpClient("OrderApi", client =>
     client.BaseAddress = new Uri(builder.Configuration["ExternalApis:OrderApi:BaseUrl"] ?? "");
 }).AddPolicyHandler(RetryPolicyFactory.GetPolicy());
 
+builder.Services.AddHttpClient("WakettApi", client =>
+{
+    client.BaseAddress = new Uri(builder.Configuration["ExternalApis:WakettApi:BaseUrl"] ?? "");
+}).AddPolicyHandler(RetryPolicyFactory.GetPolicy());
+
 builder.Services.AddTransient<PriceFetcher>();
 builder.Services.AddTransient<WeightCalculator>();
 builder.Services.AddTransient<OrderSender>();
+builder.Services.AddTransient<WakettApiClient>();
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -1,0 +1,48 @@
+using System.Text.Json;
+using System.Net.Http.Json;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public class WakettApiClient
+{
+    private readonly IHttpClientFactory _clientFactory;
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    public WakettApiClient(IHttpClientFactory clientFactory)
+    {
+        _clientFactory = clientFactory;
+    }
+
+    public async Task<WakettPriceResponse?> GetPricesAsync(IEnumerable<string> symbols, DateTimeOffset? ts = null)
+    {
+        var client = _clientFactory.CreateClient("WakettApi");
+        var payload = new
+        {
+            ts = ts?.ToString("yyyy-MM-dd HH:mm:ss.fffzzz"),
+            symbols
+        };
+        var response = await client.PostAsJsonAsync("/prices", payload, _jsonOptions);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<WakettPriceResponse>(json, _jsonOptions);
+    }
+
+    public async Task<WakettOrderResponse?> SendOrdersAsync(WakettOrderRequest request)
+    {
+        var client = _clientFactory.CreateClient("WakettApi");
+        var response = await client.PostAsJsonAsync("/orders", request, _jsonOptions);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<WakettOrderResponse>(json, _jsonOptions);
+    }
+
+    public async Task<WakettTradeResponse?> GetTradesAsync(WakettTradeRequest request)
+    {
+        var client = _clientFactory.CreateClient("WakettApi");
+        var response = await client.PostAsJsonAsync("/trades", request, _jsonOptions);
+        response.EnsureSuccessStatusCode();
+        var json = await response.Content.ReadAsStringAsync();
+        return JsonSerializer.Deserialize<WakettTradeResponse>(json, _jsonOptions);
+    }
+}

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -8,6 +8,9 @@
     },
     "OrderApi": {
       "BaseUrl": "https://orderapi.example.com"
+    },
+    "WakettApi": {
+      "BaseUrl": "https://api.qqb.wakett.com/test/"
     }
   },
   "Executables": {

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -1,0 +1,77 @@
+using Xunit;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Http;
+using TradingDaemon.Services;
+using TradingDaemon.Models;
+
+public class WakettApiClientTests
+{
+    [Fact]
+    public async Task GetPricesAsync_PostsToPricesEndpoint()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"ts\":\"\",\"prices\":[]}") });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var api = new WakettApiClient(factory);
+
+        await api.GetPricesAsync(new[] { "AAPL" });
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/prices"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SendOrdersAsync_PostsToOrdersEndpoint()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"ts\":\"\",\"orders\":[]}") });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var api = new WakettApiClient(factory);
+
+        var request = new WakettOrderRequest
+        {
+            Aum = 1_000_000,
+            Orders = new List<WakettOrderItem>
+            {
+                new() { Symbol = "AAPL", Side = "BUY", Code = "QQB-1", Size = new WakettOrderSize{ Value = 100, Type = "absolute"} }
+            }
+        };
+
+        await api.SendOrdersAsync(request);
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/orders"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetTradesAsync_PostsToTradesEndpoint()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"status\":\"OK\",\"message\":\"\",\"data\":[]}") });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var api = new WakettApiClient(factory);
+
+        var request = new WakettTradeRequest { Account = "ACC", From = "20240101", To = "20240101", Strategy = "QQB" };
+        await api.GetTradesAsync(request);
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/trades"),
+            ItExpr.IsAny<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
- wire up Wakett API client to request prices, submit orders, and fetch trades
- expose Wakett base URL via configuration and dependency injection
- cover Wakett API client with unit tests for each endpoint

## Testing
- ⚠️ `dotnet test` *(dotnet not installed)*
- ⚠️ `apt-get update` *(403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c43988926883339c14c87fb9ef07f5