### PR TITLE
Add Wakett price fetch swagger endpoint

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.OpenApi;
+using TradingDaemon.Models;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class WakettController
+{
+    public static void MapWakettEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/wakett/prices", async (WakettApiClient client, WakettPriceRequest request) =>
+        {
+            var prices = await client.GetPricesAsync(request.Symbols, request.Ts);
+            return Results.Ok(prices);
+        })
+        .WithName("FetchWakettPrices")
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Fetch prices from Wakett";
+            op.Description = "Calls the Wakett API to retrieve prices for the specified symbols.";
+            return op;
+        });
+    }
+}

--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -1,5 +1,11 @@
 namespace TradingDaemon.Models;
 
+public class WakettPriceRequest
+{
+    public List<string> Symbols { get; set; } = new();
+    public DateTimeOffset? Ts { get; set; }
+}
+
 public class WakettPriceResponse
 {
     public string Ts { get; set; } = string.Empty;

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -56,5 +56,6 @@ app.MapPriceEndpoints();
 app.MapWeightEndpoints();
 app.MapTradingEndpoints();
 app.MapReportEndpoints();
+app.MapWakettEndpoints();
 
 app.Run();


### PR DESCRIPTION
## Summary
- add Wakett price request model
- expose Wakett price fetch endpoint and map it in the API

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4485ffa8483339fa4b77d22b2cb48