### PR TITLE
feat: configure Wakett price symbols

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -8,16 +8,17 @@ public static class WakettController
 {
     public static void MapWakettEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/wakett/prices", async (WakettApiClient client, WakettPriceRequest request) =>
+        app.MapPost("/api/wakett/prices", async (WakettApiClient client, IConfiguration config, WakettPriceRequest request) =>
         {
-            var prices = await client.GetPricesAsync(request.Symbols, request.Ts);
+            var symbols = config.GetSection("ExternalApis:WakettApi:Symbols").Get<List<WakettSecuritySymbol>>() ?? new();
+            var prices = await client.GetPricesAsync(symbols, request.Ts);
             return Results.Ok(prices);
         })
         .WithName("FetchWakettPrices")
         .WithOpenApi(op =>
         {
             op.Summary = "Fetch prices from Wakett";
-            op.Description = "Calls the Wakett API to retrieve prices for the specified symbols.";
+            op.Description = "Calls the Wakett API to retrieve prices for the configured symbols.";
             return op;
         });
     }

--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -2,8 +2,13 @@ namespace TradingDaemon.Models;
 
 public class WakettPriceRequest
 {
-    public List<string> Symbols { get; set; } = new();
     public DateTimeOffset? Ts { get; set; }
+}
+
+public class WakettSecuritySymbol
+{
+    public int SecurityId { get; set; }
+    public string Symbol { get; set; } = string.Empty;
 }
 
 public class WakettPriceResponse

--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Net.Http.Json;
+using System.Linq;
 using TradingDaemon.Models;
 
 namespace TradingDaemon.Services;
@@ -14,13 +15,13 @@ public class WakettApiClient
         _clientFactory = clientFactory;
     }
 
-    public async Task<WakettPriceResponse?> GetPricesAsync(IEnumerable<string> symbols, DateTimeOffset? ts = null)
+    public async Task<WakettPriceResponse?> GetPricesAsync(IEnumerable<WakettSecuritySymbol> symbols, DateTimeOffset? ts = null)
     {
         var client = _clientFactory.CreateClient("WakettApi");
         var payload = new
         {
             ts = ts?.ToString("yyyy-MM-dd HH:mm:ss.fffzzz"),
-            symbols
+            symbols = symbols.Select(s => new { securityid = s.SecurityId, symbol = s.Symbol })
         };
         var response = await client.PostAsJsonAsync("/prices", payload, _jsonOptions);
         response.EnsureSuccessStatusCode();

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -12,7 +12,11 @@
       "BaseUrl": "https://orderapi.example.com"
     },
     "WakettApi": {
-      "BaseUrl": "https://api.qqb.wakett.com/test/"
+      "BaseUrl": "https://api.qqb.wakett.com/test/",
+      "Symbols": [
+        { "SecurityId": 1, "Symbol": "AAPL" },
+        { "SecurityId": 2, "Symbol": "MSFT" }
+      ]
     }
   },
   "Executables": {

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -11,20 +11,26 @@ public class WakettApiClientTests
     [Fact]
     public async Task GetPricesAsync_PostsToPricesEndpoint()
     {
+        HttpRequestMessage? captured = null;
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((m, _) => captured = m)
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"ts\":\"\",\"prices\":[]}") });
         var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
         var api = new WakettApiClient(factory);
 
-        await api.GetPricesAsync(new[] { "AAPL" });
+        await api.GetPricesAsync(new[] { new WakettSecuritySymbol { SecurityId = 1, Symbol = "AAPL" } });
 
         handler.Protected().Verify(
             "SendAsync",
             Times.Once(),
             ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/prices"),
             ItExpr.IsAny<CancellationToken>());
+
+        var body = await captured!.Content.ReadAsStringAsync();
+        Assert.Contains("\"securityid\":1", body);
+        Assert.Contains("\"symbol\":\"AAPL\"", body);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- allow Wakett API client to send security ID and symbol pairs to `/prices`
- read configured symbol mappings from appsettings when calling Wakett prices
- add configuration section for Wakett price symbols and update tests

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get update` *(fails: repository access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c82835653883338e1f4c060a720a67