### PR TITLE
Send only symbols to Wakett price API

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -21,7 +21,7 @@ public class WakettApiClient
         var payload = new
         {
             ts = ts?.ToString("yyyy-MM-dd HH:mm:ss.fffzzz"),
-            symbols = symbols.Select(s => new { securityid = s.SecurityId, symbol = s.Symbol })
+            symbols = symbols.Select(s => s.Symbol)
         };
         var response = await client.PostAsJsonAsync("prices", payload, _jsonOptions);
         response.EnsureSuccessStatusCode();

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -29,8 +29,8 @@ public class WakettApiClientTests
             ItExpr.IsAny<CancellationToken>());
 
         var body = await captured!.Content.ReadAsStringAsync();
-        Assert.Contains("\"securityid\":1", body);
-        Assert.Contains("\"symbol\":\"AAPL\"", body);
+        Assert.Contains("\"symbols\":[\"AAPL\"]", body);
+        Assert.DoesNotContain("\"securityid\"", body);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- update Wakett price client to send only symbol strings to the Wakett API
- adjust unit test to reflect the new payload structure

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8340b80e88333978ecdce4746893c