### PR TITLE
Format Wakett API timestamps as UTC Z strings

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Net.Http.Json;
 using System.Linq;
+using System.Globalization;
 using TradingDaemon.Models;
 
 namespace TradingDaemon.Services;
@@ -18,9 +19,15 @@ public class WakettApiClient
     public async Task<WakettPriceResponse?> GetPricesAsync(IEnumerable<WakettSecuritySymbol> symbols, DateTimeOffset? ts = null)
     {
         var client = _clientFactory.CreateClient("WakettApi");
+        string? formattedTs = null;
+        if (ts.HasValue)
+        {
+            formattedTs = ts.Value.UtcDateTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
+        }
+
         var payload = new
         {
-            ts = ts?.ToString("yyyy-MM-dd HH:mm:ss.fffzzz"),
+            ts = formattedTs,
             symbols = symbols.Select(s => s.Symbol)
         };
         var response = await client.PostAsJsonAsync("prices", payload, _jsonOptions);

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -34,6 +34,25 @@ public class WakettApiClientTests
     }
 
     [Fact]
+    public async Task GetPricesAsync_FormatsTimestampInUtcWithZSuffix()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((m, _) => captured = m)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"ts\":\"\",\"prices\":[]}") });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var api = new WakettApiClient(factory);
+
+        var ts = new DateTimeOffset(2024, 1, 1, 12, 6, 0, TimeSpan.FromHours(1));
+        await api.GetPricesAsync(new[] { new WakettSecuritySymbol { SecurityId = 1, Symbol = "AAPL" } }, ts);
+
+        var body = await captured!.Content.ReadAsStringAsync();
+        Assert.Contains("\"ts\":\"2024-01-01T11:06:00.000Z\"", body);
+    }
+
+    [Fact]
     public async Task SendOrdersAsync_PostsToOrdersEndpoint()
     {
         var handler = new Mock<HttpMessageHandler>();


### PR DESCRIPTION
## Summary
- format Wakett API request timestamps as UTC strings ending with Z for Wakett price calls
- add a unit test that verifies the formatted timestamp uses the required Z-suffixed layout

## Testing
- dotnet test *(fails: `dotnet` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c83789bf1c8333ac827f393e2f4ae1