### PR TITLE
Document Wakett price upload endpoint

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -1,4 +1,7 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
 using TradingDaemon.Models;
 using TradingDaemon.Services;
 
@@ -8,18 +11,38 @@ public static class WakettController
 {
     public static void MapWakettEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/wakett/prices", async (WakettPriceFetcher fetcher, WakettPriceRequest request) =>
+        app.MapPost("/api/wakett/prices", async Task<Ok<WakettPriceUploadResponse>> (WakettPriceFetcher fetcher, WakettPriceRequest request) =>
         {
             var result = await fetcher.FetchAndStoreAsync(request.Ts);
-            return result is not null
-                ? Results.Ok(result)
-                : Results.Ok(new { Uploaded = 0 });
+            var response = result is not null
+                ? WakettPriceUploadResponse.FromResult(result)
+                : WakettPriceUploadResponse.Empty();
+            return TypedResults.Ok(response);
         })
         .WithName("FetchWakettPrices")
+        .Produces<WakettPriceUploadResponse>()
         .WithOpenApi(op =>
         {
             op.Summary = "Fetch and store Wakett FX prices.";
             op.Description = "Retrieves FX prices from Wakett, reconstructs missing crosses, and stores them in the database.";
+            op.Responses["200"] = new OpenApiResponse
+            {
+                Description = "Summary of the FX prices that were uploaded to Stage_HistClose.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(WakettPriceUploadResponse)
+                            }
+                        }
+                    }
+                }
+            };
             return op;
         });
     }

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
@@ -481,3 +482,15 @@ public sealed record WakettPriceUploadItem(
     string Symbol,
     decimal Price,
     bool Inverted);
+
+public sealed record WakettPriceUploadResponse(
+    int Uploaded,
+    DateTime? TimestampUtc,
+    IReadOnlyList<WakettPriceUploadItem> Prices)
+{
+    public static WakettPriceUploadResponse FromResult(WakettPriceUploadResult result) =>
+        new(result.Prices.Count, result.TimestampUtc, result.Prices);
+
+    public static WakettPriceUploadResponse Empty() =>
+        new(0, null, Array.Empty<WakettPriceUploadItem>());
+}


### PR DESCRIPTION
## Summary
- return a dedicated Wakett price upload response model so the API can be documented
- expose the Wakett price upload endpoint metadata in Swagger, including the typed 200 response schema

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cac01dec58833385486cf22f343171