### PR TITLE
Trigger stored procedures after Wakett price staging

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -457,6 +457,9 @@ public class WakettPriceFetcher
             transaction);
 
         transaction.Commit();
+
+        await connection.ExecuteAsync("EXEC mkt.LoadRawFromStage @TimeframeMinute = 60");
+        await connection.ExecuteAsync("EXEC mkt.LoadFlatFromMinimal @TimeframeMinute = 60");
     }
 
     internal readonly record struct CurrencyPair(string Base, string Quote);


### PR DESCRIPTION
## Summary
- execute the same load stored procedures as the CSV price fetcher after inserting Wakett FX prices into Stage_HistClose so downstream tables update

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68caccdee374833383875472189f4e2f