### PR TITLE
Adjust Wakett price timestamp for debugging

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -226,15 +226,32 @@ public class WakettPriceFetcher
                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                 out var parsed))
         {
-            return parsed.UtcDateTime;
+            return AdjustTimestampForDebugging(parsed.UtcDateTime);
         }
 
         if (requestedTimestamp.HasValue)
         {
-            return requestedTimestamp.Value.UtcDateTime;
+            return AdjustTimestampForDebugging(requestedTimestamp.Value.UtcDateTime);
         }
 
-        return fallbackUtc;
+        return AdjustTimestampForDebugging(fallbackUtc);
+    }
+
+    private static DateTime AdjustTimestampForDebugging(DateTime timestampUtc)
+    {
+        if (timestampUtc.Minute == 6)
+        {
+            return new DateTime(
+                timestampUtc.Year,
+                timestampUtc.Month,
+                timestampUtc.Day,
+                timestampUtc.Hour,
+                0,
+                0,
+                DateTimeKind.Utc);
+        }
+
+        return timestampUtc;
     }
 
     internal static string NormalizeSymbol(string symbol)

--- a/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
@@ -127,6 +127,18 @@ public class WakettPriceFetcherTests
     }
 
     [Fact]
+    public void DetermineTimestampUtc_AdjustsResponseTimestampForDebugging()
+    {
+        var responseTs = "2024-03-01T12:06:00Z";
+        var requestTs = new DateTimeOffset(2024, 3, 1, 11, 0, 0, TimeSpan.Zero);
+        var fallback = new DateTime(2024, 3, 1, 10, 0, 0, DateTimeKind.Utc);
+
+        var result = WakettPriceFetcher.DetermineTimestampUtc(responseTs, requestTs, fallback);
+
+        Assert.Equal(new DateTime(2024, 3, 1, 12, 0, 0, DateTimeKind.Utc), result);
+    }
+
+    [Fact]
     public void DetermineTimestampUtc_FallsBackToRequest()
     {
         var requestTs = new DateTimeOffset(2024, 3, 1, 12, 0, 0, TimeSpan.Zero);


### PR DESCRIPTION
## Summary
- adjust the Wakett price upload timestamp to zero out :06 minute bars for debugging
- cover the new behavior with a unit test around DetermineTimestampUtc

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d3f94def188333b209779a22d90288