### PR TITLE
Stop requiring timestamp input for Wakett price fetcher

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
-using TradingDaemon.Models;
 using TradingDaemon.Services;
 
 namespace TradingDaemon.Controllers;
@@ -11,9 +10,9 @@ public static class WakettController
 {
     public static void MapWakettEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/wakett/prices", async Task<Ok<WakettPriceUploadResponse>> (WakettPriceFetcher fetcher, WakettPriceRequest request) =>
+        app.MapPost("/api/wakett/prices", async Task<Ok<WakettPriceUploadResponse>> (WakettPriceFetcher fetcher) =>
         {
-            var result = await fetcher.FetchAndStoreAsync(request.Ts);
+            var result = await fetcher.FetchAndStoreAsync();
             var response = result is not null
                 ? WakettPriceUploadResponse.FromResult(result)
                 : WakettPriceUploadResponse.Empty();
@@ -24,7 +23,7 @@ public static class WakettController
         .WithOpenApi(op =>
         {
             op.Summary = "Fetch and store Wakett FX prices.";
-            op.Description = "Retrieves FX prices from Wakett, reconstructs missing crosses, and stores them in the database.";
+            op.Description = "Retrieves FX prices from Wakett, reconstructs missing crosses, and stores any missing bars from the last 24 hours in the database.";
             op.Responses["200"] = new OpenApiResponse
             {
                 Description = "Summary of the FX prices that were uploaded to Stage_HistClose.",

--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -1,10 +1,5 @@
 namespace TradingDaemon.Models;
 
-public class WakettPriceRequest
-{
-    public DateTimeOffset? Ts { get; set; }
-}
-
 public class WakettSecuritySymbol
 {
     public int SecurityId { get; set; }

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -35,7 +35,6 @@ public class WakettPriceFetcher
     }
 
     public async Task<WakettPriceUploadResult?> FetchAndStoreAsync(
-        DateTimeOffset? requestedTimestamp = null,
         CancellationToken cancellationToken = default)
     {
         var baseSymbols = _config


### PR DESCRIPTION
## Summary
- remove the timestamp request payload from the Wakett price fetch endpoint and refresh the OpenAPI description to reflect automated fetching
- drop the unused WakettPriceRequest model and simplify the price fetcher signature now that timestamps are determined internally

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d401f76f4c8333a8e1d97af7266699