### PR TITLE
Ensure Wakett price requests use UTC timestamp with Z suffix

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -22,12 +22,8 @@ public class WakettApiClient
         string? formattedTs = null;
         if (ts.HasValue)
         {
-            var etZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
-
-            var etTime = TimeZoneInfo.ConvertTime(ts.Value, etZone);
-
-            // Avec offset (+HH:mm)
-            formattedTs = etTime.ToString("yyyy-MM-dd HH:mm:ss.fffK", CultureInfo.InvariantCulture);
+            var utcTime = ts.Value.ToUniversalTime();
+            formattedTs = utcTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
         }
 
         var payload = new


### PR DESCRIPTION
## Summary
- format Wakett price request timestamps in UTC using a Z suffix so they end with :06:00.000Z when appropriate

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4038fb1b48333bd66cdb22554895a