### PR TITLE
Revert Wakett timestamp format change

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -22,8 +22,12 @@ public class WakettApiClient
         string? formattedTs = null;
         if (ts.HasValue)
         {
-            var utcTime = ts.Value.ToUniversalTime();
-            formattedTs = utcTime.ToString("yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture);
+            var etZone = TimeZoneInfo.FindSystemTimeZoneById("Eastern Standard Time");
+
+            var etTime = TimeZoneInfo.ConvertTime(ts.Value, etZone);
+
+            // Avec offset (+HH:mm)
+            formattedTs = etTime.ToString("yyyy-MM-dd HH:mm:ss.fffK", CultureInfo.InvariantCulture);
         }
 
         var payload = new


### PR DESCRIPTION
## Summary
- revert the timestamp formatting change in `WakettApiClient` so requests once again use Eastern Time with offset

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d40589dd788333a1a09903ebb1d43a