### PR TITLE
Implement Wakett order submission using latest theoretical weights

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1,6 +1,8 @@
-using System.Text;
-using System.Text.Json;
+using System.Globalization;
+using System.Linq;
+using System.Runtime.InteropServices;
 using Dapper;
+using Microsoft.Extensions.Configuration;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
 
@@ -8,36 +10,251 @@ namespace TradingDaemon.Services;
 
 public class OrderSender
 {
-    private readonly IHttpClientFactory _clientFactory;
+    private static readonly IReadOnlyDictionary<string, (TimeSpan Start, TimeSpan End)> SessionBounds = new Dictionary<string, (TimeSpan Start, TimeSpan End)>
+    {
+        ["US"] = (TimeSpan.Parse("09:30", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
+        ["US2"] = (TimeSpan.Parse("09:00", CultureInfo.InvariantCulture), TimeSpan.Parse("13:59", CultureInfo.InvariantCulture)),
+        ["EU"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("08:59", CultureInfo.InvariantCulture)),
+        ["EUUS"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("11:59", CultureInfo.InvariantCulture)),
+        ["AS"] = (TimeSpan.Parse("20:00", CultureInfo.InvariantCulture), TimeSpan.Parse("01:59", CultureInfo.InvariantCulture)),
+        ["ASEU"] = (TimeSpan.Parse("20:00", CultureInfo.InvariantCulture), TimeSpan.Parse("08:59", CultureInfo.InvariantCulture)),
+        ["ALL"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
+    };
+
+    private const int TargetModelId = 1;
+
+    private readonly WakettApiClient _wakettApiClient;
     private readonly DapperContext _context;
     private readonly ILogger<OrderSender> _logger;
+    private readonly IConfiguration _configuration;
+    private readonly TimeProvider _timeProvider;
 
-    public OrderSender(IHttpClientFactory clientFactory, DapperContext context, ILogger<OrderSender> logger)
+    public OrderSender(
+        WakettApiClient wakettApiClient,
+        DapperContext context,
+        ILogger<OrderSender> logger,
+        IConfiguration configuration,
+        TimeProvider? timeProvider = null)
     {
-        _clientFactory = clientFactory;
+        _wakettApiClient = wakettApiClient;
         _context = context;
         _logger = logger;
+        _configuration = configuration;
+        _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task SendOrdersAsync()
+    public async Task SendOrdersAsync(CancellationToken cancellationToken = default)
     {
         using var connection = _context.CreateConnection();
-        var sql = "SELECT symbol, value FROM weights";
-        _logger.LogInformation("Executing SQL: {Sql}", sql);
-        var weights = await connection.QueryAsync<Weight>(sql);
-        var client = _clientFactory.CreateClient("OrderApi");
-        var apiKey = Environment.GetEnvironmentVariable("ORDER_API_KEY") ?? string.Empty;
-
-        foreach (var weight in weights)
+        var latest = await LoadLatestWeightsAsync(connection, cancellationToken);
+        if (latest.Count == 0)
         {
-            var payload = JsonSerializer.Serialize(new { symbol = weight.Symbol, weight = weight.Value });
-            var request = new HttpRequestMessage(HttpMethod.Post, "/orders")
-            {
-                Content = new StringContent(payload, Encoding.UTF8, "application/json")
-            };
-            request.Headers.Add("Authorization", $"Bearer {apiKey}");
-            var response = await client.SendAsync(request);
-            response.EnsureSuccessStatusCode();
+            _logger.LogWarning("No theoretical weights found for model {ModelId}.", TargetModelId);
+            return;
         }
+
+        var latestBarTimeUtc = latest[0].BarTimeUtc;
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        if (!IsBarRecentEnough(latestBarTimeUtc, utcNow))
+        {
+            return;
+        }
+
+        var latestWeights = latest.Where(w => w.BarTimeUtc == latestBarTimeUtc).ToList();
+
+        var symbolMap = LoadSymbolMap();
+        if (symbolMap.Count == 0)
+        {
+            _logger.LogWarning("No Wakett symbols configured. Aborting order submission.");
+            return;
+        }
+
+        var orders = BuildOrders(latestWeights, symbolMap);
+        if (orders.Count == 0)
+        {
+            _logger.LogInformation("No non-zero weights available for Wakett order submission.");
+            return;
+        }
+
+        var request = new WakettOrderRequest
+        {
+            Ts = FormatTimestamp(latestBarTimeUtc),
+            Aum = ResolveAum(),
+            Orders = orders
+        };
+
+        var response = await _wakettApiClient.SendOrdersAsync(request);
+
+        if (response?.Orders is { Count: > 0 })
+        {
+            foreach (var item in response.Orders)
+            {
+                if (item.Error is not null)
+                {
+                    _logger.LogError(
+                        "Wakett rejected order for {Symbol}: {Code} {Message}.",
+                        item.Symbol,
+                        item.Error.Code,
+                        item.Error.Message);
+                }
+                else
+                {
+                    _logger.LogInformation(
+                        "Wakett accepted order for {Symbol} with side {Side}.",
+                        item.Symbol,
+                        item.Side);
+                }
+            }
+        }
+    }
+
+    internal static string FormatTimestamp(DateTime barTimeUtc)
+    {
+        var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, NewYorkZone);
+        var offset = NewYorkZone.GetUtcOffset(local);
+        var sign = offset < TimeSpan.Zero ? "-" : "+";
+        var abs = offset.Duration();
+        var offsetString = $"{sign}{abs.Hours:00}{abs.Minutes:00}";
+        return $"{local:yyyy-MM-dd HH:mm:ss.fff}{offsetString}";
+    }
+
+    protected virtual async Task<IReadOnlyList<TheoreticalWeightRow>> LoadLatestWeightsAsync(
+        IDbConnection connection,
+        CancellationToken cancellationToken)
+    {
+        const string sql = @"SELECT TOP (1000)
+    tw.SecurityId,
+    tw.ModelId,
+    tw.BarTimeUtc,
+    tw.ModelRunId,
+    tw.Weight
+FROM [Intraday].[model].[TheoreticalWeight] tw
+WHERE tw.ModelId = @ModelId
+ORDER BY tw.BarTimeUtc DESC, tw.SecurityId";
+
+        var definition = new CommandDefinition(
+            sql,
+            new { ModelId = TargetModelId },
+            cancellationToken: cancellationToken);
+
+        var rows = await connection.QueryAsync<TheoreticalWeightRow>(definition);
+        return rows.ToList();
+    }
+
+    private bool IsBarRecentEnough(DateTime barTimeUtc, DateTime utcNow)
+    {
+        var zone = CentralEuropeZone;
+        var barLocal = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, zone);
+        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(utcNow, zone);
+
+        if (barLocal.Date < nowLocal.Date)
+        {
+            _logger.LogInformation(
+                "Using previous day's theoretical weights from {BarTimeUtc:O} for first trade of the day.",
+                barTimeUtc);
+            return true;
+        }
+
+        if (utcNow - barTimeUtc > TimeSpan.FromMinutes(60))
+        {
+            _logger.LogWarning(
+                "Latest theoretical weights are stale. Last bar: {BarTimeUtc:O}, now: {NowUtc:O}.",
+                barTimeUtc,
+                utcNow);
+            return false;
+        }
+
+        return true;
+    }
+
+    private Dictionary<int, string> LoadSymbolMap()
+    {
+        var configured = _configuration
+            .GetSection("ExternalApis:WakettApi:Symbols")
+            .Get<List<WakettSecuritySymbol>>() ?? new List<WakettSecuritySymbol>();
+
+        var map = new Dictionary<int, string>();
+        foreach (var symbol in configured)
+        {
+            map[symbol.SecurityId] = symbol.Symbol;
+        }
+
+        return map;
+    }
+
+    private static List<WakettOrderItem> BuildOrders(
+        IEnumerable<TheoreticalWeightRow> weights,
+        IReadOnlyDictionary<int, string> symbolMap)
+    {
+        var orders = new List<WakettOrderItem>();
+
+        foreach (var weight in weights.OrderBy(w => w.SecurityId))
+        {
+            if (!symbolMap.TryGetValue(weight.SecurityId, out var symbol))
+            {
+                continue;
+            }
+
+            if (weight.Weight == 0m)
+            {
+                continue;
+            }
+
+            var side = weight.Weight > 0 ? "BUY" : "SELL";
+            var sizeValue = Math.Abs((double)weight.Weight);
+
+            orders.Add(new WakettOrderItem
+            {
+                Symbol = symbol,
+                Side = side,
+                Code = $"QQB-{weight.SecurityId}",
+                Size = new WakettOrderSize
+                {
+                    Type = "percentage",
+                    Value = sizeValue
+                }
+            });
+        }
+
+        return orders;
+    }
+
+    private double? ResolveAum()
+    {
+        var configured = Environment.GetEnvironmentVariable("WAKETT_AUM")
+            ?? _configuration["ExternalApis:WakettApi:Aum"];
+
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return null;
+        }
+
+        if (double.TryParse(configured, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        _logger.LogWarning("Unable to parse Wakett AUM value '{Value}'.", configured);
+        return null;
+    }
+
+    private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York");
+
+    private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
+
+    internal sealed record TheoreticalWeightRow
+    {
+        public int SecurityId { get; init; }
+
+        public int ModelId { get; init; }
+
+        public DateTime BarTimeUtc { get; init; }
+
+        public long ModelRunId { get; init; }
+
+        public decimal Weight { get; init; }
     }
 }

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -1,86 +1,231 @@
-using Xunit;
-using Moq;
-using Moq.Protected;
+using System.Collections.Generic;
+using System.Data;
 using System.Net;
 using System.Net.Http;
-using System.Data;
-using Dapper;
-using TradingDaemon.Services;
-using TradingDaemon.Data;
-using TradingDaemon.Models;
-using Microsoft.Extensions.Logging;
+using System.Runtime.InteropServices;
+using System.Text.Json;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using TradingDaemon.Data;
+using TradingDaemon.Services;
+using Xunit;
 
 public class OrderSenderTests
 {
     [Fact]
-    public async Task SendOrdersAsync_PostsOrders()
+    public async Task SendOrdersAsync_SubmitsLatestWeightsToWakett()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 15, 0, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-30).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m },
+            new() { SecurityId = 61, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = -0.05m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "58",
+            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD",
+            ["ExternalApis:WakettApi:Symbols:1:SecurityId"] = "61",
+            ["ExternalApis:WakettApi:Symbols:1:Symbol"] = "EUR/CHF",
+            ["ExternalApis:WakettApi:Aum"] = "2500000"
+        });
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.NotNull(captured);
+        var payload = await captured!.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+
+        Assert.Equal(OrderSender.FormatTimestamp(barTimeUtc), root.GetProperty("ts").GetString());
+        Assert.Equal(2_500_000d, root.GetProperty("aum").GetDouble());
+
+        var orders = root.GetProperty("orders");
+        Assert.Equal(2, orders.GetArrayLength());
+
+        var first = orders[0];
+        Assert.Equal("EUR/USD", first.GetProperty("symbol").GetString());
+        Assert.Equal("BUY", first.GetProperty("side").GetString());
+        Assert.Equal("QQB-58", first.GetProperty("code").GetString());
+        Assert.Equal("percentage", first.GetProperty("size").GetProperty("type").GetString());
+        Assert.Equal(0.15, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
+
+        var second = orders[1];
+        Assert.Equal("EUR/CHF", second.GetProperty("symbol").GetString());
+        Assert.Equal("SELL", second.GetProperty("side").GetString());
+        Assert.Equal(0.05, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task SendOrdersAsync_DoesNotSendWhenWeightsAreStale()
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK));
-        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
-        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("OrderApi") == client);
 
-        var config = new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
         {
-            ["ConnectionStrings:DefaultConnection"] = "Server=localhost;Database=test;User Id=test;Password=test;"
-        }).Build();
-        var context = new Mock<DapperContext>(config);
-        context.Setup(c => c.CreateConnection()).Returns(new FakeDbConnection());
+            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "58",
+            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD"
+        });
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
 
         var logger = Mock.Of<ILogger<OrderSender>>();
-        var sender = new OrderSender(factory, context.Object, logger);
+
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
+        var nowLocal = new DateTime(2024, 1, 2, 12, 0, 0);
+        var nowUtc = TimeZoneInfo.ConvertTimeToUtc(nowLocal, zone);
+        var staleLocal = nowLocal.AddHours(-3);
+        var staleUtc = TimeZoneInfo.ConvertTimeToUtc(staleLocal, zone);
+
+        var timeProvider = new TestTimeProvider(new DateTimeOffset(nowUtc, TimeSpan.Zero));
+
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = staleUtc, ModelRunId = 1, Weight = 0.2m }
+        };
+
+        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights);
 
         await sender.SendOrdersAsync();
 
-        handler.Protected().Verify("SendAsync", Times.AtLeast(0), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
     }
-}
 
-// Simple fake IDbConnection that does nothing
-class FakeDbConnection : IDbConnection
-{
-    public string ConnectionString { get; set; } = string.Empty;
-    public int ConnectionTimeout => 0;
-    public string Database => string.Empty;
-    public ConnectionState State => ConnectionState.Open;
-    public IDbTransaction BeginTransaction() => null!;
-    public IDbTransaction BeginTransaction(IsolationLevel il) => null!;
-    public void ChangeDatabase(string databaseName) {}
-    public void Close() {}
-    public IDbCommand CreateCommand() => new FakeDbCommand();
-    public void Open() {}
-    public void Dispose() {}
-}
-
-class FakeDbCommand : IDbCommand
-{
-    public string CommandText { get; set; } = string.Empty;
-    public int CommandTimeout { get; set; }
-    public CommandType CommandType { get; set; }
-    public IDbConnection? Connection { get; set; }
-    public IDataParameterCollection Parameters { get; } = new FakeParameterCollection();
-    public IDbTransaction? Transaction { get; set; }
-    public UpdateRowSource UpdatedRowSource { get; set; }
-    public void Cancel() {}
-    public IDbDataParameter CreateParameter() => null!;
-    public void Dispose() {}
-    public int ExecuteNonQuery() => 0;
-    public IDataReader ExecuteReader() => null!;
-    public IDataReader ExecuteReader(CommandBehavior behavior) => null!;
-    public object? ExecuteScalar() => null;
-    public void Prepare() {}
-}
-
-class FakeParameterCollection : List<IDataParameter>, IDataParameterCollection
-{
-    object? IDataParameterCollection.this[string parameterName]
+    [Fact]
+    public async Task SendOrdersAsync_UsesPreviousDayWeightsForFirstTrade()
     {
-        get => null;
-        set {}
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "58",
+            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD"
+        });
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+
+        var nowLocal = new DateTime(2024, 1, 2, 7, 0, 0);
+        var nowUtc = TimeZoneInfo.ConvertTimeToUtc(nowLocal, zone);
+        var previousDayLocal = new DateTime(2024, 1, 1, 15, 59, 0);
+        var previousDayUtc = TimeZoneInfo.ConvertTimeToUtc(previousDayLocal, zone);
+
+        var timeProvider = new TestTimeProvider(new DateTimeOffset(nowUtc, TimeSpan.Zero));
+
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = previousDayUtc, ModelRunId = 1, Weight = 0.3m }
+        };
+
+        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.NotNull(captured);
+        var payload = await captured!.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+        Assert.Equal(OrderSender.FormatTimestamp(previousDayUtc), root.GetProperty("ts").GetString());
     }
-    bool IDataParameterCollection.Contains(string parameterName) => false;
-    int IDataParameterCollection.IndexOf(string parameterName) => -1;
-    void IDataParameterCollection.RemoveAt(string parameterName) {}
+
+    private static IConfigurationRoot BuildConfiguration(IDictionary<string, string?> values)
+        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+
+    private sealed class TestOrderSender : OrderSender
+    {
+        private readonly IReadOnlyList<TheoreticalWeightRow> _weights;
+
+        public TestOrderSender(
+            WakettApiClient client,
+            DapperContext context,
+            ILogger<OrderSender> logger,
+            IConfiguration configuration,
+            TimeProvider timeProvider,
+            IReadOnlyList<TheoreticalWeightRow> weights)
+            : base(client, context, logger, configuration, timeProvider)
+        {
+            _weights = weights;
+        }
+
+        protected override Task<IReadOnlyList<TheoreticalWeightRow>> LoadLatestWeightsAsync(
+            IDbConnection connection,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_weights);
+    }
+
+    private sealed class TestTimeProvider : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow;
+
+        public TestTimeProvider(DateTimeOffset utcNow)
+        {
+            _utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow() => _utcNow;
+    }
 }


### PR DESCRIPTION
## Summary
- add session bounds and enhanced Wakett order submission logic that queries the latest theoretical weights, validates bar recency and formats requests for the Wakett API
- resolve Wakett symbols/AUM from configuration, build percentage orders, and log Wakett API responses
- cover the new behaviour with unit tests that verify request payloads, stale-weight skipping, and previous-day allowances

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d50f6d6d148333bca7a7b31d993014