### PR TITLE
Add Swagger endpoint for OrderSender

### DIFF
--- a/src/TradingDaemon/Controllers/OrderController.cs
+++ b/src/TradingDaemon/Controllers/OrderController.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class OrderController
+{
+    public static void MapOrderEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/orders/send", async Task<Ok<OrderSendResponse>> (OrderSender orderSender) =>
+        {
+            await orderSender.SendOrdersAsync();
+            return TypedResults.Ok(new OrderSendResponse("OrdersSent"));
+        })
+        .WithName("SendOrders")
+        .Produces<OrderSendResponse>()
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Submit Wakett orders";
+            op.Description = "Loads the latest theoretical weights, converts them into Wakett orders, and submits them through the Wakett API.";
+            op.Responses["200"] = new OpenApiResponse
+            {
+                Description = "The order submission workflow completed and Wakett orders were sent.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(OrderSendResponse)
+                            }
+                        }
+                    }
+                }
+            };
+            return op;
+        });
+    }
+}
+
+public sealed record OrderSendResponse(string Status);

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -55,6 +55,7 @@ var app = builder.Build();
 app.MapFillEndpoints();
 app.MapPriceEndpoints();
 app.MapWeightEndpoints();
+app.MapOrderEndpoints();
 app.MapTradingEndpoints();
 app.MapReportEndpoints();
 app.MapWakettEndpoints();


### PR DESCRIPTION
## Summary
- add a dedicated /api/orders/send endpoint that runs OrderSender and documents it in Swagger
- include the new endpoint in the application pipeline so it is exposed alongside other operations

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d51bb48da4833392655e3bc63ae4eb