### PR TITLE
Add Swagger endpoint for Wakett order sender

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -44,5 +44,40 @@ public static class WakettController
             };
             return op;
         });
+
+        app.MapPost("/api/wakett/orders/send", async Task<Ok<WakettOrderSubmissionResponse>> (OrderSender orderSender) =>
+        {
+            await orderSender.SendOrdersAsync();
+            return TypedResults.Ok(new WakettOrderSubmissionResponse("OrdersSent"));
+        })
+        .WithName("SendWakettOrders")
+        .Produces<WakettOrderSubmissionResponse>()
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Submit orders to Wakett.";
+            op.Description = "Triggers the Wakett order sender to translate the latest theoretical weights into Wakett orders a"
+                + "nd submit them through the Wakett trading API.";
+            op.Responses["200"] = new OpenApiResponse
+            {
+                Description = "The Wakett order sender completed and attempted to submit all orders.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(WakettOrderSubmissionResponse)
+                            }
+                        }
+                    }
+                }
+            };
+            return op;
+        });
     }
 }
+
+public sealed record WakettOrderSubmissionResponse(string Status);


### PR DESCRIPTION
## Summary
- add a Wakett orders endpoint to the Wakett controller that invokes the existing order sender
- document the new endpoint in Swagger with a dedicated response record

## Testing
- `dotnet test` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5201945d0833391265500ad65b19c