### PR TITLE
Fix missing HttpResponseMessage namespace

### DIFF
--- a/src/TradingDaemon/Utils/RetryPolicyFactory.cs
+++ b/src/TradingDaemon/Utils/RetryPolicyFactory.cs
@@ -1,5 +1,6 @@
 using Polly;
 using System.Net;
+using System.Net.Http;
 
 namespace TradingDaemon.Utils;
 


### PR DESCRIPTION
## Summary
- add the missing System.Net.Http import so RetryPolicyFactory can use HttpResponseMessage

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d523dd2bb88333a324ee4f105d38a6