### PR TITLE
Fix OrderSender compile issues

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1,3 +1,4 @@
+using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -245,7 +246,7 @@ ORDER BY tw.BarTimeUtc DESC, tw.SecurityId";
     private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
 
-    internal sealed record TheoreticalWeightRow
+    protected sealed record TheoreticalWeightRow
     {
         public int SecurityId { get; init; }
 


### PR DESCRIPTION
## Summary
- import System.Data in OrderSender to align IDbConnection usage
- adjust TheoreticalWeightRow accessibility so LoadLatestWeightsAsync remains consistent

## Testing
- `dotnet build TradingDaemon.sln` *(fails: dotnet command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d525daa60c8333a430e75d12192d48