### PR TITLE
Net theoretical weights to USD crosses

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -188,37 +188,168 @@ ORDER BY tw.BarTimeUtc DESC, tw.SecurityId";
         IEnumerable<TheoreticalWeightRow> weights,
         IReadOnlyDictionary<int, string> symbolMap)
     {
-        var orders = new List<WakettOrderItem>();
+        var parsedSymbols = symbolMap
+            .Select(pair => SymbolInfo.TryCreate(pair.Key, pair.Value, out var info) ? info : null)
+            .Where(info => info is not null)
+            .Cast<SymbolInfo>()
+            .ToDictionary(info => info.SecurityId);
 
-        foreach (var weight in weights.OrderBy(w => w.SecurityId))
+        if (parsedSymbols.Count == 0)
         {
-            if (!symbolMap.TryGetValue(weight.SecurityId, out var symbol))
-            {
-                continue;
-            }
+            return new List<WakettOrderItem>();
+        }
 
+        var exposures = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var weight in weights)
+        {
             if (weight.Weight == 0m)
             {
                 continue;
             }
 
-            var side = weight.Weight > 0 ? "BUY" : "SELL";
-            var sizeValue = Math.Abs((double)weight.Weight);
-
-            orders.Add(new WakettOrderItem
+            if (!parsedSymbols.TryGetValue(weight.SecurityId, out var symbol))
             {
-                Symbol = symbol,
-                Side = side,
-                Code = $"QQB-{weight.SecurityId}",
+                continue;
+            }
+
+            AddExposure(exposures, symbol.BaseCurrency, weight.Weight);
+            AddExposure(exposures, symbol.QuoteCurrency, -weight.Weight);
+        }
+
+        if (exposures.Count == 0)
+        {
+            return new List<WakettOrderItem>();
+        }
+
+        var usdBasePairs = parsedSymbols.Values
+            .Where(info => string.Equals(info.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+            .GroupBy(info => info.BaseCurrency, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(info => info.SecurityId).First(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var usdQuotePairs = parsedSymbols.Values
+            .Where(info => string.Equals(info.BaseCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+            .GroupBy(info => info.QuoteCurrency, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                group => group.Key,
+                group => group.OrderBy(info => info.SecurityId).First(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var orderDescriptors = new List<(int SecurityId, string Symbol, decimal Weight)>();
+
+        foreach (var kvp in exposures)
+        {
+            var currency = kvp.Key;
+            var exposure = kvp.Value;
+
+            if (string.Equals(currency, "USD", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (exposure == 0m)
+            {
+                continue;
+            }
+
+            if (usdBasePairs.TryGetValue(currency, out var basePair))
+            {
+                orderDescriptors.Add((basePair.SecurityId, basePair.Symbol, exposure));
+                continue;
+            }
+
+            if (usdQuotePairs.TryGetValue(currency, out var quotePair))
+            {
+                orderDescriptors.Add((quotePair.SecurityId, quotePair.Symbol, -exposure));
+            }
+        }
+
+        return orderDescriptors
+            .Where(order => order.Weight != 0m)
+            .OrderBy(order => order.SecurityId)
+            .Select(order => new WakettOrderItem
+            {
+                Symbol = order.Symbol,
+                Side = order.Weight > 0 ? "BUY" : "SELL",
+                Code = $"QQB-{order.SecurityId}",
                 Size = new WakettOrderSize
                 {
                     Type = "percentage",
-                    Value = sizeValue
+                    Value = Math.Abs((double)order.Weight)
                 }
-            });
+            })
+            .ToList();
+    }
+
+    private static void AddExposure(IDictionary<string, decimal> exposures, string currency, decimal value)
+    {
+        if (value == 0m)
+        {
+            return;
         }
 
-        return orders;
+        if (!exposures.TryGetValue(currency, out var existing))
+        {
+            exposures[currency] = value;
+            return;
+        }
+
+        var updated = existing + value;
+
+        if (updated == 0m)
+        {
+            exposures.Remove(currency);
+        }
+        else
+        {
+            exposures[currency] = updated;
+        }
+    }
+
+    private sealed record SymbolInfo(int SecurityId, string Symbol, string BaseCurrency, string QuoteCurrency)
+    {
+        public static bool TryCreate(int securityId, string? symbol, out SymbolInfo? info)
+        {
+            info = null;
+
+            if (string.IsNullOrWhiteSpace(symbol))
+            {
+                return false;
+            }
+
+            var trimmed = symbol.Trim();
+            var normalized = trimmed.ToUpperInvariant();
+
+            string baseCurrency;
+            string quoteCurrency;
+
+            if (normalized.Contains('/'))
+            {
+                var parts = normalized.Split('/');
+                if (parts.Length != 2 || parts[0].Length != 3 || parts[1].Length != 3)
+                {
+                    return false;
+                }
+
+                baseCurrency = parts[0];
+                quoteCurrency = parts[1];
+            }
+            else if (normalized.Length == 6)
+            {
+                baseCurrency = normalized[..3];
+                quoteCurrency = normalized[3..6];
+            }
+            else
+            {
+                return false;
+            }
+
+            info = new SymbolInfo(securityId, trimmed, baseCurrency, quoteCurrency);
+            return true;
+        }
     }
 
     private double? ResolveAum()

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -44,6 +44,8 @@ public class OrderSenderTests
             ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD",
             ["ExternalApis:WakettApi:Symbols:1:SecurityId"] = "61",
             ["ExternalApis:WakettApi:Symbols:1:Symbol"] = "EUR/CHF",
+            ["ExternalApis:WakettApi:Symbols:2:SecurityId"] = "136",
+            ["ExternalApis:WakettApi:Symbols:2:Symbol"] = "USD/CHF",
             ["ExternalApis:WakettApi:Aum"] = "2500000"
         });
 
@@ -79,12 +81,96 @@ public class OrderSenderTests
         Assert.Equal("BUY", first.GetProperty("side").GetString());
         Assert.Equal("QQB-58", first.GetProperty("code").GetString());
         Assert.Equal("percentage", first.GetProperty("size").GetProperty("type").GetString());
-        Assert.Equal(0.15, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
+        Assert.Equal(0.1, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
 
         var second = orders[1];
-        Assert.Equal("EUR/CHF", second.GetProperty("symbol").GetString());
+        Assert.Equal("USD/CHF", second.GetProperty("symbol").GetString());
         Assert.Equal("SELL", second.GetProperty("side").GetString());
+        Assert.Equal("QQB-136", second.GetProperty("code").GetString());
         Assert.Equal(0.05, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task SendOrdersAsync_NetsCrossesIntoUsdPairs()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 15, 0, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-30).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 61, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 11, Weight = 0.2m },
+            new() { SecurityId = 62, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 11, Weight = 0.1m },
+            new() { SecurityId = 65, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 11, Weight = -0.1m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "61",
+            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/CHF",
+            ["ExternalApis:WakettApi:Symbols:1:SecurityId"] = "62",
+            ["ExternalApis:WakettApi:Symbols:1:Symbol"] = "CAD/JPY",
+            ["ExternalApis:WakettApi:Symbols:2:SecurityId"] = "65",
+            ["ExternalApis:WakettApi:Symbols:2:Symbol"] = "USD/JPY",
+            ["ExternalApis:WakettApi:Symbols:3:SecurityId"] = "66",
+            ["ExternalApis:WakettApi:Symbols:3:Symbol"] = "EUR/USD",
+            ["ExternalApis:WakettApi:Symbols:4:SecurityId"] = "64",
+            ["ExternalApis:WakettApi:Symbols:4:Symbol"] = "USD/CAD",
+            ["ExternalApis:WakettApi:Symbols:5:SecurityId"] = "136",
+            ["ExternalApis:WakettApi:Symbols:5:Symbol"] = "USD/CHF"
+        });
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.NotNull(captured);
+        var payload = await captured!.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var orders = document.RootElement.GetProperty("orders");
+
+        Assert.Equal(3, orders.GetArrayLength());
+
+        var first = orders[0];
+        Assert.Equal("USD/CAD", first.GetProperty("symbol").GetString());
+        Assert.Equal("SELL", first.GetProperty("side").GetString());
+        Assert.Equal("QQB-64", first.GetProperty("code").GetString());
+        Assert.Equal(0.1, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
+
+        var second = orders[1];
+        Assert.Equal("EUR/USD", second.GetProperty("symbol").GetString());
+        Assert.Equal("BUY", second.GetProperty("side").GetString());
+        Assert.Equal("QQB-66", second.GetProperty("code").GetString());
+        Assert.Equal(0.2, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
+
+        var third = orders[2];
+        Assert.Equal("USD/CHF", third.GetProperty("symbol").GetString());
+        Assert.Equal("BUY", third.GetProperty("side").GetString());
+        Assert.Equal("QQB-136", third.GetProperty("code").GetString());
+        Assert.Equal(0.2, third.GetProperty("size").GetProperty("value").GetDouble(), 6);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- compute currency exposures from theoretical weights and rebuild orders only for USD crosses using configured symbols
- add helpers to parse Wakett symbols and align order direction with symbol orientation
- update and extend order sender tests to cover USD netting behaviour

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d53c43c1f08333949d6b3c35a45124