### PR TITLE
Adjust Wakett order timestamps to next session bar

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -22,6 +22,17 @@ public class OrderSender
         ["ALL"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
     };
 
+    private static readonly IReadOnlyList<string> SessionPreference = new[]
+    {
+        "US",
+        "US2",
+        "EU",
+        "EUUS",
+        "AS",
+        "ASEU",
+        "ALL"
+    };
+
     private const int TargetModelId = 1;
 
     private readonly WakettApiClient _wakettApiClient;
@@ -64,6 +75,10 @@ public class OrderSender
 
         var latestWeights = latest.Where(w => w.BarTimeUtc == latestBarTimeUtc).ToList();
 
+        var barInterval = ResolveBarInterval(latest, latestBarTimeUtc);
+        var session = ResolveTradingSession(latestBarTimeUtc);
+        var orderTimestampUtc = CalculateOrderTimestamp(latestBarTimeUtc, barInterval, session);
+
         var symbolMap = await LoadSymbolMapAsync(connection, cancellationToken);
         if (symbolMap.Count == 0)
         {
@@ -80,7 +95,7 @@ public class OrderSender
 
         var request = new WakettOrderRequest
         {
-            Ts = FormatTimestamp(latestBarTimeUtc),
+            Ts = FormatTimestamp(orderTimestampUtc),
             Aum = ResolveAum(),
             Orders = orders
         };
@@ -118,6 +133,135 @@ public class OrderSender
         var abs = offset.Duration();
         var offsetString = $"{sign}{abs.Hours:00}{abs.Minutes:00}";
         return $"{local:yyyy-MM-dd HH:mm:ss.fff}{offsetString}";
+    }
+
+    internal static DateTime CalculateOrderTimestamp(DateTime barTimeUtc, TimeSpan barInterval, string sessionKey)
+    {
+        if (!SessionBounds.TryGetValue(sessionKey, out var bounds))
+        {
+            bounds = SessionBounds["US"];
+        }
+
+        var zone = NewYorkZone;
+        var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, zone);
+        var (sessionStart, sessionEnd) = GetSessionWindow(local, bounds);
+
+        var candidate = local + barInterval;
+        if (candidate <= sessionEnd)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(candidate, zone);
+        }
+
+        var nextSessionStart = sessionStart.AddDays(1);
+        return TimeZoneInfo.ConvertTimeToUtc(nextSessionStart, zone);
+    }
+
+    private TimeSpan ResolveBarInterval(IReadOnlyList<TheoreticalWeightRow> weights, DateTime latestBarTimeUtc)
+    {
+        foreach (var row in weights)
+        {
+            if (row.BarTimeUtc < latestBarTimeUtc)
+            {
+                var interval = latestBarTimeUtc - row.BarTimeUtc;
+                if (interval > TimeSpan.Zero)
+                {
+                    return interval;
+                }
+            }
+        }
+
+        var configured = Environment.GetEnvironmentVariable("WAKETT_BAR_INTERVAL_MINUTES")
+            ?? _configuration["ExternalApis:WakettApi:BarIntervalMinutes"];
+
+        if (int.TryParse(configured, NumberStyles.Integer, CultureInfo.InvariantCulture, out var minutes) && minutes > 0)
+        {
+            return TimeSpan.FromMinutes(minutes);
+        }
+
+        var programme = _configuration.GetSection("Programmes").GetChildren()
+            .FirstOrDefault(section => int.TryParse(section["ModelId"], out var id) && id == TargetModelId);
+
+        if (programme is not null && int.TryParse(programme["Timeframe"], NumberStyles.Integer, CultureInfo.InvariantCulture, out var programmeMinutes) && programmeMinutes > 0)
+        {
+            return TimeSpan.FromMinutes(programmeMinutes);
+        }
+
+        return TimeSpan.FromHours(1);
+    }
+
+    private string ResolveTradingSession(DateTime barTimeUtc)
+    {
+        var configured = Environment.GetEnvironmentVariable("WAKETT_SESSION")
+            ?? _configuration["ExternalApis:WakettApi:Session"];
+
+        if (!string.IsNullOrWhiteSpace(configured))
+        {
+            var normalized = configured.Trim().ToUpperInvariant();
+            if (SessionBounds.ContainsKey(normalized))
+            {
+                return normalized;
+            }
+        }
+
+        var programme = _configuration.GetSection("Programmes").GetChildren()
+            .FirstOrDefault(section => int.TryParse(section["ModelId"], out var id) && id == TargetModelId);
+
+        if (programme is not null)
+        {
+            var programmeSession = programme["Session"];
+            if (!string.IsNullOrWhiteSpace(programmeSession))
+            {
+                var normalized = programmeSession.Trim().ToUpperInvariant();
+                if (SessionBounds.ContainsKey(normalized))
+                {
+                    return normalized;
+                }
+            }
+        }
+
+        var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, NewYorkZone);
+        foreach (var session in SessionPreference)
+        {
+            if (SessionBounds.TryGetValue(session, out var bounds) && IsWithinSession(local, bounds))
+            {
+                return session;
+            }
+        }
+
+        return "US";
+    }
+
+    private static (DateTime Start, DateTime End) GetSessionWindow(DateTime local, (TimeSpan Start, TimeSpan End) bounds)
+    {
+        var duration = bounds.End - bounds.Start;
+        if (duration <= TimeSpan.Zero)
+        {
+            duration += TimeSpan.FromDays(1);
+        }
+
+        var start = local.Date + bounds.Start;
+
+        while (true)
+        {
+            var end = start + duration;
+            if (local >= start && local <= end)
+            {
+                return (start, end);
+            }
+
+            start = local < start ? start.AddDays(-1) : start.AddDays(1);
+        }
+    }
+
+    private static bool IsWithinSession(DateTime local, (TimeSpan Start, TimeSpan End) bounds)
+    {
+        var time = local.TimeOfDay;
+        if (bounds.Start <= bounds.End)
+        {
+            return time >= bounds.Start && time <= bounds.End;
+        }
+
+        return time >= bounds.Start || time <= bounds.End;
     }
 
     protected virtual async Task<IReadOnlyList<TheoreticalWeightRow>> LoadLatestWeightsAsync(

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -30,8 +30,8 @@ public class OrderSenderTests
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
         var apiClient = new WakettApiClient(factory);
 
-        var now = new DateTimeOffset(2024, 1, 2, 15, 0, 0, TimeSpan.Zero);
-        var barTimeUtc = now.AddMinutes(-30).UtcDateTime;
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
         var weights = new List<OrderSender.TheoreticalWeightRow>
         {
             new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m },
@@ -71,7 +71,8 @@ public class OrderSenderTests
         using var document = JsonDocument.Parse(payload);
         var root = document.RootElement;
 
-        Assert.Equal(OrderSender.FormatTimestamp(barTimeUtc), root.GetProperty("ts").GetString());
+        var expectedOrderTimestampUtc = OrderSender.CalculateOrderTimestamp(barTimeUtc, TimeSpan.FromMinutes(60), "US");
+        Assert.Equal(OrderSender.FormatTimestamp(expectedOrderTimestampUtc), root.GetProperty("ts").GetString());
         Assert.Equal(2_500_000d, root.GetProperty("aum").GetDouble());
 
         var orders = root.GetProperty("orders");
@@ -107,8 +108,8 @@ public class OrderSenderTests
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
         var apiClient = new WakettApiClient(factory);
 
-        var now = new DateTimeOffset(2024, 1, 2, 15, 0, 0, TimeSpan.Zero);
-        var barTimeUtc = now.AddMinutes(-30).UtcDateTime;
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
         var weights = new List<OrderSender.TheoreticalWeightRow>
         {
             new() { SecurityId = 61, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 11, Weight = 0.2m },
@@ -250,7 +251,7 @@ public class OrderSenderTests
 
         var nowLocal = new DateTime(2024, 1, 2, 7, 0, 0);
         var nowUtc = TimeZoneInfo.ConvertTimeToUtc(nowLocal, zone);
-        var previousDayLocal = new DateTime(2024, 1, 1, 15, 59, 0);
+        var previousDayLocal = new DateTime(2024, 1, 1, 21, 0, 0);
         var previousDayUtc = TimeZoneInfo.ConvertTimeToUtc(previousDayLocal, zone);
 
         var timeProvider = new TestTimeProvider(new DateTimeOffset(nowUtc, TimeSpan.Zero));
@@ -274,11 +275,26 @@ public class OrderSenderTests
         var payload = await captured!.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
         var root = document.RootElement;
-        Assert.Equal(OrderSender.FormatTimestamp(previousDayUtc), root.GetProperty("ts").GetString());
+        var expectedTsUtc = OrderSender.CalculateOrderTimestamp(previousDayUtc, TimeSpan.FromMinutes(60), "US");
+        Assert.Equal(OrderSender.FormatTimestamp(expectedTsUtc), root.GetProperty("ts").GetString());
     }
 
     private static IConfigurationRoot BuildConfiguration(IDictionary<string, string?> values)
-        => new ConfigurationBuilder().AddInMemoryCollection(values).Build();
+    {
+        var defaults = new Dictionary<string, string?>
+        {
+            ["Programmes:0:ModelId"] = "1",
+            ["Programmes:0:Session"] = "US",
+            ["Programmes:0:Timeframe"] = "60"
+        };
+
+        foreach (var kvp in values)
+        {
+            defaults[kvp.Key] = kvp.Value;
+        }
+
+        return new ConfigurationBuilder().AddInMemoryCollection(defaults).Build();
+    }
 
     private sealed class TestOrderSender : OrderSender
     {


### PR DESCRIPTION
## Summary
- derive the order submission timestamp one bar after the latest weight while respecting configured sessions
- infer bar intervals and sessions from configuration/environment with fallbacks when building the Wakett order request
- update OrderSender tests to cover the new timestamp logic and supply default programme metadata

## Testing
- `dotnet test` *(fails: dotnet CLI is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5480517248333a97cf269692bc0fc