### PR TITLE
Use model schedule for Wakett order timestamps

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -77,7 +77,13 @@ public class OrderSender
 
         var barInterval = ResolveBarInterval(latest, latestBarTimeUtc);
         var session = ResolveTradingSession(latestBarTimeUtc);
-        var orderTimestampUtc = CalculateOrderTimestamp(latestBarTimeUtc, barInterval, session);
+        var schedule = await LoadModelScheduleAsync(connection, cancellationToken);
+        var orderTimestampUtc = CalculateOrderTimestamp(
+            latestBarTimeUtc,
+            barInterval,
+            session,
+            schedule?.Offset,
+            schedule?.BarSize);
 
         var symbolMap = await LoadSymbolMapAsync(connection, cancellationToken);
         if (symbolMap.Count == 0)
@@ -135,7 +141,12 @@ public class OrderSender
         return $"{local:yyyy-MM-dd HH:mm:ss.fff}{offsetString}";
     }
 
-    internal static DateTime CalculateOrderTimestamp(DateTime barTimeUtc, TimeSpan barInterval, string sessionKey)
+    internal static DateTime CalculateOrderTimestamp(
+        DateTime barTimeUtc,
+        TimeSpan barInterval,
+        string sessionKey,
+        int? offsetMinutes = null,
+        int? barSizeMinutes = null)
     {
         if (!SessionBounds.TryGetValue(sessionKey, out var bounds))
         {
@@ -146,6 +157,18 @@ public class OrderSender
         var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, zone);
         var (sessionStart, sessionEnd) = GetSessionWindow(local, bounds);
 
+        var scheduleCandidate = TryGetNextScheduledTime(
+            local,
+            sessionStart,
+            sessionEnd,
+            offsetMinutes,
+            barSizeMinutes);
+
+        if (scheduleCandidate is not null)
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(scheduleCandidate.Value, zone);
+        }
+
         var candidate = local + barInterval;
         if (candidate <= sessionEnd)
         {
@@ -154,6 +177,86 @@ public class OrderSender
 
         var nextSessionStart = sessionStart.AddDays(1);
         return TimeZoneInfo.ConvertTimeToUtc(nextSessionStart, zone);
+    }
+
+    private static DateTime? TryGetNextScheduledTime(
+        DateTime local,
+        DateTime sessionStart,
+        DateTime sessionEnd,
+        int? offsetMinutes,
+        int? barSizeMinutes)
+    {
+        if (offsetMinutes is not > 0)
+        {
+            return null;
+        }
+
+        var baseMinute = Math.Max(0, barSizeMinutes ?? 0);
+        var step = offsetMinutes.Value;
+
+        var withinSession = GetNextScheduledLocal(local, step, baseMinute, strictlyGreater: true);
+        if (withinSession <= sessionEnd)
+        {
+            return withinSession;
+        }
+
+        var duration = sessionEnd - sessionStart;
+        if (duration <= TimeSpan.Zero)
+        {
+            duration += TimeSpan.FromDays(1);
+        }
+
+        var nextSessionStart = sessionStart.AddDays(1);
+        var nextSessionEnd = nextSessionStart + duration;
+
+        var nextSession = GetNextScheduledLocal(nextSessionStart, step, baseMinute, strictlyGreater: false);
+        if (nextSession > nextSessionEnd)
+        {
+            return nextSessionStart;
+        }
+
+        return nextSession;
+    }
+
+    private static DateTime GetNextScheduledLocal(
+        DateTime reference,
+        int stepMinutes,
+        int baseMinute,
+        bool strictlyGreater)
+    {
+        const int MinutesPerDay = 24 * 60;
+
+        var minutes = (int)Math.Floor(reference.TimeOfDay.TotalMinutes);
+
+        int nextMinute;
+        if (minutes < baseMinute || (minutes == baseMinute && !strictlyGreater))
+        {
+            nextMinute = baseMinute;
+        }
+        else
+        {
+            var delta = minutes - baseMinute;
+            var steps = delta / stepMinutes;
+            var remainder = delta % stepMinutes;
+
+            if (remainder == 0)
+            {
+                if (strictlyGreater)
+                {
+                    steps += 1;
+                }
+            }
+            else
+            {
+                steps += 1;
+            }
+
+            nextMinute = baseMinute + (steps * stepMinutes);
+        }
+
+        var dayOffset = Math.DivRem(nextMinute, MinutesPerDay, out var minuteOfDay);
+        var candidateDate = reference.Date.AddDays(dayOffset);
+        return candidateDate + TimeSpan.FromMinutes(minuteOfDay);
     }
 
     private TimeSpan ResolveBarInterval(IReadOnlyList<TheoreticalWeightRow> weights, DateTime latestBarTimeUtc)
@@ -285,6 +388,26 @@ ORDER BY tw.BarTimeUtc DESC, tw.SecurityId";
 
         var rows = await connection.QueryAsync<TheoreticalWeightRow>(definition);
         return rows.ToList();
+    }
+
+    protected virtual async Task<ModelScheduleRow?> LoadModelScheduleAsync(
+        IDbConnection connection,
+        CancellationToken cancellationToken)
+    {
+        const string sql = @"SELECT TOP (1)
+    BarSize,
+    Offset
+FROM [Intraday].[model].[Model]
+WHERE ModelId = @ModelId
+ORDER BY ModelId";
+
+        var definition = new CommandDefinition(
+            sql,
+            new { ModelId = TargetModelId },
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QueryFirstOrDefaultAsync<ModelScheduleRow>(definition);
+        return row;
     }
 
     private bool IsBarRecentEnough(DateTime barTimeUtc, DateTime utcNow)
@@ -556,5 +679,12 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         public int SecurityId { get; init; }
 
         public string? Symbol { get; init; }
+    }
+
+    protected sealed record ModelScheduleRow
+    {
+        public int? BarSize { get; init; }
+
+        public int? Offset { get; init; }
     }
 }

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -56,7 +56,15 @@ public class OrderSenderTests
         var logger = Mock.Of<ILogger<OrderSender>>();
         var timeProvider = new TestTimeProvider(now);
 
-        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights, symbolMap);
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
 
         await sender.SendOrdersAsync();
 
@@ -71,7 +79,12 @@ public class OrderSenderTests
         using var document = JsonDocument.Parse(payload);
         var root = document.RootElement;
 
-        var expectedOrderTimestampUtc = OrderSender.CalculateOrderTimestamp(barTimeUtc, TimeSpan.FromMinutes(60), "US");
+        var expectedOrderTimestampUtc = OrderSender.CalculateOrderTimestamp(
+            barTimeUtc,
+            TimeSpan.FromMinutes(60),
+            "US",
+            60,
+            0);
         Assert.Equal(OrderSender.FormatTimestamp(expectedOrderTimestampUtc), root.GetProperty("ts").GetString());
         Assert.Equal(2_500_000d, root.GetProperty("aum").GetDouble());
 
@@ -135,7 +148,15 @@ public class OrderSenderTests
         var logger = Mock.Of<ILogger<OrderSender>>();
         var timeProvider = new TestTimeProvider(now);
 
-        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights, symbolMap);
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
 
         await sender.SendOrdersAsync();
 
@@ -207,7 +228,15 @@ public class OrderSenderTests
             new() { SecurityId = 58, ModelId = 1, BarTimeUtc = staleUtc, ModelRunId = 1, Weight = 0.2m }
         };
 
-        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights, symbolMap);
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
 
         await sender.SendOrdersAsync();
 
@@ -261,7 +290,15 @@ public class OrderSenderTests
             new() { SecurityId = 58, ModelId = 1, BarTimeUtc = previousDayUtc, ModelRunId = 1, Weight = 0.3m }
         };
 
-        var sender = new TestOrderSender(apiClient, context.Object, logger, configuration, timeProvider, weights, symbolMap);
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
 
         await sender.SendOrdersAsync();
 
@@ -275,8 +312,55 @@ public class OrderSenderTests
         var payload = await captured!.Content.ReadAsStringAsync();
         using var document = JsonDocument.Parse(payload);
         var root = document.RootElement;
-        var expectedTsUtc = OrderSender.CalculateOrderTimestamp(previousDayUtc, TimeSpan.FromMinutes(60), "US");
+        var expectedTsUtc = OrderSender.CalculateOrderTimestamp(
+            previousDayUtc,
+            TimeSpan.FromMinutes(60),
+            "US",
+            60,
+            0);
         Assert.Equal(OrderSender.FormatTimestamp(expectedTsUtc), root.GetProperty("ts").GetString());
+    }
+
+    [Fact]
+    public void CalculateOrderTimestamp_UsesModelScheduleWithinSession()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var localBar = new DateTime(2024, 1, 2, 10, 0, 0, DateTimeKind.Unspecified);
+        var barTimeUtc = TimeZoneInfo.ConvertTimeToUtc(localBar, zone);
+
+        var result = OrderSender.CalculateOrderTimestamp(
+            barTimeUtc,
+            TimeSpan.FromMinutes(60),
+            "US",
+            15,
+            5);
+
+        var expectedLocal = new DateTime(2024, 1, 2, 10, 5, 0, DateTimeKind.Unspecified);
+        var expectedUtc = TimeZoneInfo.ConvertTimeToUtc(expectedLocal, zone);
+
+        Assert.Equal(expectedUtc, result);
+    }
+
+    [Fact]
+    public void CalculateOrderTimestamp_RollsToNextSessionWhenScheduleExceedsEnd()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var localBar = new DateTime(2024, 1, 2, 15, 50, 0, DateTimeKind.Unspecified);
+        var barTimeUtc = TimeZoneInfo.ConvertTimeToUtc(localBar, zone);
+
+        var result = OrderSender.CalculateOrderTimestamp(
+            barTimeUtc,
+            TimeSpan.FromMinutes(60),
+            "US",
+            15,
+            5);
+
+        var nextSessionLocal = new DateTime(2024, 1, 3, 9, 35, 0, DateTimeKind.Unspecified);
+        var expectedUtc = TimeZoneInfo.ConvertTimeToUtc(nextSessionLocal, zone);
+
+        Assert.Equal(expectedUtc, result);
     }
 
     private static IConfigurationRoot BuildConfiguration(IDictionary<string, string?> values)
@@ -300,6 +384,7 @@ public class OrderSenderTests
     {
         private readonly IReadOnlyList<TheoreticalWeightRow> _weights;
         private readonly IReadOnlyDictionary<int, string> _symbolMap;
+        private readonly ModelScheduleRow? _schedule;
 
         public TestOrderSender(
             WakettApiClient client,
@@ -308,11 +393,13 @@ public class OrderSenderTests
             IConfiguration configuration,
             TimeProvider timeProvider,
             IReadOnlyList<TheoreticalWeightRow> weights,
-            IReadOnlyDictionary<int, string> symbolMap)
+            IReadOnlyDictionary<int, string> symbolMap,
+            ModelScheduleRow? schedule)
             : base(client, context, logger, configuration, timeProvider)
         {
             _weights = weights;
             _symbolMap = symbolMap;
+            _schedule = schedule;
         }
 
         protected override Task<IReadOnlyList<TheoreticalWeightRow>> LoadLatestWeightsAsync(
@@ -324,6 +411,11 @@ public class OrderSenderTests
             IDbConnection connection,
             CancellationToken cancellationToken)
             => Task.FromResult(new Dictionary<int, string>(_symbolMap));
+
+        protected override Task<ModelScheduleRow?> LoadModelScheduleAsync(
+            IDbConnection connection,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_schedule);
     }
 
     private sealed class TestTimeProvider : TimeProvider


### PR DESCRIPTION
## Summary
- load the model's bar size and offset when preparing Wakett orders
- derive order timestamps from the model schedule when available, with fallbacks to existing behaviour
- extend unit tests to cover schedule-driven timestamps and expose the schedule to the test sender helper

## Testing
- dotnet test *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d54bd44bd4833383cb4c07191a2425