### PR TITLE
Align hourly buckets with session start for offset zero

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Globalization;
 using System.Runtime.InteropServices;
 using System.Linq;
@@ -139,6 +140,7 @@ public class PriceFetcher
         var result = new List<(DateTime, decimal)>();
         DateTime? currentBucket = null;
         decimal lastClose = 0;
+        var sessionStartAligned = AlignSessionStart(bounds.Start, minutes);
         foreach (var item in series.OrderBy(s => s.BarTimeUtc))
         {
             var local = TimeZoneInfo.ConvertTimeFromUtc(item.BarTimeUtc, zone);
@@ -147,6 +149,10 @@ public class PriceFetcher
             var end = start.Add(TimeSpan.FromMinutes(minutes - 1));
             if (end < bounds.Start || end > bounds.End) continue;
             var bucket = new DateTime(local.Year, local.Month, local.Day, local.Hour, local.Minute / minutes * minutes, 0);
+            if (bucket.TimeOfDay < sessionStartAligned)
+            {
+                bucket = new DateTime(local.Year, local.Month, local.Day).Add(sessionStartAligned);
+            }
             if (currentBucket != bucket)
             {
                 if (currentBucket.HasValue)
@@ -158,6 +164,22 @@ public class PriceFetcher
         if (currentBucket.HasValue)
             result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), zone), lastClose));
         return result;
+    }
+
+    private static TimeSpan AlignSessionStart(TimeSpan sessionStart, int minutes)
+    {
+        if (minutes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minutes), "Aggregation interval must be positive.");
+        }
+
+        if (sessionStart == TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var totalMinutes = (int)Math.Ceiling(sessionStart.TotalMinutes / minutes) * minutes;
+        return TimeSpan.FromMinutes(totalMinutes);
     }
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -675,6 +675,7 @@ public class WakettPriceFetcher
         var result = new List<(DateTime, decimal)>();
         DateTime? currentBucket = null;
         decimal lastClose = 0;
+        var sessionStartAligned = AlignSessionStart(bounds.Start, minutes);
         foreach (var item in series.OrderBy(s => s.BarTimeUtc))
         {
             var local = TimeZoneInfo.ConvertTimeFromUtc(item.BarTimeUtc, zone);
@@ -683,6 +684,10 @@ public class WakettPriceFetcher
             var end = start.Add(TimeSpan.FromMinutes(minutes - 1));
             if (end < bounds.Start || end > bounds.End) continue;
             var bucket = new DateTime(local.Year, local.Month, local.Day, local.Hour, local.Minute / minutes * minutes, 0);
+            if (bucket.TimeOfDay < sessionStartAligned)
+            {
+                bucket = new DateTime(local.Year, local.Month, local.Day).Add(sessionStartAligned);
+            }
             if (currentBucket != bucket)
             {
                 if (currentBucket.HasValue)
@@ -694,6 +699,22 @@ public class WakettPriceFetcher
         if (currentBucket.HasValue)
             result.Add((TimeZoneInfo.ConvertTimeToUtc(currentBucket.Value.AddMinutes(offset), zone), lastClose));
         return result;
+    }
+
+    private static TimeSpan AlignSessionStart(TimeSpan sessionStart, int minutes)
+    {
+        if (minutes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(nameof(minutes), "Aggregation interval must be positive.");
+        }
+
+        if (sessionStart == TimeSpan.Zero)
+        {
+            return TimeSpan.Zero;
+        }
+
+        var totalMinutes = (int)Math.Ceiling(sessionStart.TotalMinutes / minutes) * minutes;
+        return TimeSpan.FromMinutes(totalMinutes);
     }
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -41,7 +41,7 @@ public class PriceFetcherTests
     }
 
     [Fact]
-    public void RawNMin_Includes9amBarInUSSession()
+    public void RawNMin_FirstUsBarAlignsToNextHour()
     {
         var series = new List<HistClose>
         {
@@ -57,7 +57,8 @@ public class PriceFetcherTests
         var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
         var times = result.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
 
-        Assert.Contains(new TimeSpan(9, 0, 0), times);
+        Assert.Contains(new TimeSpan(10, 0, 0), times);
+        Assert.DoesNotContain(new TimeSpan(9, 0, 0), times);
     }
 
     [Fact]
@@ -145,7 +146,7 @@ public class PriceFetcherTests
 
         Assert.DoesNotContain(new TimeSpan(8, 0, 0), times);
         Assert.DoesNotContain(new TimeSpan(16, 0, 0), times);
-        Assert.Contains(new TimeSpan(9, 0, 0), times);
+        Assert.Contains(new TimeSpan(10, 0, 0), times);
         Assert.Contains(new TimeSpan(15, 0, 0), times);
     }
 }


### PR DESCRIPTION
## Summary
- ensure hourly aggregation buckets are not earlier than the aligned session start so US sessions begin on the next :00 when offset is zero
- share the alignment logic between the price fetchers via a new helper so Wakett uploads and staged prices behave consistently
- update unit expectations to cover the adjusted session boundary timing

## Testing
- `dotnet test` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d54f766e20833396a48148a4f34c93