### PR TITLE
Allow overriding Wakett order AUM via API request

### DIFF
--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -45,9 +45,11 @@ public static class WakettController
             return op;
         });
 
-        app.MapPost("/api/wakett/orders/send", async Task<Ok<WakettOrderSubmissionResponse>> (OrderSender orderSender) =>
+        app.MapPost("/api/wakett/orders/send", async Task<Ok<WakettOrderSubmissionResponse>> (
+            OrderSender orderSender,
+            SendWakettOrdersRequest? request) =>
         {
-            await orderSender.SendOrdersAsync();
+            await orderSender.SendOrdersAsync(request?.Aum);
             return TypedResults.Ok(new WakettOrderSubmissionResponse("OrdersSent"));
         })
         .WithName("SendWakettOrders")
@@ -57,6 +59,24 @@ public static class WakettController
             op.Summary = "Submit orders to Wakett.";
             op.Description = "Triggers the Wakett order sender to translate the latest theoretical weights into Wakett orders a"
                 + "nd submit them through the Wakett trading API.";
+            op.RequestBody = new OpenApiRequestBody
+            {
+                Required = false,
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(SendWakettOrdersRequest)
+                            }
+                        }
+                    }
+                }
+            };
             op.Responses["200"] = new OpenApiResponse
             {
                 Description = "The Wakett order sender completed and attempted to submit all orders.",
@@ -81,3 +101,5 @@ public static class WakettController
 }
 
 public sealed record WakettOrderSubmissionResponse(string Status);
+
+public sealed record SendWakettOrdersRequest(double? Aum);

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -55,7 +55,7 @@ public class OrderSender
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
-    public async Task SendOrdersAsync(CancellationToken cancellationToken = default)
+    public async Task SendOrdersAsync(double? aumOverride = null, CancellationToken cancellationToken = default)
     {
         using var connection = _context.CreateConnection();
         var latest = await LoadLatestWeightsAsync(connection, cancellationToken);
@@ -102,7 +102,7 @@ public class OrderSender
         var request = new WakettOrderRequest
         {
             Ts = FormatTimestamp(orderTimestampUtc),
-            Aum = ResolveAum(),
+            Aum = aumOverride ?? ResolveAum(),
             Orders = orders
         };
 

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -106,6 +106,64 @@ public class OrderSenderTests
     }
 
     [Fact]
+    public async Task SendOrdersAsync_UsesOverrideAumWhenProvided()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Aum"] = "2500000"
+        });
+
+        var symbolMap = new Dictionary<int, string>
+        {
+            [58] = "EURUSD"
+        };
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
+
+        await sender.SendOrdersAsync(3_100_000d);
+
+        Assert.NotNull(captured);
+        var payload = await captured!.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var root = document.RootElement;
+        Assert.Equal(3_100_000d, root.GetProperty("aum").GetDouble());
+    }
+
+    [Fact]
     public async Task SendOrdersAsync_NetsCrossesIntoUsdPairs()
     {
         HttpRequestMessage? captured = null;


### PR DESCRIPTION
## Summary
- allow the Wakett send orders endpoint to accept an optional AUM payload
- thread the optional AUM through OrderSender so it overrides the configured value when present
- document the new payload in OpenAPI metadata and cover the override behavior with a unit test

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5598a9e54833394a8e21af7221361