### PR TITLE
Format Wakett order symbols as currency pairs

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -557,7 +557,7 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
                 group => group.OrderBy(info => info.SecurityId).First(),
                 StringComparer.OrdinalIgnoreCase);
 
-        var orderDescriptors = new List<(int SecurityId, string Symbol, decimal Weight)>();
+        var orderDescriptors = new List<(int SecurityId, SymbolInfo Info, decimal Weight)>();
 
         foreach (var kvp in exposures)
         {
@@ -576,13 +576,13 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
             if (usdBasePairs.TryGetValue(currency, out var basePair))
             {
-                orderDescriptors.Add((basePair.SecurityId, basePair.Symbol, exposure));
+                orderDescriptors.Add((basePair.SecurityId, basePair, exposure));
                 continue;
             }
 
             if (usdQuotePairs.TryGetValue(currency, out var quotePair))
             {
-                orderDescriptors.Add((quotePair.SecurityId, quotePair.Symbol, -exposure));
+                orderDescriptors.Add((quotePair.SecurityId, quotePair, -exposure));
             }
         }
 
@@ -591,7 +591,7 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             .OrderBy(order => order.SecurityId)
             .Select(order => new WakettOrderItem
             {
-                Symbol = order.Symbol,
+                Symbol = order.Info.FormattedSymbol,
                 Side = order.Weight > 0 ? "BUY" : "SELL",
                 Code = $"QQB-{order.SecurityId}",
                 Size = new WakettOrderSize
@@ -630,6 +630,8 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
     private sealed record SymbolInfo(int SecurityId, string Symbol, string BaseCurrency, string QuoteCurrency)
     {
+        public string FormattedSymbol => $"{BaseCurrency}/{QuoteCurrency}";
+
         public static bool TryCreate(int securityId, string? symbol, out SymbolInfo? info)
         {
             info = null;

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -92,14 +92,14 @@ public class OrderSenderTests
         Assert.Equal(2, orders.GetArrayLength());
 
         var first = orders[0];
-        Assert.Equal("EURUSD", first.GetProperty("symbol").GetString());
+        Assert.Equal("EUR/USD", first.GetProperty("symbol").GetString());
         Assert.Equal("BUY", first.GetProperty("side").GetString());
         Assert.Equal("QQB-58", first.GetProperty("code").GetString());
         Assert.Equal("percentage", first.GetProperty("size").GetProperty("type").GetString());
         Assert.Equal(0.1, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
 
         var second = orders[1];
-        Assert.Equal("USDCHF", second.GetProperty("symbol").GetString());
+        Assert.Equal("USD/CHF", second.GetProperty("symbol").GetString());
         Assert.Equal("SELL", second.GetProperty("side").GetString());
         Assert.Equal("QQB-136", second.GetProperty("code").GetString());
         Assert.Equal(0.05, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
@@ -232,19 +232,19 @@ public class OrderSenderTests
         Assert.Equal(3, orders.GetArrayLength());
 
         var first = orders[0];
-        Assert.Equal("USDCAD", first.GetProperty("symbol").GetString());
+        Assert.Equal("USD/CAD", first.GetProperty("symbol").GetString());
         Assert.Equal("SELL", first.GetProperty("side").GetString());
         Assert.Equal("QQB-64", first.GetProperty("code").GetString());
         Assert.Equal(0.1, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
 
         var second = orders[1];
-        Assert.Equal("EURUSD", second.GetProperty("symbol").GetString());
+        Assert.Equal("EUR/USD", second.GetProperty("symbol").GetString());
         Assert.Equal("BUY", second.GetProperty("side").GetString());
         Assert.Equal("QQB-66", second.GetProperty("code").GetString());
         Assert.Equal(0.2, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
 
         var third = orders[2];
-        Assert.Equal("USDCHF", third.GetProperty("symbol").GetString());
+        Assert.Equal("USD/CHF", third.GetProperty("symbol").GetString());
         Assert.Equal("BUY", third.GetProperty("side").GetString());
         Assert.Equal("QQB-136", third.GetProperty("code").GetString());
         Assert.Equal(0.2, third.GetProperty("size").GetProperty("value").GetDouble(), 6);


### PR DESCRIPTION
## Summary
- ensure Wakett order payloads emit currency pairs with a slash separator
- expose a formatted symbol on order symbols and use it when building orders
- update order sender unit tests to expect the slash-delimited symbols

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d55c2cc45c833392f5204a85e9c121