### PR TITLE
Validate Wakett order symbols against allowed list

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
 using System.Linq;
@@ -92,7 +93,14 @@ public class OrderSender
             return;
         }
 
-        var orders = BuildOrders(latestWeights, symbolMap);
+        var allowedSymbols = LoadAllowedSymbols();
+        if (allowedSymbols.Count == 0)
+        {
+            _logger.LogWarning("No allowed Wakett symbols configured. Aborting order submission.");
+            return;
+        }
+
+        var orders = BuildOrders(latestWeights, symbolMap, allowedSymbols);
         if (orders.Count == 0)
         {
             _logger.LogInformation("No non-zero weights available for Wakett order submission.");
@@ -503,9 +511,42 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         return map;
     }
 
+    private HashSet<string> LoadAllowedSymbols()
+    {
+        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in EnumerateConfiguredSymbols("ExternalApis:WakettApi:Symbols"))
+        {
+            allowed.Add(item);
+        }
+
+        foreach (var item in EnumerateConfiguredSymbols("ExternalApis:WakettApi:MissingSymbols"))
+        {
+            allowed.Add(item);
+        }
+
+        return allowed;
+    }
+
+    private IEnumerable<string> EnumerateConfiguredSymbols(string section)
+    {
+        var configured = _configuration
+            .GetSection(section)
+            .Get<List<WakettSecuritySymbol>>() ?? new();
+
+        foreach (var symbol in configured)
+        {
+            if (SymbolInfo.TryCreate(symbol.SecurityId, symbol.Symbol, out var info))
+            {
+                yield return info.FormattedSymbol;
+            }
+        }
+    }
+
     private static List<WakettOrderItem> BuildOrders(
         IEnumerable<TheoreticalWeightRow> weights,
-        IReadOnlyDictionary<int, string> symbolMap)
+        IReadOnlyDictionary<int, string> symbolMap,
+        ISet<string> allowedSymbols)
     {
         var parsedSymbols = symbolMap
             .Select(pair => SymbolInfo.TryCreate(pair.Key, pair.Value, out var info) ? info : null)
@@ -586,21 +627,42 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             }
         }
 
-        return orderDescriptors
-            .Where(order => order.Weight != 0m)
-            .OrderBy(order => order.SecurityId)
-            .Select(order => new WakettOrderItem
+        var result = new List<WakettOrderItem>();
+
+        foreach (var order in orderDescriptors.Where(order => order.Weight != 0m).OrderBy(order => order.SecurityId))
+        {
+            var formatted = order.Info.FormattedSymbol;
+            var side = order.Weight > 0 ? "BUY" : "SELL";
+            var value = Math.Abs((double)order.Weight);
+
+            if (!allowedSymbols.Contains(formatted))
             {
-                Symbol = order.Info.FormattedSymbol,
-                Side = order.Weight > 0 ? "BUY" : "SELL",
+                var reversed = order.Info.ReversedFormattedSymbol;
+                if (allowedSymbols.Contains(reversed))
+                {
+                    formatted = reversed;
+                    side = side == "BUY" ? "SELL" : "BUY";
+                }
+                else
+                {
+                    continue;
+                }
+            }
+
+            result.Add(new WakettOrderItem
+            {
+                Symbol = formatted,
+                Side = side,
                 Code = $"QQB-{order.SecurityId}",
                 Size = new WakettOrderSize
                 {
                     Type = "percentage",
-                    Value = Math.Abs((double)order.Weight)
+                    Value = value
                 }
-            })
-            .ToList();
+            });
+        }
+
+        return result;
     }
 
     private static void AddExposure(IDictionary<string, decimal> exposures, string currency, decimal value)
@@ -631,6 +693,7 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private sealed record SymbolInfo(int SecurityId, string Symbol, string BaseCurrency, string QuoteCurrency)
     {
         public string FormattedSymbol => $"{BaseCurrency}/{QuoteCurrency}";
+        public string ReversedFormattedSymbol => $"{QuoteCurrency}/{BaseCurrency}";
 
         public static bool TryCreate(int securityId, string? symbol, out SymbolInfo? info)
         {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -251,6 +251,74 @@ public class OrderSenderTests
     }
 
     [Fact]
+    public async Task SendOrdersAsync_FlipsSideForReversedAllowedSymbol()
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 200, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 11, Weight = 0.2m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>());
+
+        var symbolMap = new Dictionary<int, string>
+        {
+            [200] = "CHFUSD"
+        };
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 });
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Once(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.NotNull(captured);
+        var payload = await captured!.Content.ReadAsStringAsync();
+        using var document = JsonDocument.Parse(payload);
+        var orders = document.RootElement.GetProperty("orders");
+
+        Assert.Equal(1, orders.GetArrayLength());
+
+        var first = orders[0];
+        Assert.Equal("USD/CHF", first.GetProperty("symbol").GetString());
+        Assert.Equal("SELL", first.GetProperty("side").GetString());
+        Assert.Equal("QQB-200", first.GetProperty("code").GetString());
+        Assert.Equal(0.2, first.GetProperty("size").GetProperty("value").GetDouble(), 6);
+    }
+
+    [Fact]
     public async Task SendOrdersAsync_DoesNotSendWhenWeightsAreStale()
     {
         var handler = new Mock<HttpMessageHandler>();
@@ -448,7 +516,21 @@ public class OrderSenderTests
         {
             ["Programmes:0:ModelId"] = "1",
             ["Programmes:0:Session"] = "US",
-            ["Programmes:0:Timeframe"] = "60"
+            ["Programmes:0:Timeframe"] = "60",
+            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "58",
+            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD",
+            ["ExternalApis:WakettApi:Symbols:1:SecurityId"] = "61",
+            ["ExternalApis:WakettApi:Symbols:1:Symbol"] = "EUR/CHF",
+            ["ExternalApis:WakettApi:Symbols:2:SecurityId"] = "62",
+            ["ExternalApis:WakettApi:Symbols:2:Symbol"] = "CAD/JPY",
+            ["ExternalApis:WakettApi:Symbols:3:SecurityId"] = "64",
+            ["ExternalApis:WakettApi:Symbols:3:Symbol"] = "USD/CAD",
+            ["ExternalApis:WakettApi:Symbols:4:SecurityId"] = "65",
+            ["ExternalApis:WakettApi:Symbols:4:Symbol"] = "USD/JPY",
+            ["ExternalApis:WakettApi:Symbols:5:SecurityId"] = "66",
+            ["ExternalApis:WakettApi:Symbols:5:Symbol"] = "EUR/USD",
+            ["ExternalApis:WakettApi:Symbols:6:SecurityId"] = "136",
+            ["ExternalApis:WakettApi:Symbols:6:Symbol"] = "USD/CHF"
         };
 
         foreach (var kvp in values)


### PR DESCRIPTION
## Summary
- load the allowed Wakett symbols from configuration and ensure generated orders only include permitted pairs
- flip the order side when the configured symbol orientation must be inverted, skipping symbols that are not supported
- extend the order sender tests with configuration defaults and a case covering inverted symbols

## Testing
- dotnet test *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d55f41d2bc83339ad715d0fc0eb425