### PR TITLE
Log Wakett order request payload

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -44,6 +44,8 @@ public class WakettApiClient
     public async Task<WakettOrderResponse?> SendOrdersAsync(WakettOrderRequest request)
     {
         var client = _clientFactory.CreateClient("WakettApi");
+        var jsonBody = JsonSerializer.Serialize(request, _jsonOptions);
+        System.Console.WriteLine($"Sending Wakett order request: {jsonBody}");
         var response = await client.PostAsJsonAsync("orders", request, _jsonOptions);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- serialize the Wakett order request and write it to the console before sending it

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5645dcde88333ae3775b1cad10196