### PR TITLE
Lowercase Wakett order request body

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -2,6 +2,7 @@ using System.Text.Json;
 using System.Net.Http.Json;
 using System.Linq;
 using System.Globalization;
+using System.Text;
 using TradingDaemon.Models;
 
 namespace TradingDaemon.Services;
@@ -45,8 +46,10 @@ public class WakettApiClient
     {
         var client = _clientFactory.CreateClient("WakettApi");
         var jsonBody = JsonSerializer.Serialize(request, _jsonOptions);
-        System.Console.WriteLine($"Sending Wakett order request: {jsonBody}");
-        var response = await client.PostAsJsonAsync("orders", request, _jsonOptions);
+        var lowerCaseJsonBody = jsonBody.ToLowerInvariant();
+        System.Console.WriteLine($"Sending Wakett order request: {lowerCaseJsonBody}");
+        var content = new StringContent(lowerCaseJsonBody, Encoding.UTF8, "application/json");
+        var response = await client.PostAsync("orders", content);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<WakettOrderResponse>(json, _jsonOptions);


### PR DESCRIPTION
## Summary
- convert the Wakett order request JSON payload to lowercase before sending
- send the lowercase payload using explicit StringContent

## Testing
- dotnet test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5668d1f388333a2d810c3bcdedd2c