### PR TITLE
Ensure order request JSON fields are lowercase

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -11,6 +11,11 @@ public class WakettApiClient
 {
     private readonly IHttpClientFactory _clientFactory;
     private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNameCaseInsensitive = true };
+    private static readonly JsonSerializerOptions OrderRequestJsonOptions = new()
+    {
+        PropertyNamingPolicy = LowerCaseNamingPolicy.Instance,
+        DictionaryKeyPolicy = LowerCaseNamingPolicy.Instance
+    };
 
     public WakettApiClient(IHttpClientFactory clientFactory)
     {
@@ -45,10 +50,9 @@ public class WakettApiClient
     public async Task<WakettOrderResponse?> SendOrdersAsync(WakettOrderRequest request)
     {
         var client = _clientFactory.CreateClient("WakettApi");
-        var jsonBody = JsonSerializer.Serialize(request, _jsonOptions);
-        var lowerCaseJsonBody = jsonBody.ToLowerInvariant();
-        System.Console.WriteLine($"Sending Wakett order request: {lowerCaseJsonBody}");
-        var content = new StringContent(lowerCaseJsonBody, Encoding.UTF8, "application/json");
+        var jsonBody = JsonSerializer.Serialize(request, OrderRequestJsonOptions);
+        System.Console.WriteLine($"Sending Wakett order request: {jsonBody}");
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
         var response = await client.PostAsync("orders", content);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
@@ -62,5 +66,19 @@ public class WakettApiClient
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<WakettTradeResponse>(json, _jsonOptions);
+    }
+}
+
+internal sealed class LowerCaseNamingPolicy : JsonNamingPolicy
+{
+    public static LowerCaseNamingPolicy Instance { get; } = new();
+
+    private LowerCaseNamingPolicy()
+    {
+    }
+
+    public override string ConvertName(string name)
+    {
+        return name.ToLowerInvariant();
     }
 }

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -55,8 +55,10 @@ public class WakettApiClientTests
     [Fact]
     public async Task SendOrdersAsync_PostsToOrdersEndpoint()
     {
+        HttpRequestMessage? captured = null;
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((m, _) => captured = m)
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"ts\":\"\",\"orders\":[]}") });
         var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
@@ -78,6 +80,19 @@ public class WakettApiClientTests
             Times.Once(),
             ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/orders"),
             ItExpr.IsAny<CancellationToken>());
+
+        var body = await captured!.Content.ReadAsStringAsync();
+        Assert.Contains("\"orders\":[{", body);
+        Assert.Contains("\"symbol\":\"AAPL\"", body);
+        Assert.Contains("\"side\":\"BUY\"", body);
+        Assert.Contains("\"code\":\"QQB-1\"", body);
+        Assert.Contains("\"size\":{\"value\":100", body);
+        Assert.Contains("\"type\":\"absolute\"", body);
+        Assert.DoesNotContain("\"Symbol\"", body);
+        Assert.DoesNotContain("\"Side\"", body);
+        Assert.DoesNotContain("\"Code\"", body);
+        Assert.DoesNotContain("\"Value\"", body);
+        Assert.DoesNotContain("\"Type\"", body);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- introduce a custom JSON naming policy that lowercases order request field names during serialization
- update the Wakett order request serialization to use the new policy while keeping payload values intact
- extend the Wakett API client test to assert that the outgoing order request payload uses lowercase field names

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68d568fa95208333aa32c49b2ca11e74