### PR TITLE
Adjust US session start time to 10:00

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -14,7 +14,7 @@ public class OrderSender
 {
     private static readonly IReadOnlyDictionary<string, (TimeSpan Start, TimeSpan End)> SessionBounds = new Dictionary<string, (TimeSpan Start, TimeSpan End)>
     {
-        ["US"] = (TimeSpan.Parse("09:30", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
+        ["US"] = (TimeSpan.Parse("10:00", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
         ["US2"] = (TimeSpan.Parse("09:00", CultureInfo.InvariantCulture), TimeSpan.Parse("13:59", CultureInfo.InvariantCulture)),
         ["EU"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("08:59", CultureInfo.InvariantCulture)),
         ["EUUS"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("11:59", CultureInfo.InvariantCulture)),

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -123,7 +123,7 @@ public class PriceFetcher
 
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
-        ["US"] = (NewYorkZone, TimeSpan.Parse("09:30"), TimeSpan.Parse("15:59")),
+        ["US"] = (NewYorkZone, TimeSpan.Parse("10:00"), TimeSpan.Parse("15:59")),
         ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
     };
 

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -661,7 +661,7 @@ public class WakettPriceFetcher
 
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
-        ["US"] = (NewYorkZone, TimeSpan.Parse("09:30"), TimeSpan.Parse("15:59")),
+        ["US"] = (NewYorkZone, TimeSpan.Parse("10:00"), TimeSpan.Parse("15:59")),
         ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
     };
 


### PR DESCRIPTION
## Summary
- update the US session start time to 10:00 across order sending and price fetching services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d64eb90e048333b57c29055c816b47