### PR TITLE
Adjust Wakett order timestamp minute for debugging

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -142,6 +142,15 @@ public class OrderSender
     internal static string FormatTimestamp(DateTime barTimeUtc)
     {
         var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, NewYorkZone);
+        local = new DateTime(
+            local.Year,
+            local.Month,
+            local.Day,
+            local.Hour,
+            6,
+            0,
+            0,
+            local.Kind);
         var offset = NewYorkZone.GetUtcOffset(local);
         var sign = offset < TimeSpan.Zero ? "-" : "+";
         var abs = offset.Duration();


### PR DESCRIPTION
## Summary
- force Wakett order timestamp formatting to use the :06:00.000 minute for debugging

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d659e5f9008333971af9bb01973d23