### PR TITLE
Adjust Wakett timestamp for top-of-hour bars

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -300,15 +300,32 @@ VALUES
     internal static string FormatTimestamp(DateTime barTimeUtc)
     {
         var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, NewYorkZone);
-        local = new DateTime(
-            local.Year,
-            local.Month,
-            local.Day,
-            local.Hour,
-            6,
-            0,
-            0,
-            local.Kind);
+
+        if (local.Minute == 0 && local.Second == 0 && local.Millisecond == 0)
+        {
+            local = local.AddHours(1);
+            local = new DateTime(
+                local.Year,
+                local.Month,
+                local.Day,
+                local.Hour,
+                0,
+                0,
+                local.Kind);
+        }
+        else
+        {
+            local = new DateTime(
+                local.Year,
+                local.Month,
+                local.Day,
+                local.Hour,
+                6,
+                0,
+                0,
+                local.Kind);
+        }
+
         var offset = NewYorkZone.GetUtcOffset(local);
         var sign = offset < TimeSpan.Zero ? "-" : "+";
         var abs = offset.Duration();

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -510,6 +510,25 @@ public class OrderSenderTests
         Assert.Equal(expectedUtc, result);
     }
 
+    [Fact]
+    public void FormatTimestamp_TopOfHourBarsAdvanceToNextHour()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var localBar = new DateTime(2024, 2, 5, 9, 0, 0, DateTimeKind.Unspecified);
+        var barTimeUtc = TimeZoneInfo.ConvertTimeToUtc(localBar, zone);
+
+        var formatted = OrderSender.FormatTimestamp(barTimeUtc);
+
+        var expectedLocal = localBar.AddHours(1);
+        var offset = zone.GetUtcOffset(expectedLocal);
+        var sign = offset < TimeSpan.Zero ? "-" : "+";
+        var abs = offset.Duration();
+        var expected = $"{expectedLocal:yyyy-MM-dd HH:mm:ss.fff}{sign}{abs.Hours:00}{abs.Minutes:00}";
+
+        Assert.Equal(expected, formatted);
+    }
+
     private static IConfigurationRoot BuildConfiguration(IDictionary<string, string?> values)
     {
         var defaults = new Dictionary<string, string?>


### PR DESCRIPTION
## Summary
- adjust Wakett timestamp formatting so top-of-hour bars are advanced to the next hour before submission
- add a unit test to confirm the new top-of-hour timestamp behaviour

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d69b21c8148333be3b90788b6c107c