### PR TITLE
Adjust Wakett order timestamps to :06

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -304,27 +304,16 @@ VALUES
         if (local.Minute == 0 && local.Second == 0 && local.Millisecond == 0)
         {
             local = local.AddHours(1);
-            local = new DateTime(
-                local.Year,
-                local.Month,
-                local.Day,
-                local.Hour,
-                0,
-                0,
-                local.Kind);
         }
-        else
-        {
-            local = new DateTime(
-                local.Year,
-                local.Month,
-                local.Day,
-                local.Hour,
-                6,
-                0,
-                0,
-                local.Kind);
-        }
+
+        local = new DateTime(
+            local.Year,
+            local.Month,
+            local.Day,
+            local.Hour,
+            6,
+            0,
+            local.Kind);
 
         var offset = NewYorkZone.GetUtcOffset(local);
         var sign = offset < TimeSpan.Zero ? "-" : "+";

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -520,7 +520,7 @@ public class OrderSenderTests
 
         var formatted = OrderSender.FormatTimestamp(barTimeUtc);
 
-        var expectedLocal = localBar.AddHours(1);
+        var expectedLocal = localBar.AddHours(1).AddMinutes(6);
         var offset = zone.GetUtcOffset(expectedLocal);
         var sign = offset < TimeSpan.Zero ? "-" : "+";
         var abs = offset.Duration();


### PR DESCRIPTION
## Summary
- update `OrderSender.FormatTimestamp` to always schedule Wakett orders at six minutes past the hour while still rolling top-of-hour bars forward
- adjust the corresponding unit test expectation to reflect the new :06 timestamp format

## Testing
- `dotnet test` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a533113083338e68d2ecd38b387b