### PR TITLE
Add Wakett fills ingestion endpoint and schema

### DIFF
--- a/scripts/sql/CreateWakettFillTable.sql
+++ b/scripts/sql/CreateWakettFillTable.sql
@@ -1,0 +1,75 @@
+/*
+    Creates the table used to persist Wakett fills returned by the /trades endpoint.
+    Execute inside the Wakett database context.
+*/
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.schemas s
+    INNER JOIN sys.tables t ON s.schema_id = t.schema_id
+    WHERE s.name = N'wakett'
+      AND t.name = N'Fill'
+)
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM sys.schemas
+        WHERE name = N'wakett'
+    )
+    BEGIN
+        EXEC ('CREATE SCHEMA [wakett] AUTHORIZATION dbo;');
+    END;
+
+    CREATE TABLE [wakett].[Fill]
+    (
+        WakettFillId        BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        ExecuteId           NVARCHAR(64)         NOT NULL,
+        Account             NVARCHAR(64)         NOT NULL,
+        RequestedFrom       CHAR(8)              NOT NULL,
+        RequestedTo         CHAR(8)              NOT NULL,
+        RequestedStrategy   NVARCHAR(64)         NULL,
+        PortfolioId         NVARCHAR(32)         NULL,
+        Portfolio           NVARCHAR(64)         NULL,
+        Alias               NVARCHAR(128)        NULL,
+        Broker              NVARCHAR(64)         NULL,
+        StrategyId          NVARCHAR(64)         NULL,
+        SymbolId            NVARCHAR(64)         NULL,
+        Symbol              NVARCHAR(32)         NOT NULL,
+        InstrumentId        NVARCHAR(64)         NULL,
+        Reference           NVARCHAR(64)         NULL,
+        CoreOrderId         INT                  NULL,
+        SubOrderId          INT                  NULL,
+        Label               NVARCHAR(64)         NULL,
+        Side                NVARCHAR(8)          NULL,
+        OrderPrice          DECIMAL(19,9)        NULL,
+        OrderId             NVARCHAR(64)         NULL,
+        OrderTimestamp      DATETIMEOFFSET(7)    NULL,
+        OrderSize           DECIMAL(19,9)        NULL,
+        OrderChannel        NVARCHAR(32)         NULL,
+        ProviderId          NVARCHAR(64)         NULL,
+        ProviderTimestamp   DATETIMEOFFSET(7)    NULL,
+        ExecuteTimestamp    DATETIMEOFFSET(7)    NULL,
+        EntitySize          DECIMAL(19,9)        NULL,
+        ExecuteSize         DECIMAL(19,9)        NULL,
+        ExecutePrice        DECIMAL(19,9)        NULL,
+        TradeTimestamp      DATETIMEOFFSET(7)    NULL,
+        Event               NVARCHAR(32)         NULL,
+        UserName            NVARCHAR(64)         NULL,
+        Code                NVARCHAR(64)         NULL,
+        RecordType          NVARCHAR(32)         NULL,
+        Quote               DECIMAL(19,9)        NULL,
+        Amount              DECIMAL(19,9)        NULL,
+        Rate                DECIMAL(19,9)        NULL,
+        CreatedAtUtc        DATETIME2(7)         NOT NULL CONSTRAINT DF_WakettFill_CreatedAtUtc DEFAULT SYSUTCDATETIME(),
+        UpdatedAtUtc        DATETIME2(7)         NOT NULL CONSTRAINT DF_WakettFill_UpdatedAtUtc DEFAULT SYSUTCDATETIME()
+    );
+
+    CREATE UNIQUE INDEX UX_WakettFill_ExecuteId
+        ON [wakett].[Fill] (ExecuteId);
+
+    CREATE INDEX IX_WakettFill_RequestedWindow
+        ON [wakett].[Fill] (Account, RequestedFrom, RequestedTo);
+
+    CREATE INDEX IX_WakettFill_ExecuteTimestamp
+        ON [wakett].[Fill] (ExecuteTimestamp);
+END;

--- a/src/TradingDaemon/Controllers/WakettController.cs
+++ b/src/TradingDaemon/Controllers/WakettController.cs
@@ -1,7 +1,9 @@
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.OpenApi.Models;
+using TradingDaemon.Models;
 using TradingDaemon.Services;
 
 namespace TradingDaemon.Controllers;
@@ -97,7 +99,98 @@ public static class WakettController
             };
             return op;
         });
+
+        app.MapPost("/api/wakett/fills/fetch", async Task<Results<BadRequest<ProblemDetails>, Ok<WakettFillUploadResponse>>>(
+            WakettTradeFetcher tradeFetcher,
+            FetchWakettFillsRequest request,
+            CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                var result = await tradeFetcher.FetchAndStoreAsync(request, cancellationToken);
+                return TypedResults.Ok(result);
+            }
+            catch (ArgumentException ex)
+            {
+                return TypedResults.BadRequest(CreateProblem("InvalidRequest", ex.Message));
+            }
+            catch (WakettTradeFetcherException ex)
+            {
+                return TypedResults.BadRequest(CreateProblem(ex.Status, ex.Message));
+            }
+        })
+        .WithName("FetchWakettFills")
+        .Produces<WakettFillUploadResponse>()
+        .ProducesProblem(StatusCodes.Status400BadRequest)
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Fetch Wakett executions and persist them as fills.";
+            op.Description = "Calls the Wakett /trades endpoint for the specified account and date window (5pm NY cut), then upserts each execution into the [wakett].[Fill] table.";
+            op.RequestBody = new OpenApiRequestBody
+            {
+                Required = true,
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(FetchWakettFillsRequest)
+                            }
+                        }
+                    }
+                }
+            };
+            op.Responses[StatusCodes.Status200OK.ToString()] = new OpenApiResponse
+            {
+                Description = "Summary of the Wakett executions that were written to the wakett.Fill table.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(WakettFillUploadResponse)
+                            }
+                        }
+                    }
+                }
+            };
+
+            op.Responses[StatusCodes.Status400BadRequest.ToString()] = new OpenApiResponse
+            {
+                Description = "The request parameters were invalid or the Wakett API returned an error.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/problem+json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(ProblemDetails)
+                            }
+                        }
+                    }
+                }
+            };
+            return op;
+        });
     }
+
+    private static ProblemDetails CreateProblem(string title, string detail)
+        => new()
+        {
+            Title = title,
+            Detail = detail
+        };
 }
 
 public sealed record WakettOrderSubmissionResponse(string Status);

--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -95,7 +95,9 @@ public class WakettTradeRequest
     public string Account { get; set; } = string.Empty;
     public string From { get; set; } = string.Empty;
     public string To { get; set; } = string.Empty;
-    public string Strategy { get; set; } = string.Empty;
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Strategy { get; set; }
 }
 
 public class WakettTradeResponse
@@ -107,16 +109,104 @@ public class WakettTradeResponse
 
 public class WakettTrade
 {
-    public string Portfolio { get; set; } = string.Empty;
-    public string Broker { get; set; } = string.Empty;
-    public string StrategyID { get; set; } = string.Empty;
-    public string Symbol { get; set; } = string.Empty;
-    public string Side { get; set; } = string.Empty;
-    public double Price { get; set; }
-    public double OrderSize { get; set; }
-    public double ExecuteSize { get; set; }
-    public double ExecutePrice { get; set; }
-    public string Event { get; set; } = string.Empty;
+    [JsonPropertyName("portfolioID")]
+    public string? PortfolioId { get; set; }
+
+    [JsonPropertyName("portfolio")]
+    public string? Portfolio { get; set; }
+
+    [JsonPropertyName("alias")]
+    public string? Alias { get; set; }
+
+    [JsonPropertyName("broker")]
+    public string? Broker { get; set; }
+
+    [JsonPropertyName("strategyID")]
+    public string? StrategyId { get; set; }
+
+    [JsonPropertyName("symbolID")]
+    public string? SymbolId { get; set; }
+
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; set; }
+
+    [JsonPropertyName("instrumentID")]
+    public string? InstrumentId { get; set; }
+
+    [JsonPropertyName("ref")]
+    public string? Reference { get; set; }
+
+    [JsonPropertyName("id")]
+    public int? CoreOrderId { get; set; }
+
+    [JsonPropertyName("sub")]
+    public int? SubOrderId { get; set; }
+
+    [JsonPropertyName("label")]
+    public string? Label { get; set; }
+
+    [JsonPropertyName("side")]
+    public string? Side { get; set; }
+
+    [JsonPropertyName("price")]
+    public double? Price { get; set; }
+
+    [JsonPropertyName("orderID")]
+    public string? OrderId { get; set; }
+
+    [JsonPropertyName("orderTS")]
+    public string? OrderTimestamp { get; set; }
+
+    [JsonPropertyName("orderSize")]
+    public double? OrderSize { get; set; }
+
+    [JsonPropertyName("orderChannel")]
+    public string? OrderChannel { get; set; }
+
+    [JsonPropertyName("providerID")]
+    public string? ProviderId { get; set; }
+
+    [JsonPropertyName("providerTS")]
+    public string? ProviderTimestamp { get; set; }
+
+    [JsonPropertyName("executeID")]
+    public string? ExecuteId { get; set; }
+
+    [JsonPropertyName("executeTS")]
+    public string? ExecuteTimestamp { get; set; }
+
+    [JsonPropertyName("entitySize")]
+    public double? EntitySize { get; set; }
+
+    [JsonPropertyName("executeSize")]
+    public double? ExecuteSize { get; set; }
+
+    [JsonPropertyName("executePrice")]
+    public double? ExecutePrice { get; set; }
+
+    [JsonPropertyName("tradets")]
+    public string? TradeTimestamp { get; set; }
+
+    [JsonPropertyName("event")]
+    public string? Event { get; set; }
+
+    [JsonPropertyName("user")]
+    public string? User { get; set; }
+
+    [JsonPropertyName("code")]
+    public string? Code { get; set; }
+
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+
+    [JsonPropertyName("quote")]
+    public double? Quote { get; set; }
+
+    [JsonPropertyName("amount")]
+    public double? Amount { get; set; }
+
+    [JsonPropertyName("rate")]
+    public double? Rate { get; set; }
 }
 
 public class WakettError

--- a/src/TradingDaemon/Models/WakettTradeFetchModels.cs
+++ b/src/TradingDaemon/Models/WakettTradeFetchModels.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace TradingDaemon.Models;
+
+public sealed class FetchWakettFillsRequest
+{
+    public string Account { get; set; } = string.Empty;
+    public string From { get; set; } = string.Empty;
+    public string To { get; set; } = string.Empty;
+    public string? Strategy { get; set; }
+}
+
+public sealed record WakettFillUploadResponse(
+    string Account,
+    string From,
+    string To,
+    string? Strategy,
+    string Status,
+    string Message,
+    int TotalRecords,
+    int InsertedRecords,
+    int UpdatedRecords,
+    DateTime RequestedAtUtc,
+    IReadOnlyList<WakettFillUploadSkippedRecord> SkippedRecords)
+{
+    [JsonIgnore]
+    public int PersistedRecords => InsertedRecords + UpdatedRecords;
+}
+
+public sealed record WakettFillUploadSkippedRecord(
+    string Reason,
+    string? ExecuteId,
+    string? Symbol);

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -35,6 +35,7 @@ builder.Services.AddTransient<ReportRunner>();
 
 builder.Services.AddTransient<WakettApiClient>();
 builder.Services.AddTransient<WakettPriceFetcher>();
+builder.Services.AddTransient<WakettTradeFetcher>();
 
 
 builder.Services.AddEndpointsApiExplorer();

--- a/src/TradingDaemon/Services/WakettTradeFetcher.cs
+++ b/src/TradingDaemon/Services/WakettTradeFetcher.cs
@@ -1,0 +1,616 @@
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Globalization;
+using System.Text;
+using Dapper;
+using Microsoft.Extensions.Logging;
+using TradingDaemon.Data;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public class WakettTradeFetcher
+{
+    private static readonly string[] TimestampFormats =
+    {
+        "yyyy-MM-dd HH:mm:ss.fff zzz",
+        "yyyy-MM-dd HH:mm:ss.fffzzz",
+        "yyyy-MM-dd HH:mm:ss zzz",
+        "yyyy-MM-dd HH:mm:sszzz",
+        "yyyy-MM-dd'T'HH:mm:ss.fff zzz",
+        "yyyy-MM-dd'T'HH:mm:ss.fffzzz",
+        "yyyy-MM-dd'T'HH:mm:ss zzz",
+        "yyyy-MM-dd'T'HH:mm:sszzz"
+    };
+
+    private const string MergeSql = @"
+MERGE [wakett].[Fill] AS target
+USING (VALUES (
+    @ExecuteId,
+    @Account,
+    @RequestedFrom,
+    @RequestedTo,
+    @RequestedStrategy,
+    @PortfolioId,
+    @Portfolio,
+    @Alias,
+    @Broker,
+    @StrategyId,
+    @SymbolId,
+    @Symbol,
+    @InstrumentId,
+    @Reference,
+    @CoreOrderId,
+    @SubOrderId,
+    @Label,
+    @Side,
+    @OrderPrice,
+    @OrderId,
+    @OrderTimestamp,
+    @OrderSize,
+    @OrderChannel,
+    @ProviderId,
+    @ProviderTimestamp,
+    @ExecuteTimestamp,
+    @EntitySize,
+    @ExecuteSize,
+    @ExecutePrice,
+    @TradeTimestamp,
+    @Event,
+    @UserName,
+    @Code,
+    @RecordType,
+    @Quote,
+    @Amount,
+    @Rate,
+    @RecordedAtUtc
+)) AS source (
+    ExecuteId,
+    Account,
+    RequestedFrom,
+    RequestedTo,
+    RequestedStrategy,
+    PortfolioId,
+    Portfolio,
+    Alias,
+    Broker,
+    StrategyId,
+    SymbolId,
+    Symbol,
+    InstrumentId,
+    Reference,
+    CoreOrderId,
+    SubOrderId,
+    Label,
+    Side,
+    OrderPrice,
+    OrderId,
+    OrderTimestamp,
+    OrderSize,
+    OrderChannel,
+    ProviderId,
+    ProviderTimestamp,
+    ExecuteTimestamp,
+    EntitySize,
+    ExecuteSize,
+    ExecutePrice,
+    TradeTimestamp,
+    Event,
+    UserName,
+    Code,
+    RecordType,
+    Quote,
+    Amount,
+    Rate,
+    RecordedAtUtc
+)
+ON target.ExecuteId = source.ExecuteId
+WHEN MATCHED THEN
+    UPDATE SET
+        Account = source.Account,
+        RequestedFrom = source.RequestedFrom,
+        RequestedTo = source.RequestedTo,
+        RequestedStrategy = source.RequestedStrategy,
+        PortfolioId = source.PortfolioId,
+        Portfolio = source.Portfolio,
+        Alias = source.Alias,
+        Broker = source.Broker,
+        StrategyId = source.StrategyId,
+        SymbolId = source.SymbolId,
+        Symbol = source.Symbol,
+        InstrumentId = source.InstrumentId,
+        Reference = source.Reference,
+        CoreOrderId = source.CoreOrderId,
+        SubOrderId = source.SubOrderId,
+        Label = source.Label,
+        Side = source.Side,
+        OrderPrice = source.OrderPrice,
+        OrderId = source.OrderId,
+        OrderTimestamp = source.OrderTimestamp,
+        OrderSize = source.OrderSize,
+        OrderChannel = source.OrderChannel,
+        ProviderId = source.ProviderId,
+        ProviderTimestamp = source.ProviderTimestamp,
+        ExecuteTimestamp = source.ExecuteTimestamp,
+        EntitySize = source.EntitySize,
+        ExecuteSize = source.ExecuteSize,
+        ExecutePrice = source.ExecutePrice,
+        TradeTimestamp = source.TradeTimestamp,
+        Event = source.Event,
+        UserName = source.UserName,
+        Code = source.Code,
+        RecordType = source.RecordType,
+        Quote = source.Quote,
+        Amount = source.Amount,
+        Rate = source.Rate,
+        UpdatedAtUtc = source.RecordedAtUtc
+WHEN NOT MATCHED THEN
+    INSERT (
+        ExecuteId,
+        Account,
+        RequestedFrom,
+        RequestedTo,
+        RequestedStrategy,
+        PortfolioId,
+        Portfolio,
+        Alias,
+        Broker,
+        StrategyId,
+        SymbolId,
+        Symbol,
+        InstrumentId,
+        Reference,
+        CoreOrderId,
+        SubOrderId,
+        Label,
+        Side,
+        OrderPrice,
+        OrderId,
+        OrderTimestamp,
+        OrderSize,
+        OrderChannel,
+        ProviderId,
+        ProviderTimestamp,
+        ExecuteTimestamp,
+        EntitySize,
+        ExecuteSize,
+        ExecutePrice,
+        TradeTimestamp,
+        Event,
+        UserName,
+        Code,
+        RecordType,
+        Quote,
+        Amount,
+        Rate,
+        CreatedAtUtc,
+        UpdatedAtUtc
+    )
+    VALUES (
+        source.ExecuteId,
+        source.Account,
+        source.RequestedFrom,
+        source.RequestedTo,
+        source.RequestedStrategy,
+        source.PortfolioId,
+        source.Portfolio,
+        source.Alias,
+        source.Broker,
+        source.StrategyId,
+        source.SymbolId,
+        source.Symbol,
+        source.InstrumentId,
+        source.Reference,
+        source.CoreOrderId,
+        source.SubOrderId,
+        source.Label,
+        source.Side,
+        source.OrderPrice,
+        source.OrderId,
+        source.OrderTimestamp,
+        source.OrderSize,
+        source.OrderChannel,
+        source.ProviderId,
+        source.ProviderTimestamp,
+        source.ExecuteTimestamp,
+        source.EntitySize,
+        source.ExecuteSize,
+        source.ExecutePrice,
+        source.TradeTimestamp,
+        source.Event,
+        source.UserName,
+        source.Code,
+        source.RecordType,
+        source.Quote,
+        source.Amount,
+        source.Rate,
+        source.RecordedAtUtc,
+        source.RecordedAtUtc
+    )
+OUTPUT $action;";
+
+    private readonly WakettApiClient _client;
+    private readonly DapperContext _context;
+    private readonly ILogger<WakettTradeFetcher> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public WakettTradeFetcher(
+        WakettApiClient client,
+        DapperContext context,
+        ILogger<WakettTradeFetcher> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _client = client;
+        _context = context;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<WakettFillUploadResponse> FetchAndStoreAsync(
+        FetchWakettFillsRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var normalized = NormalizeRequest(request);
+
+        _logger.LogInformation(
+            "Requesting Wakett fills for account {Account} from {From} to {To} (strategy: {Strategy}).",
+            normalized.Account,
+            normalized.FromString,
+            normalized.ToString,
+            normalized.Strategy ?? "<all>");
+
+        var tradeRequest = new WakettTradeRequest
+        {
+            Account = normalized.Account,
+            From = normalized.FromString,
+            To = normalized.ToString,
+            Strategy = normalized.Strategy
+        };
+
+        var response = await _client.GetTradesAsync(tradeRequest);
+        if (response is null)
+        {
+            throw new WakettTradeFetcherException(
+                "NoResponse",
+                "The Wakett trading API returned an empty response when requesting fills.");
+        }
+
+        if (!string.Equals(response.Status, "OK", StringComparison.OrdinalIgnoreCase))
+        {
+            throw new WakettTradeFetcherException(response.Status, response.Message);
+        }
+
+        var executions = response.Data ?? new List<WakettTrade>();
+        var recordedAtUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var skipped = new List<WakettFillUploadSkippedRecord>();
+
+        if (executions.Count == 0)
+        {
+            _logger.LogInformation(
+                "The Wakett trading API returned no executions for account {Account} between {From} and {To}.",
+                normalized.Account,
+                normalized.FromString,
+                normalized.ToString);
+
+            return new WakettFillUploadResponse(
+                normalized.Account,
+                normalized.FromString,
+                normalized.ToString,
+                normalized.Strategy,
+                response.Status,
+                response.Message,
+                0,
+                0,
+                0,
+                recordedAtUtc,
+                skipped);
+        }
+
+        using var connection = _context.CreateConnection();
+        if (connection is DbConnection dbConnection)
+        {
+            await dbConnection.OpenAsync(cancellationToken);
+        }
+        else
+        {
+            connection.Open();
+        }
+
+        using var transaction = connection.BeginTransaction();
+        var inserted = 0;
+        var updated = 0;
+        var seenExecuteIds = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var trade in executions)
+        {
+            var item = CreateUploadItem(trade, normalized, recordedAtUtc, skipped);
+            if (item is null)
+            {
+                continue;
+            }
+
+            if (!seenExecuteIds.Add(item.ExecuteId))
+            {
+                skipped.Add(new WakettFillUploadSkippedRecord(
+                    "Duplicate execute identifier in response.",
+                    item.ExecuteId,
+                    item.Symbol));
+                continue;
+            }
+
+            var command = new CommandDefinition(
+                MergeSql,
+                item,
+                transaction,
+                cancellationToken: cancellationToken);
+
+            var action = await connection.QuerySingleAsync<string>(command);
+            if (string.Equals(action, "INSERT", StringComparison.OrdinalIgnoreCase))
+            {
+                inserted++;
+            }
+            else if (string.Equals(action, "UPDATE", StringComparison.OrdinalIgnoreCase))
+            {
+                updated++;
+            }
+        }
+
+        transaction.Commit();
+
+        _logger.LogInformation(
+            "Persisted {Inserted} new and {Updated} existing Wakett fills for execute window {From}-{To}.",
+            inserted,
+            updated,
+            normalized.FromString,
+            normalized.ToString);
+
+        return new WakettFillUploadResponse(
+            normalized.Account,
+            normalized.FromString,
+            normalized.ToString,
+            normalized.Strategy,
+            response.Status,
+            response.Message,
+            executions.Count,
+            inserted,
+            updated,
+            recordedAtUtc,
+            skipped);
+    }
+
+    private WakettFillUploadItem? CreateUploadItem(
+        WakettTrade trade,
+        NormalizedRequest normalized,
+        DateTime recordedAtUtc,
+        List<WakettFillUploadSkippedRecord> skipped)
+    {
+        var executeId = trade.ExecuteId?.Trim();
+        if (string.IsNullOrWhiteSpace(executeId))
+        {
+            skipped.Add(new WakettFillUploadSkippedRecord(
+                "Execution is missing executeID.",
+                null,
+                trade.Symbol));
+            return null;
+        }
+
+        var symbol = trade.Symbol?.Trim();
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            skipped.Add(new WakettFillUploadSkippedRecord(
+                "Execution is missing symbol.",
+                executeId,
+                null));
+            return null;
+        }
+
+        return new WakettFillUploadItem(
+            executeId,
+            normalized.Account,
+            normalized.FromString,
+            normalized.ToString,
+            normalized.Strategy,
+            TrimOrNull(trade.PortfolioId),
+            TrimOrNull(trade.Portfolio),
+            TrimOrNull(trade.Alias),
+            TrimOrNull(trade.Broker),
+            TrimOrNull(trade.StrategyId),
+            TrimOrNull(trade.SymbolId),
+            symbol.ToUpperInvariant(),
+            TrimOrNull(trade.InstrumentId),
+            TrimOrNull(trade.Reference),
+            trade.CoreOrderId,
+            trade.SubOrderId,
+            TrimOrNull(trade.Label),
+            TrimOrNull(trade.Side)?.ToUpperInvariant(),
+            ToDecimal(trade.Price),
+            TrimOrNull(trade.OrderId),
+            ParseTimestamp(trade.OrderTimestamp, "orderTS", executeId),
+            ToDecimal(trade.OrderSize),
+            TrimOrNull(trade.OrderChannel),
+            TrimOrNull(trade.ProviderId),
+            ParseTimestamp(trade.ProviderTimestamp, "providerTS", executeId),
+            ParseTimestamp(trade.ExecuteTimestamp, "executeTS", executeId),
+            ToDecimal(trade.EntitySize),
+            ToDecimal(trade.ExecuteSize),
+            ToDecimal(trade.ExecutePrice),
+            ParseTimestamp(trade.TradeTimestamp, "tradets", executeId),
+            TrimOrNull(trade.Event),
+            TrimOrNull(trade.User),
+            TrimOrNull(trade.Code),
+            TrimOrNull(trade.Type),
+            ToDecimal(trade.Quote),
+            ToDecimal(trade.Amount),
+            ToDecimal(trade.Rate),
+            recordedAtUtc);
+    }
+
+    private static decimal? ToDecimal(double? value)
+        => value.HasValue ? Convert.ToDecimal(value.Value, CultureInfo.InvariantCulture) : null;
+
+    private DateTimeOffset? ParseTimestamp(string? raw, string fieldName, string executeId)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return null;
+        }
+
+        var trimmed = raw.Trim();
+        var normalized = NormalizeTimestamp(trimmed);
+
+        if (DateTimeOffset.TryParseExact(
+                normalized,
+                TimestampFormats,
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AllowWhiteSpaces,
+                out var timestamp))
+        {
+            return timestamp;
+        }
+
+        _logger.LogWarning(
+            "Unable to parse {Field} timestamp '{Value}' for Wakett executeID {ExecuteId}.",
+            fieldName,
+            raw,
+            executeId);
+        return null;
+    }
+
+    private static string NormalizeTimestamp(string value)
+    {
+        var builder = new StringBuilder(value);
+        var plusIndex = value.LastIndexOf('+');
+        var minusIndex = value.LastIndexOf('-');
+        var index = Math.Max(plusIndex, minusIndex);
+        if (index > 0 && index < value.Length - 1)
+        {
+            var offset = value[index..];
+            if (offset.Length == 5 && (offset[0] == '+' || offset[0] == '-') && char.IsDigit(offset[1]) && char.IsDigit(offset[2]) && char.IsDigit(offset[3]) && char.IsDigit(offset[4]))
+            {
+                builder.Clear();
+                builder.Append(value.AsSpan(0, index + 3));
+                builder.Append(':');
+                builder.Append(value.AsSpan(index + 3));
+                return builder.ToString();
+            }
+        }
+
+        return value;
+    }
+
+    private static string? TrimOrNull(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var trimmed = value.Trim();
+        return trimmed.Length == 0 ? null : trimmed;
+    }
+
+    private static NormalizedRequest NormalizeRequest(FetchWakettFillsRequest request)
+    {
+        var account = TrimOrNull(request.Account)
+            ?? throw new ArgumentException("Account must be provided.", nameof(request));
+
+        var from = ParseDate(request.From, nameof(request.From));
+        var to = ParseDate(request.To, nameof(request.To));
+        if (to < from)
+        {
+            throw new ArgumentException("The 'to' date must be on or after the 'from' date.", nameof(request));
+        }
+
+        var strategy = TrimOrNull(request.Strategy);
+
+        return new NormalizedRequest(
+            account,
+            from,
+            to,
+            from.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+            to.ToString("yyyyMMdd", CultureInfo.InvariantCulture),
+            strategy);
+    }
+
+    private static DateOnly ParseDate(string? value, string propertyName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            throw new ArgumentException($"{propertyName} must be provided in YYYYMMDD format.", propertyName);
+        }
+
+        var trimmed = value.Trim();
+        if (!DateOnly.TryParseExact(trimmed, "yyyyMMdd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+        {
+            throw new ArgumentException($"{propertyName} must be provided in YYYYMMDD format.", propertyName);
+        }
+
+        return date;
+    }
+
+    private readonly record struct NormalizedRequest(
+        string Account,
+        DateOnly From,
+        DateOnly To,
+        string FromString,
+        string ToString,
+        string? Strategy);
+}
+
+public sealed class WakettTradeFetcherException : Exception
+{
+    public WakettTradeFetcherException(string status, string message)
+        : base(string.IsNullOrWhiteSpace(message) ? status : message)
+    {
+        Status = status;
+    }
+
+    public string Status { get; }
+}
+
+internal sealed record WakettFillUploadItem(
+    string ExecuteId,
+    string Account,
+    string RequestedFrom,
+    string RequestedTo,
+    string? RequestedStrategy,
+    string? PortfolioId,
+    string? Portfolio,
+    string? Alias,
+    string? Broker,
+    string? StrategyId,
+    string? SymbolId,
+    string Symbol,
+    string? InstrumentId,
+    string? Reference,
+    int? CoreOrderId,
+    int? SubOrderId,
+    string? Label,
+    string? Side,
+    decimal? OrderPrice,
+    string? OrderId,
+    DateTimeOffset? OrderTimestamp,
+    decimal? OrderSize,
+    string? OrderChannel,
+    string? ProviderId,
+    DateTimeOffset? ProviderTimestamp,
+    DateTimeOffset? ExecuteTimestamp,
+    decimal? EntitySize,
+    decimal? ExecuteSize,
+    decimal? ExecutePrice,
+    DateTimeOffset? TradeTimestamp,
+    string? Event,
+    string? UserName,
+    string? Code,
+    string? RecordType,
+    decimal? Quote,
+    decimal? Amount,
+    decimal? Rate,
+    DateTime RecordedAtUtc);


### PR DESCRIPTION
## Summary
- add a WakettTradeFetcher service that calls the Wakett /trades API and upserts executions into the new wakett.Fill table
- expose /api/wakett/fills/fetch with Swagger documentation and request/response models to drive the ingestion
- add a SQL deployment script that creates the wakett.Fill table and supporting indexes

## Testing
- dotnet build *(fails: `dotnet` not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a325126c83338dc2645df5eb3fca