### PR TITLE
Fix Wakett trades fetch to use GET request

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using System.Linq;
 using System.Globalization;
 using System.Text;
+using System.Collections.Generic;
 using TradingDaemon.Models;
 
 namespace TradingDaemon.Services;
@@ -62,7 +63,24 @@ public class WakettApiClient
     public async Task<WakettTradeResponse?> GetTradesAsync(WakettTradeRequest request)
     {
         var client = _clientFactory.CreateClient("WakettApi");
-        var response = await client.PostAsJsonAsync("trades", request, _jsonOptions);
+
+        var queryParameters = new List<KeyValuePair<string, string>>
+        {
+            new("account", request.Account),
+            new("from", request.From),
+            new("to", request.To)
+        };
+
+        if (!string.IsNullOrWhiteSpace(request.Strategy))
+        {
+            queryParameters.Add(new("strategy", request.Strategy));
+        }
+
+        static string Escape(string value) => Uri.EscapeDataString(value);
+
+        var queryString = string.Join("&", queryParameters.Select(p => $"{Escape(p.Key)}={Escape(p.Value)}"));
+
+        var response = await client.GetAsync($"trades?{queryString}");
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<WakettTradeResponse>(json, _jsonOptions);

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -96,7 +96,7 @@ public class WakettApiClientTests
     }
 
     [Fact]
-    public async Task GetTradesAsync_PostsToTradesEndpoint()
+    public async Task GetTradesAsync_GetsTradesEndpointWithQuery()
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
@@ -111,7 +111,10 @@ public class WakettApiClientTests
         handler.Protected().Verify(
             "SendAsync",
             Times.Once(),
-            ItExpr.Is<HttpRequestMessage>(m => m.Method == HttpMethod.Post && m.RequestUri!.PathAndQuery == "/trades"),
+            ItExpr.Is<HttpRequestMessage>(m =>
+                m.Method == HttpMethod.Get
+                && m.RequestUri!.PathAndQuery == "/trades?account=ACC&from=20240101&to=20240101&strategy=QQB"
+                && m.Content == null),
             ItExpr.IsAny<CancellationToken>());
     }
 }


### PR DESCRIPTION
## Summary
- switch the Wakett trades API call to use a GET with query parameters instead of POST
- include the optional strategy filter when present while building the query string
- update the Wakett API client test to assert the GET request and expected query

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d6a941658883338f7e8b07b7960312