### PR TITLE
Skip weekend hours when fetching Wakett prices

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -441,21 +441,15 @@ public class WakettPriceFetcher
             return Array.Empty<DateTime>();
 
         var nowUtc = DateTime.UtcNow;
-        var endHourUtc = new DateTime(
-            nowUtc.Year,
-            nowUtc.Month,
-            nowUtc.Day,
-            nowUtc.Hour,
-            0,
-            0,
-            DateTimeKind.Utc);
-        var startHourUtc = endHourUtc.AddHours(-23);
-
-        var expectedTimestamps = new List<DateTime>(capacity: 24);
-        for (var i = 0; i < 24; i++)
+        var normalizedNowUtc = NormalizeToHourUtc(nowUtc);
+        var expectedTimestamps = BuildExpectedBarHours(normalizedNowUtc, 24);
+        if (expectedTimestamps.Count == 0)
         {
-            expectedTimestamps.Add(startHourUtc.AddHours(i));
+            return Array.Empty<DateTime>();
         }
+
+        var startHourUtc = expectedTimestamps[0];
+        var endHourUtc = expectedTimestamps[^1];
 
         const string sql = @"SELECT SecurityId, BarTimeUtc FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
 
@@ -506,6 +500,49 @@ public class WakettPriceFetcher
 
         return missing;
     }
+
+    internal static IReadOnlyList<DateTime> BuildExpectedBarHours(DateTime endHourUtc, int count)
+    {
+        if (count <= 0)
+        {
+            return Array.Empty<DateTime>();
+        }
+
+        var normalizedEnd = NormalizeToHourUtc(endHourUtc);
+        var result = new List<DateTime>(count);
+
+        var current = normalizedEnd;
+        while (result.Count < count)
+        {
+            if (!IsWeekend(current))
+            {
+                result.Add(current);
+            }
+
+            current = current.AddHours(-1);
+        }
+
+        result.Reverse();
+        return result;
+    }
+
+    private static DateTime NormalizeToHourUtc(DateTime value)
+    {
+        var utc = value.Kind == DateTimeKind.Utc
+            ? value
+            : DateTime.SpecifyKind(value, DateTimeKind.Utc);
+
+        return new DateTime(
+            utc.Year,
+            utc.Month,
+            utc.Day,
+            utc.Hour,
+            0,
+            0,
+            DateTimeKind.Utc);
+    }
+
+    private static bool IsWeekend(DateTime value) => value.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday;
 
     private async Task<Dictionary<int, CurrencyPair>> LoadSecurityPairsAsync(
         IEnumerable<int> securityIds,

--- a/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -157,5 +158,18 @@ public class WakettPriceFetcherTests
         var result = WakettPriceFetcher.DetermineTimestampUtc("not-a-date", null, fallback);
 
         Assert.Equal(fallback, result);
+    }
+
+    [Fact]
+    public void BuildExpectedBarHours_SkipsWeekendHours()
+    {
+        var endHour = new DateTime(2024, 3, 4, 12, 0, 0, DateTimeKind.Utc); // Monday
+
+        var hours = WakettPriceFetcher.BuildExpectedBarHours(endHour, 24);
+
+        Assert.Equal(24, hours.Count);
+        Assert.Equal(new DateTime(2024, 3, 1, 13, 0, 0, DateTimeKind.Utc), hours[0]);
+        Assert.Equal(endHour, hours[^1]);
+        Assert.DoesNotContain(hours, h => h.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday);
     }
 }


### PR DESCRIPTION
## Summary
- skip weekend timestamps when determining which Wakett price bars to request
- add reusable helpers for normalizing timestamps to hourly boundaries
- cover the weekend filtering with a dedicated unit test

## Testing
- dotnet test TradingDaemon.sln *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68da58f6cdbc83338a430d447759d731