### PR TITLE
Fix Wakett trade fetch request

### DIFF
--- a/src/TradingDaemon/Services/WakettApiClient.cs
+++ b/src/TradingDaemon/Services/WakettApiClient.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Net.Http.Json;
 using System.Linq;
 using System.Globalization;
@@ -16,6 +17,13 @@ public class WakettApiClient
     {
         PropertyNamingPolicy = LowerCaseNamingPolicy.Instance,
         DictionaryKeyPolicy = LowerCaseNamingPolicy.Instance
+    };
+
+    private static readonly JsonSerializerOptions TradeRequestJsonOptions = new()
+    {
+        PropertyNamingPolicy = LowerCaseNamingPolicy.Instance,
+        DictionaryKeyPolicy = LowerCaseNamingPolicy.Instance,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
     };
 
     public WakettApiClient(IHttpClientFactory clientFactory)
@@ -64,27 +72,10 @@ public class WakettApiClient
     {
         var client = _clientFactory.CreateClient("WakettApi");
 
-        var queryParameters = new List<KeyValuePair<string, string>>
-        {
+        var jsonBody = JsonSerializer.Serialize(request, TradeRequestJsonOptions);
+        var content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
 
-            new(nameof(WakettTradeRequest.Account), request.Account),
-            new(nameof(WakettTradeRequest.From), request.From),
-            new(nameof(WakettTradeRequest.To), request.To)
-
-        };
-
-        if (!string.IsNullOrWhiteSpace(request.Strategy))
-        {
-
-            queryParameters.Add(new(nameof(WakettTradeRequest.Strategy), request.Strategy));
-
-        }
-
-        static string Escape(string value) => Uri.EscapeDataString(value);
-
-        var queryString = string.Join("&", queryParameters.Select(p => $"{Escape(p.Key)}={Escape(p.Value)}"));
-
-        var response = await client.GetAsync($"trades?{queryString}");
+        var response = await client.PostAsync("trades", content);
         response.EnsureSuccessStatusCode();
         var json = await response.Content.ReadAsStringAsync();
         return JsonSerializer.Deserialize<WakettTradeResponse>(json, _jsonOptions);

--- a/src/TradingDaemon/Services/WakettTradeFetcher.cs
+++ b/src/TradingDaemon/Services/WakettTradeFetcher.cs
@@ -263,14 +263,14 @@ OUTPUT $action;";
             "Requesting Wakett fills for account {Account} from {From} to {To} (strategy: {Strategy}).",
             normalized.Account,
             normalized.FromString,
-            normalized.ToString,
+            normalized.ToStringValue,
             normalized.Strategy ?? "<all>");
 
         var tradeRequest = new WakettTradeRequest
         {
             Account = normalized.Account,
             From = normalized.FromString,
-            To = normalized.ToAString,
+            To = normalized.ToStringValue,
             Strategy = normalized.Strategy
         };
 
@@ -297,12 +297,12 @@ OUTPUT $action;";
                 "The Wakett trading API returned no executions for account {Account} between {From} and {To}.",
                 normalized.Account,
                 normalized.FromString,
-                normalized.ToString);
+                normalized.ToStringValue);
 
             return new WakettFillUploadResponse(
                 normalized.Account,
                 normalized.FromString,
-                normalized.ToAString,
+                normalized.ToStringValue,
                 normalized.Strategy,
                 response.Status,
                 response.Message,
@@ -369,12 +369,12 @@ OUTPUT $action;";
             inserted,
             updated,
             normalized.FromString,
-            normalized.ToAString);
+            normalized.ToStringValue);
 
         return new WakettFillUploadResponse(
             normalized.Account,
             normalized.FromString,
-            normalized.ToAString,
+            normalized.ToStringValue,
             normalized.Strategy,
             response.Status,
             response.Message,
@@ -415,7 +415,7 @@ OUTPUT $action;";
             executeId,
             normalized.Account,
             normalized.FromString,
-            normalized.ToAString,
+            normalized.ToStringValue,
             normalized.Strategy,
             TrimOrNull(trade.PortfolioId),
             TrimOrNull(trade.Portfolio),
@@ -560,7 +560,7 @@ OUTPUT $action;";
         DateOnly From,
         DateOnly To,
         string FromString,
-        string ToAString,
+        string ToStringValue,
         string? Strategy);
 }
 

--- a/tests/TradingDaemon.Tests/WakettApiClientTests.cs
+++ b/tests/TradingDaemon.Tests/WakettApiClientTests.cs
@@ -96,10 +96,12 @@ public class WakettApiClientTests
     }
 
     [Fact]
-    public async Task GetTradesAsync_GetsTradesEndpointWithQuery()
+    public async Task GetTradesAsync_PostsTradesEndpointWithBody()
     {
+        HttpRequestMessage? captured = null;
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((m, _) => captured = m)
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("{\"status\":\"OK\",\"message\":\"\",\"data\":[]}") });
         var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://test") };
         var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
@@ -112,11 +114,19 @@ public class WakettApiClientTests
             "SendAsync",
             Times.Once(),
             ItExpr.Is<HttpRequestMessage>(m =>
-                m.Method == HttpMethod.Get
-
-                && m.RequestUri!.PathAndQuery == "/trades?Account=ACC&From=20240101&To=20240101&Strategy=QQB"
-
-                && m.Content == null),
+                m.Method == HttpMethod.Post
+                && m.RequestUri!.PathAndQuery == "/trades"
+                && m.Content != null),
             ItExpr.IsAny<CancellationToken>());
+
+        var body = await captured!.Content!.ReadAsStringAsync();
+        Assert.Contains("\"account\":\"ACC\"", body);
+        Assert.Contains("\"from\":\"20240101\"", body);
+        Assert.Contains("\"to\":\"20240101\"", body);
+        Assert.Contains("\"strategy\":\"QQB\"", body);
+        Assert.DoesNotContain("\"Account\"", body);
+        Assert.DoesNotContain("\"From\"", body);
+        Assert.DoesNotContain("\"To\"", body);
+        Assert.DoesNotContain("\"Strategy\"", body);
     }
 }


### PR DESCRIPTION
## Summary
- send Wakett trade fetch requests as POSTs with the JSON payload expected by the Wakett history API
- normalize logging/output to use the formatted to-date string value consistently
- extend the Wakett API client test to cover the new POST request body

## Testing
- Not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68da8b82b67483338a6bdae74474655f