### PR TITLE
Add trading limit enforcement before order submission

### DIFF
--- a/scripts/sql/CreateWakettTradingLimitTables.sql
+++ b/scripts/sql/CreateWakettTradingLimitTables.sql
@@ -1,0 +1,63 @@
+/*
+    Creates the tables used to store Wakett trading limits and limit breach reports.
+    Execute inside the Wakett database context.
+*/
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.schemas
+    WHERE name = N'wakett'
+)
+BEGIN
+    EXEC ('CREATE SCHEMA [wakett] AUTHORIZATION dbo;');
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.schemas s
+    INNER JOIN sys.tables t ON s.schema_id = t.schema_id
+    WHERE s.name = N'wakett'
+      AND t.name = N'TradingLimit'
+)
+BEGIN
+    CREATE TABLE [wakett].[TradingLimit]
+    (
+        TradingLimitId           INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        ModelId                  INT              NOT NULL,
+        SingleTradeGrossLimit    DECIMAL(19,9)    NULL,
+        PortfolioGrossLimit      DECIMAL(19,9)    NULL,
+        PortfolioNetLimit        DECIMAL(19,9)    NULL,
+        SingleTradeTurnoverLimit DECIMAL(19,9)    NULL,
+        TotalTurnoverLimit       DECIMAL(19,9)    NULL,
+        CreatedAtUtc             DATETIME2(7)     NOT NULL DEFAULT SYSUTCDATETIME(),
+        UpdatedAtUtc             DATETIME2(7)     NOT NULL DEFAULT SYSUTCDATETIME()
+    );
+
+    CREATE INDEX IX_TradingLimit_ModelId
+        ON [wakett].[TradingLimit] (ModelId, TradingLimitId DESC);
+END;
+
+IF NOT EXISTS (
+    SELECT 1
+    FROM sys.schemas s
+    INNER JOIN sys.tables t ON s.schema_id = t.schema_id
+    WHERE s.name = N'wakett'
+      AND t.name = N'TradingLimitBreachReport'
+)
+BEGIN
+    CREATE TABLE [wakett].[TradingLimitBreachReport]
+    (
+        TradingLimitBreachReportId BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        ModelId                    INT                  NOT NULL,
+        OccurredAtUtc              DATETIME2(7)         NOT NULL DEFAULT SYSUTCDATETIME(),
+        LimitType                  NVARCHAR(64)         NOT NULL,
+        LimitValue                 DECIMAL(19,9)        NULL,
+        ObservedValue              DECIMAL(19,9)        NULL,
+        Details                    NVARCHAR(1024)       NULL,
+        OrdersJson                 NVARCHAR(MAX)        NULL,
+        Aum                        DECIMAL(19,4)        NULL
+    );
+
+    CREATE INDEX IX_TradingLimitBreachReport_ModelId
+        ON [wakett].[TradingLimitBreachReport] (ModelId, OccurredAtUtc DESC);
+END;

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -113,12 +113,40 @@ public class OrderSender
             return;
         }
 
+        var aum = aumOverride ?? ResolveAum();
+
+        var tradingLimits = await LoadTradingLimitsAsync(connection, cancellationToken);
+        if (tradingLimits is not null)
+        {
+            var breaches = EvaluateTradingLimitBreaches(tradingLimits, builtOrders, aum);
+            if (breaches.Count > 0)
+            {
+                foreach (var breach in breaches)
+                {
+                    _logger.LogWarning(
+                        "Trading limit {LimitType} breached: observed {ObservedValue} vs limit {LimitValue}. {Details}",
+                        breach.LimitType,
+                        breach.ObservedValue,
+                        breach.LimitValue,
+                        breach.Message);
+                }
+
+                await LogTradingLimitBreachesAsync(
+                    connection,
+                    breaches,
+                    builtOrders,
+                    aum,
+                    cancellationToken);
+                return;
+            }
+        }
+
         var orders = builtOrders.Select(order => order.Order).ToList();
 
         var request = new WakettOrderRequest
         {
             ts = FormatTimestamp(orderTimestampUtc),
-            aum = aumOverride ?? ResolveAum(),
+            aum = aum,
             orders = orders
         };
 
@@ -307,6 +335,85 @@ VALUES
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to persist Wakett order response results.");
+        }
+    }
+
+    protected virtual async Task LogTradingLimitBreachesAsync(
+        IDbConnection connection,
+        IReadOnlyList<TradingLimitBreachResult> breaches,
+        IReadOnlyList<(int SecurityId, WakettOrderItem Order)> orders,
+        double? aum,
+        CancellationToken cancellationToken)
+    {
+        if (breaches.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var orderSnapshots = orders
+                .Select(order => new TradingLimitOrderSnapshot(
+                    order.SecurityId,
+                    order.Order.symbol ?? string.Empty,
+                    order.Order.side ?? string.Empty,
+                    order.Order.size?.type ?? string.Empty,
+                    order.Order.size?.value ?? 0d))
+                .ToList();
+
+            var ordersJson = orderSnapshots.Count > 0
+                ? JsonSerializer.Serialize(orderSnapshots, OrderTradeJsonOptions)
+                : null;
+
+            var aumValue = aum.HasValue ? (decimal?)aum.Value : null;
+
+            const string insertSql = @"INSERT INTO [wakett].[TradingLimitBreachReport]
+(
+    ModelId,
+    LimitType,
+    LimitValue,
+    ObservedValue,
+    Details,
+    OrdersJson,
+    Aum
+)
+VALUES
+(
+    @ModelId,
+    @LimitType,
+    @LimitValue,
+    @ObservedValue,
+    @Details,
+    @OrdersJson,
+    @Aum
+);";
+
+            foreach (var breach in breaches)
+            {
+                var definition = new CommandDefinition(
+                    insertSql,
+                    new
+                    {
+                        ModelId = TargetModelId,
+                        breach.LimitType,
+                        breach.LimitValue,
+                        breach.ObservedValue,
+                        Details = breach.Message,
+                        OrdersJson = ordersJson,
+                        Aum = aumValue
+                    },
+                    cancellationToken: cancellationToken);
+
+                await connection.ExecuteAsync(definition);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to log trading limit breach report.");
         }
     }
 
@@ -685,6 +792,31 @@ ORDER BY ModelId";
         return row;
     }
 
+    protected virtual async Task<TradingLimitRow?> LoadTradingLimitsAsync(
+        IDbConnection connection,
+        CancellationToken cancellationToken)
+    {
+        const string sql = @"SELECT TOP (1)
+    TradingLimitId,
+    ModelId,
+    SingleTradeGrossLimit,
+    PortfolioGrossLimit,
+    PortfolioNetLimit,
+    SingleTradeTurnoverLimit,
+    TotalTurnoverLimit
+FROM [wakett].[TradingLimit]
+WHERE ModelId = @ModelId
+ORDER BY TradingLimitId DESC;";
+
+        var definition = new CommandDefinition(
+            sql,
+            new { ModelId = TargetModelId },
+            cancellationToken: cancellationToken);
+
+        var row = await connection.QueryFirstOrDefaultAsync<TradingLimitRow>(definition);
+        return row;
+    }
+
     private bool IsBarRecentEnough(DateTime barTimeUtc, DateTime utcNow)
     {
         var zone = CentralEuropeZone;
@@ -900,6 +1032,180 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         return result;
     }
 
+    private static IReadOnlyList<TradingLimitBreachResult> EvaluateTradingLimitBreaches(
+        TradingLimitRow limits,
+        IReadOnlyList<(int SecurityId, WakettOrderItem Order)> builtOrders,
+        double? aum)
+    {
+        if (builtOrders.Count == 0)
+        {
+            return Array.Empty<TradingLimitBreachResult>();
+        }
+
+        var metrics = new List<TradingOrderMetric>();
+
+        foreach (var entry in builtOrders)
+        {
+            if (entry.Order.size is null)
+            {
+                continue;
+            }
+
+            var symbol = entry.Order.symbol?.Trim() ?? string.Empty;
+            var side = entry.Order.side?.Trim() ?? string.Empty;
+            var signedSize = (decimal)entry.Order.size.value;
+
+            if (string.Equals(side, "SELL", StringComparison.OrdinalIgnoreCase))
+            {
+                signedSize = -signedSize;
+            }
+
+            metrics.Add(new TradingOrderMetric(entry.SecurityId, symbol, side, signedSize));
+        }
+
+        if (metrics.Count == 0)
+        {
+            return Array.Empty<TradingLimitBreachResult>();
+        }
+
+        var breaches = new List<TradingLimitBreachResult>();
+        var aumDecimal = aum.HasValue ? (decimal?)aum.Value : null;
+
+        decimal ComputeTurnover(decimal size) => aumDecimal.HasValue ? size * aumDecimal.Value : size;
+
+        TradingOrderMetric FindLargest(Func<TradingOrderMetric, decimal> selector)
+        {
+            var candidate = metrics[0];
+            var candidateValue = selector(candidate);
+
+            for (var i = 1; i < metrics.Count; i++)
+            {
+                var metric = metrics[i];
+                var value = selector(metric);
+                if (value > candidateValue)
+                {
+                    candidate = metric;
+                    candidateValue = value;
+                }
+            }
+
+            return candidate;
+        }
+
+        if (limits.SingleTradeGrossLimit is decimal singleGrossLimit)
+        {
+            var worst = FindLargest(metric => metric.AbsoluteSize);
+            var observed = worst.AbsoluteSize;
+            if (observed > singleGrossLimit)
+            {
+                var message = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Order for {0} exceeds single trade gross limit ({1} > {2}).",
+                    worst.Symbol,
+                    observed,
+                    singleGrossLimit);
+                breaches.Add(new TradingLimitBreachResult(
+                    "SingleTradeGrossLimit",
+                    singleGrossLimit,
+                    observed,
+                    message));
+            }
+        }
+
+        if (limits.PortfolioGrossLimit is decimal portfolioGrossLimit)
+        {
+            var observed = metrics.Sum(metric => metric.AbsoluteSize);
+            if (observed > portfolioGrossLimit)
+            {
+                var message = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Total gross exposure {0} exceeds portfolio gross limit {1}.",
+                    observed,
+                    portfolioGrossLimit);
+                breaches.Add(new TradingLimitBreachResult(
+                    "PortfolioGrossLimit",
+                    portfolioGrossLimit,
+                    observed,
+                    message));
+            }
+        }
+
+        if (limits.PortfolioNetLimit is decimal portfolioNetLimit)
+        {
+            var observed = Math.Abs(metrics.Sum(metric => metric.SignedSize));
+            if (observed > portfolioNetLimit)
+            {
+                var message = string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Net exposure {0} exceeds portfolio net limit {1}.",
+                    observed,
+                    portfolioNetLimit);
+                breaches.Add(new TradingLimitBreachResult(
+                    "PortfolioNetLimit",
+                    portfolioNetLimit,
+                    observed,
+                    message));
+            }
+        }
+
+        if (limits.SingleTradeTurnoverLimit is decimal singleTradeTurnoverLimit)
+        {
+            var worstTurnover = FindLargest(metric => ComputeTurnover(metric.AbsoluteSize));
+            var observed = ComputeTurnover(worstTurnover.AbsoluteSize);
+            if (observed > singleTradeTurnoverLimit)
+            {
+                var message = aumDecimal.HasValue
+                    ? string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Order for {0} exceeds single trade turnover limit ({1} > {2}) using AUM {3}.",
+                        worstTurnover.Symbol,
+                        observed,
+                        singleTradeTurnoverLimit,
+                        aumDecimal.Value)
+                    : string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Order for {0} exceeds single trade turnover limit ({1} > {2}).",
+                        worstTurnover.Symbol,
+                        observed,
+                        singleTradeTurnoverLimit);
+
+                breaches.Add(new TradingLimitBreachResult(
+                    "SingleTradeTurnoverLimit",
+                    singleTradeTurnoverLimit,
+                    observed,
+                    message));
+            }
+        }
+
+        if (limits.TotalTurnoverLimit is decimal totalTurnoverLimit)
+        {
+            var observed = metrics.Sum(metric => ComputeTurnover(metric.AbsoluteSize));
+            if (observed > totalTurnoverLimit)
+            {
+                var message = aumDecimal.HasValue
+                    ? string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Total turnover {0} exceeds limit {1} using AUM {2}.",
+                        observed,
+                        totalTurnoverLimit,
+                        aumDecimal.Value)
+                    : string.Format(
+                        CultureInfo.InvariantCulture,
+                        "Total turnover {0} exceeds limit {1}.",
+                        observed,
+                        totalTurnoverLimit);
+
+                breaches.Add(new TradingLimitBreachResult(
+                    "TotalTurnoverLimit",
+                    totalTurnoverLimit,
+                    observed,
+                    message));
+            }
+        }
+
+        return breaches;
+    }
+
     private static string? ResolveOrderCode(
         string? responseCode,
         string? responseSymbol,
@@ -1017,6 +1323,32 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
     private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
+
+    private sealed record TradingLimitOrderSnapshot(int SecurityId, string Symbol, string Side, string SizeType, double SizeValue);
+
+    private readonly record struct TradingOrderMetric(int SecurityId, string Symbol, string Side, decimal SignedSize)
+    {
+        public decimal AbsoluteSize => Math.Abs(SignedSize);
+    }
+
+    protected sealed record TradingLimitBreachResult(string LimitType, decimal LimitValue, decimal ObservedValue, string Message);
+
+    protected sealed record TradingLimitRow
+    {
+        public int TradingLimitId { get; init; }
+
+        public int ModelId { get; init; }
+
+        public decimal? SingleTradeGrossLimit { get; init; }
+
+        public decimal? PortfolioGrossLimit { get; init; }
+
+        public decimal? PortfolioNetLimit { get; init; }
+
+        public decimal? SingleTradeTurnoverLimit { get; init; }
+
+        public decimal? TotalTurnoverLimit { get; init; }
+    }
 
     protected sealed record TheoreticalWeightRow
     {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.Logging;
 using Moq;
 using Moq.Protected;
 using TradingDaemon.Data;
+using TradingDaemon.Models;
 using TradingDaemon.Services;
 using Xunit;
 
@@ -103,6 +104,66 @@ public class OrderSenderTests
         Assert.Equal("SELL", second.GetProperty("side").GetString());
         Assert.Equal(OrderSender.BuildOrderCode(136, expectedOrderTimestampUtc), second.GetProperty("code").GetString());
         Assert.Equal(0.05, second.GetProperty("size").GetProperty("value").GetDouble(), 6);
+    }
+
+    [Fact]
+    public async Task SendOrdersAsync_DoesNotSendWhenTradingLimitBreached()
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m },
+            new() { SecurityId = 61, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = -0.05m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Aum"] = "2500000"
+        });
+
+        var symbolMap = new Dictionary<int, string>
+        {
+            [58] = "EURUSD",
+            [61] = "EURCHF",
+            [136] = "USDCHF"
+        };
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var tradingLimit = TestOrderSender.CreateTradingLimit(singleTradeGross: 0.05m);
+
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 },
+            tradingLimit);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.Single(sender.LoggedBreaches);
+        var breach = sender.LoggedBreaches[0];
+        Assert.Equal("SingleTradeGrossLimit", breach.LimitType);
     }
 
     [Fact]
@@ -579,6 +640,8 @@ public class OrderSenderTests
         private readonly IReadOnlyList<TheoreticalWeightRow> _weights;
         private readonly IReadOnlyDictionary<int, string> _symbolMap;
         private readonly ModelScheduleRow? _schedule;
+        private readonly TradingLimitRow? _tradingLimit;
+        private readonly List<TradingLimitBreachResult> _loggedBreaches = new();
 
         public TestOrderSender(
             WakettApiClient client,
@@ -588,13 +651,33 @@ public class OrderSenderTests
             TimeProvider timeProvider,
             IReadOnlyList<TheoreticalWeightRow> weights,
             IReadOnlyDictionary<int, string> symbolMap,
-            ModelScheduleRow? schedule)
+            ModelScheduleRow? schedule,
+            TradingLimitRow? tradingLimit = null)
             : base(client, context, logger, configuration, timeProvider)
         {
             _weights = weights;
             _symbolMap = symbolMap;
             _schedule = schedule;
+            _tradingLimit = tradingLimit;
         }
+
+        public IReadOnlyList<TradingLimitBreachResult> LoggedBreaches => _loggedBreaches;
+
+        public static TradingLimitRow CreateTradingLimit(
+            decimal? singleTradeGross = null,
+            decimal? portfolioGross = null,
+            decimal? portfolioNet = null,
+            decimal? singleTradeTurnover = null,
+            decimal? totalTurnover = null)
+            => new()
+            {
+                ModelId = 1,
+                SingleTradeGrossLimit = singleTradeGross,
+                PortfolioGrossLimit = portfolioGross,
+                PortfolioNetLimit = portfolioNet,
+                SingleTradeTurnoverLimit = singleTradeTurnover,
+                TotalTurnoverLimit = totalTurnover
+            };
 
         protected override Task<IReadOnlyList<TheoreticalWeightRow>> LoadLatestWeightsAsync(
             IDbConnection connection,
@@ -610,6 +693,22 @@ public class OrderSenderTests
             IDbConnection connection,
             CancellationToken cancellationToken)
             => Task.FromResult(_schedule);
+
+        protected override Task<TradingLimitRow?> LoadTradingLimitsAsync(
+            IDbConnection connection,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_tradingLimit);
+
+        protected override Task LogTradingLimitBreachesAsync(
+            IDbConnection connection,
+            IReadOnlyList<TradingLimitBreachResult> breaches,
+            IReadOnlyList<(int SecurityId, WakettOrderItem Order)> orders,
+            double? aum,
+            CancellationToken cancellationToken)
+        {
+            _loggedBreaches.AddRange(breaches);
+            return Task.CompletedTask;
+        }
     }
 
     private sealed class TestTimeProvider : TimeProvider


### PR DESCRIPTION
## Summary
- add SQL DDL to create Wakett trading limit and breach report tables
- enforce configured trading limits before sending Wakett orders and persist breach reports
- extend unit tests to cover limit breaches and configurable limits in the order sender

## Testing
- dotnet test *(fails: `dotnet` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da76811e088333b85df809378d4a56