### PR TITLE
Add automated Wakett session workflow

### DIFF
--- a/src/TradingDaemon/Models/WakettAutomationOptions.cs
+++ b/src/TradingDaemon/Models/WakettAutomationOptions.cs
@@ -1,0 +1,13 @@
+namespace TradingDaemon.Models;
+
+public sealed class WakettAutomationOptions
+{
+    public int WorkflowMinuteOffset { get; set; } = 2;
+
+    public int FillIntervalMinutes { get; set; } = 10;
+
+    public string FillAccount { get; set; } = string.Empty;
+
+    public string? FillStrategy { get; set; }
+}
+

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -3,6 +3,7 @@ using TradingDaemon.Controllers;
 using TradingDaemon.Data;
 using TradingDaemon.Logging;
 using TradingDaemon.Services;
+using TradingDaemon.Models;
 using TradingDaemon.Utils;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -48,6 +49,9 @@ builder.Services.AddTransient<ReportRunner>();
 builder.Services.AddTransient<WakettApiClient>();
 builder.Services.AddTransient<WakettPriceFetcher>();
 builder.Services.AddTransient<WakettTradeFetcher>();
+
+builder.Services.Configure<WakettAutomationOptions>(builder.Configuration.GetSection("Automation:Wakett"));
+builder.Services.AddHostedService<WakettAutomationService>();
 
 
 builder.Services.AddEndpointsApiExplorer();

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -3,6 +3,7 @@ using System.Data;
 using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Dapper;
@@ -406,6 +407,8 @@ VALUES
 
                 await connection.ExecuteAsync(definition);
             }
+
+            ShowBreachWarning(breaches);
         }
         catch (OperationCanceledException)
         {
@@ -414,6 +417,43 @@ VALUES
         catch (Exception ex)
         {
             _logger.LogError(ex, "Failed to log trading limit breach report.");
+        }
+    }
+
+    private void ShowBreachWarning(IReadOnlyList<TradingLimitBreachResult> breaches)
+    {
+        if (!OperatingSystem.IsWindows() || breaches.Count == 0)
+        {
+            return;
+        }
+
+        try
+        {
+            var builder = new StringBuilder();
+            builder.AppendLine("Trading limit breach detected. Orders were not sent.");
+
+            foreach (var breach in breaches)
+            {
+                builder.Append("• ");
+                builder.Append(breach.LimitType);
+                builder.Append(": observed ");
+                builder.Append(breach.ObservedValue.ToString("0.######", CultureInfo.InvariantCulture));
+                builder.Append(" vs limit ");
+                builder.AppendLine(breach.LimitValue.ToString("0.######", CultureInfo.InvariantCulture));
+                if (!string.IsNullOrWhiteSpace(breach.Message))
+                {
+                    builder.AppendLine(breach.Message);
+                }
+            }
+
+            var message = builder.ToString();
+            var type = Type.GetType("System.Windows.Forms.MessageBox, System.Windows.Forms");
+            type?.GetMethod("Show", new[] { typeof(string), typeof(string) })?
+                .Invoke(null, new object[] { message, "Trading Limit Breach" });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to display trading limit breach warning.");
         }
     }
 

--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -1,0 +1,344 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public sealed class WakettAutomationService : BackgroundService
+{
+    private static readonly TimeSpan SessionStart = TimeSpan.FromHours(9);
+    private static readonly TimeSpan SessionEnd = new(15, 59, 0);
+
+    private readonly WakettPriceFetcher _priceFetcher;
+    private readonly WeightCalculator _weightCalculator;
+    private readonly OrderSender _orderSender;
+    private readonly WakettTradeFetcher _tradeFetcher;
+    private readonly IHostApplicationLifetime _applicationLifetime;
+    private readonly ILogger<WakettAutomationService> _logger;
+    private readonly WakettAutomationOptions _options;
+    private readonly TimeProvider _timeProvider;
+
+    public WakettAutomationService(
+        WakettPriceFetcher priceFetcher,
+        WeightCalculator weightCalculator,
+        OrderSender orderSender,
+        WakettTradeFetcher tradeFetcher,
+        IHostApplicationLifetime applicationLifetime,
+        IOptions<WakettAutomationOptions> options,
+        ILogger<WakettAutomationService> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _priceFetcher = priceFetcher;
+        _weightCalculator = weightCalculator;
+        _orderSender = orderSender;
+        _tradeFetcher = tradeFetcher;
+        _applicationLifetime = applicationLifetime;
+        _logger = logger;
+        _options = options?.Value ?? new WakettAutomationOptions();
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Starting Wakett automation service.");
+
+        try
+        {
+            await RunTradingWorkflowAsync(stoppingToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Initial Wakett workflow run failed.");
+        }
+
+        var sessionActive = false;
+        var nextWorkflowUtc = GetNextWorkflowRunUtc(_timeProvider.GetUtcNow().UtcDateTime);
+        var nextFillUtc = GetNextFillCheckUtc(_timeProvider.GetUtcNow().UtcDateTime);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            var nowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+            var withinSession = IsWithinSession(nowUtc);
+
+            if (withinSession)
+            {
+                if (!sessionActive)
+                {
+                    sessionActive = true;
+                    await RunFillCheckAsync(stoppingToken);
+                    nextWorkflowUtc = GetNextWorkflowRunUtc(nowUtc);
+                    nextFillUtc = GetNextFillCheckUtc(_timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1));
+                }
+
+                if (nowUtc >= nextWorkflowUtc)
+                {
+                    try
+                    {
+                        await RunTradingWorkflowAsync(stoppingToken);
+                    }
+                    catch (Exception ex) when (ex is not OperationCanceledException)
+                    {
+                        _logger.LogError(ex, "Scheduled Wakett workflow run failed.");
+                    }
+
+                    nextWorkflowUtc = GetNextWorkflowRunUtc(_timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1));
+                }
+
+                if (nowUtc >= nextFillUtc)
+                {
+                    await RunFillCheckAsync(stoppingToken);
+                    nextFillUtc = GetNextFillCheckUtc(_timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1));
+                }
+
+                var nextEvent = nextWorkflowUtc < nextFillUtc ? nextWorkflowUtc : nextFillUtc;
+                await DelayUntilAsync(nextEvent, stoppingToken);
+            }
+            else
+            {
+                if (sessionActive)
+                {
+                    await RunFillCheckAsync(stoppingToken);
+                    _logger.LogInformation("US session completed. Shutting down application.");
+                    _applicationLifetime.StopApplication();
+                    return;
+                }
+
+                var nextSessionStart = GetNextSessionStartUtc(nowUtc);
+                nextWorkflowUtc = GetFirstWorkflowRunUtc(nextSessionStart);
+                nextFillUtc = GetFirstFillCheckUtc(nextSessionStart);
+                await DelayUntilAsync(nextSessionStart, stoppingToken);
+            }
+        }
+    }
+
+    private async Task RunTradingWorkflowAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Executing automated Wakett trading workflow.");
+
+        try
+        {
+            await _priceFetcher.FetchAndStoreAsync(stoppingToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Failed to fetch Wakett prices.");
+        }
+
+        bool pricesComplete;
+        try
+        {
+            pricesComplete = await _priceFetcher.AreRecentPricesCompleteAsync(stoppingToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Failed to verify Wakett prices completeness.");
+            return;
+        }
+
+        if (!pricesComplete)
+        {
+            _logger.LogWarning("Skipping weight calculation and order submission because prices are incomplete.");
+            return;
+        }
+
+        try
+        {
+            await _weightCalculator.CalculateAndStoreAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Weight calculation failed; skipping order submission.");
+            return;
+        }
+
+        try
+        {
+            await _orderSender.SendOrdersAsync(cancellationToken: stoppingToken);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Wakett order submission failed.");
+        }
+    }
+
+    private async Task RunFillCheckAsync(CancellationToken stoppingToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.FillAccount))
+        {
+            _logger.LogDebug("Skipping Wakett fill check because no account is configured.");
+            return;
+        }
+
+        var localNow = TimeZoneInfo.ConvertTimeFromUtc(_timeProvider.GetUtcNow().UtcDateTime, NewYorkTimeZone);
+        var tradingDate = DateOnly.FromDateTime(localNow);
+        var dateString = tradingDate.ToString("yyyyMMdd", CultureInfo.InvariantCulture);
+
+        var request = new FetchWakettFillsRequest
+        {
+            Account = _options.FillAccount,
+            From = dateString,
+            To = dateString,
+            Strategy = _options.FillStrategy
+        };
+
+        try
+        {
+            await _tradeFetcher.FetchAndStoreAsync(request, stoppingToken);
+        }
+        catch (WakettTradeFetcherException ex)
+        {
+            _logger.LogError(ex, "Wakett fill fetch returned an error: {Message}", ex.Message);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Unexpected failure while fetching Wakett fills.");
+        }
+    }
+
+    private async Task DelayUntilAsync(DateTime targetUtc, CancellationToken stoppingToken)
+    {
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var delay = targetUtc - now;
+        if (delay <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(delay, stoppingToken);
+        }
+        catch (TaskCanceledException)
+        {
+        }
+    }
+
+    private DateTime GetNextWorkflowRunUtc(DateTime referenceUtc)
+    {
+        if (!IsWithinSession(referenceUtc))
+        {
+            var nextSession = GetNextSessionStartUtc(referenceUtc);
+            return GetFirstWorkflowRunUtc(nextSession);
+        }
+
+        var local = TimeZoneInfo.ConvertTimeFromUtc(referenceUtc, NewYorkTimeZone);
+        var endLocal = GetSessionEndLocal(local);
+        var candidate = new DateTime(local.Year, local.Month, local.Day, local.Hour, WorkflowMinuteOffset, 0);
+        if (candidate < local)
+        {
+            candidate = candidate.AddHours(1);
+        }
+
+        if (candidate > endLocal)
+        {
+            var nextSession = GetNextSessionStartUtc(referenceUtc);
+            return GetFirstWorkflowRunUtc(nextSession);
+        }
+
+        return TimeZoneInfo.ConvertTimeToUtc(candidate, NewYorkTimeZone);
+    }
+
+    private DateTime GetNextFillCheckUtc(DateTime referenceUtc)
+    {
+        if (!IsWithinSession(referenceUtc))
+        {
+            var nextSession = GetNextSessionStartUtc(referenceUtc);
+            return GetFirstFillCheckUtc(nextSession);
+        }
+
+        var interval = Math.Max(1, _options.FillIntervalMinutes);
+        var local = TimeZoneInfo.ConvertTimeFromUtc(referenceUtc, NewYorkTimeZone);
+        var endLocal = GetSessionEndLocal(local);
+        var minute = local.Minute;
+        var remainder = minute % interval;
+        var delta = remainder == 0 && local.Second == 0 ? interval : interval - remainder;
+        var candidate = new DateTime(local.Year, local.Month, local.Day, local.Hour, minute, 0).AddMinutes(delta);
+
+        if (candidate > endLocal)
+        {
+            var nextSession = GetNextSessionStartUtc(referenceUtc);
+            return GetFirstFillCheckUtc(nextSession);
+        }
+
+        return TimeZoneInfo.ConvertTimeToUtc(candidate, NewYorkTimeZone);
+    }
+
+    private DateTime GetFirstWorkflowRunUtc(DateTime sessionStartUtc)
+    {
+        var localStart = TimeZoneInfo.ConvertTimeFromUtc(sessionStartUtc, NewYorkTimeZone);
+        var firstLocal = localStart.AddMinutes(WorkflowMinuteOffset);
+        var endLocal = GetSessionEndLocal(localStart);
+        if (firstLocal > endLocal)
+        {
+            firstLocal = localStart;
+        }
+
+        return TimeZoneInfo.ConvertTimeToUtc(firstLocal, NewYorkTimeZone);
+    }
+
+    private DateTime GetFirstFillCheckUtc(DateTime sessionStartUtc)
+    {
+        return sessionStartUtc;
+    }
+
+    private static DateTime GetSessionEndLocal(DateTime local)
+    {
+        var end = new DateTime(local.Year, local.Month, local.Day, SessionEnd.Hours, SessionEnd.Minutes, SessionEnd.Seconds);
+        if (SessionEnd < SessionStart)
+        {
+            end = end.AddDays(1);
+        }
+
+        return end;
+    }
+
+    private DateTime GetNextSessionStartUtc(DateTime referenceUtc)
+    {
+        var local = TimeZoneInfo.ConvertTimeFromUtc(referenceUtc, NewYorkTimeZone);
+        var candidate = new DateTime(local.Year, local.Month, local.Day, SessionStart.Hours, SessionStart.Minutes, 0);
+
+        if (local < candidate && !IsWeekend(candidate))
+        {
+            return TimeZoneInfo.ConvertTimeToUtc(candidate, NewYorkTimeZone);
+        }
+
+        do
+        {
+            candidate = candidate.AddDays(1);
+        }
+        while (IsWeekend(candidate));
+
+        return TimeZoneInfo.ConvertTimeToUtc(candidate, NewYorkTimeZone);
+    }
+
+    private bool IsWithinSession(DateTime utcTime)
+    {
+        var local = TimeZoneInfo.ConvertTimeFromUtc(utcTime, NewYorkTimeZone);
+        if (IsWeekend(local))
+        {
+            return false;
+        }
+
+        var timeOfDay = local.TimeOfDay;
+        if (SessionEnd < SessionStart)
+        {
+            return timeOfDay >= SessionStart || timeOfDay <= SessionEnd;
+        }
+
+        return timeOfDay >= SessionStart && timeOfDay <= SessionEnd;
+    }
+
+    private static bool IsWeekend(DateTime value)
+        => value.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday;
+
+    private int WorkflowMinuteOffset => Math.Clamp(_options.WorkflowMinuteOffset, 0, 59);
+
+    private static TimeZoneInfo NewYorkTimeZone
+        => TimeZoneInfo.FindSystemTimeZoneById(
+            OperatingSystem.IsWindows() ? "Eastern Standard Time" : "America/New_York");
+}

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -39,24 +39,10 @@ public class WakettPriceFetcher
     public async Task<WakettPriceUploadResult?> FetchAndStoreAsync(
         CancellationToken cancellationToken = default)
     {
-        var baseSymbols = _config
-            .GetSection("ExternalApis:WakettApi:Symbols")
-            .Get<List<WakettSecuritySymbol>>() ?? new();
-        if (baseSymbols.Count == 0)
+        if (!TryLoadConfiguredSymbols(out var baseSymbols, out var missingSymbols, out var allSecurityIds))
         {
-            _logger.LogWarning("No Wakett symbols configured. Aborting price fetch.");
             return null;
         }
-
-        var missingSymbols = _config
-            .GetSection("ExternalApis:WakettApi:MissingSymbols")
-            .Get<List<WakettSecuritySymbol>>() ?? new();
-
-        var allSecurityIds = baseSymbols
-            .Concat(missingSymbols)
-            .Select(s => s.SecurityId)
-            .Distinct()
-            .ToArray();
 
         var missingBars = await FindMissingBarTimestampsAsync(allSecurityIds, cancellationToken);
         if (missingBars.Count == 0)
@@ -155,6 +141,26 @@ public class WakettPriceFetcher
         }
 
         return lastResult;
+    }
+
+    public async Task<bool> AreRecentPricesCompleteAsync(CancellationToken cancellationToken = default)
+    {
+        if (!TryLoadConfiguredSymbols(out _, out _, out var securityIds))
+        {
+            return false;
+        }
+
+        var missingBars = await FindMissingBarTimestampsAsync(securityIds, cancellationToken);
+        if (missingBars.Count == 0)
+        {
+            _logger.LogInformation("All Wakett prices are present for the last 24 trading hours.");
+            return true;
+        }
+
+        _logger.LogWarning(
+            "Detected {Count} missing Wakett price bar(s) within the last 24 trading hours.",
+            missingBars.Count);
+        return false;
     }
 
     internal static IReadOnlyList<ComputedRate> BuildComputedRates(
@@ -431,6 +437,36 @@ public class WakettPriceFetcher
             graph[pair.Quote] = inverse;
         }
         inverse[pair.Base] = 1m / rate;
+    }
+
+    private bool TryLoadConfiguredSymbols(
+        out IReadOnlyList<WakettSecuritySymbol> baseSymbols,
+        out IReadOnlyList<WakettSecuritySymbol> missingSymbols,
+        out int[] allSecurityIds)
+    {
+        baseSymbols = _config
+            .GetSection("ExternalApis:WakettApi:Symbols")
+            .Get<List<WakettSecuritySymbol>>() ?? new();
+
+        if (baseSymbols.Count == 0)
+        {
+            _logger.LogWarning("No Wakett symbols configured. Aborting Wakett price processing.");
+            missingSymbols = Array.Empty<WakettSecuritySymbol>();
+            allSecurityIds = Array.Empty<int>();
+            return false;
+        }
+
+        missingSymbols = _config
+            .GetSection("ExternalApis:WakettApi:MissingSymbols")
+            .Get<List<WakettSecuritySymbol>>() ?? new();
+
+        allSecurityIds = baseSymbols
+            .Concat(missingSymbols)
+            .Select(s => s.SecurityId)
+            .Distinct()
+            .ToArray();
+
+        return true;
     }
 
     private async Task<IReadOnlyList<DateTime>> FindMissingBarTimestampsAsync(

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -132,10 +132,16 @@
       "StartDate": "2022-01-01"
     }
   ],
-    "Quartz"
-    :
-    {
-      "Cron": "0 0/30 7-19 ? * *",
-      "TimeZone": "GMT Standard Time"
+  "Quartz": {
+    "Cron": "0 0/30 7-19 ? * *",
+    "TimeZone": "GMT Standard Time"
+  },
+  "Automation": {
+    "Wakett": {
+      "WorkflowMinuteOffset": 2,
+      "FillIntervalMinutes": 10,
+      "FillAccount": "",
+      "FillStrategy": null
     }
+  }
 }


### PR DESCRIPTION
## Summary
- add a hosted service that orchestrates Wakett price ingestion, weight calculation, order submission, and periodic fill checks during the US trading session
- expose Wakett price completeness checks and configuration options needed by the automation workflow
- display a Windows warning when trading limits are breached and register the new automation service with default settings

## Testing
- dotnet test *(fails: `dotnet` is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbbd6e68608333911639a15ed827fe