### PR TITLE
Interpret trading turnover limits as weights

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1111,7 +1111,32 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         var breaches = new List<TradingLimitBreachResult>();
         var aumDecimal = aum.HasValue ? (decimal?)aum.Value : null;
 
-        decimal ComputeTurnover(decimal size) => aumDecimal.HasValue ? size * aumDecimal.Value : size;
+        string FormatTurnoverMessage(
+            string prefix,
+            decimal observedWeight,
+            decimal limitWeight,
+            decimal? aumValue)
+        {
+            if (aumValue.HasValue)
+            {
+                var notional = observedWeight * aumValue.Value;
+                return string.Format(
+                    CultureInfo.InvariantCulture,
+                    "{0} ({1} > {2}). Equivalent notional {3} using AUM {4}.",
+                    prefix,
+                    observedWeight,
+                    limitWeight,
+                    notional,
+                    aumValue.Value);
+            }
+
+            return string.Format(
+                CultureInfo.InvariantCulture,
+                "{0} ({1} > {2}).",
+                prefix,
+                observedWeight,
+                limitWeight);
+        }
 
         TradingOrderMetric FindLargest(Func<TradingOrderMetric, decimal> selector)
         {
@@ -1190,55 +1215,42 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
         if (limits.SingleTradeTurnoverLimit is decimal singleTradeTurnoverLimit)
         {
-            var worstTurnover = FindLargest(metric => ComputeTurnover(metric.AbsoluteSize));
-            var observed = ComputeTurnover(worstTurnover.AbsoluteSize);
-            if (observed > singleTradeTurnoverLimit)
+            var worstTurnover = FindLargest(metric => metric.AbsoluteSize);
+            var observedWeight = worstTurnover.AbsoluteSize;
+            if (observedWeight > singleTradeTurnoverLimit)
             {
-                var message = aumDecimal.HasValue
-                    ? string.Format(
+                var message = FormatTurnoverMessage(
+                    string.Format(
                         CultureInfo.InvariantCulture,
-                        "Order for {0} exceeds single trade turnover limit ({1} > {2}) using AUM {3}.",
-                        worstTurnover.Symbol,
-                        observed,
-                        singleTradeTurnoverLimit,
-                        aumDecimal.Value)
-                    : string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Order for {0} exceeds single trade turnover limit ({1} > {2}).",
-                        worstTurnover.Symbol,
-                        observed,
-                        singleTradeTurnoverLimit);
+                        "Order for {0} exceeds single trade turnover weight limit",
+                        worstTurnover.Symbol),
+                    observedWeight,
+                    singleTradeTurnoverLimit,
+                    aumDecimal);
 
                 breaches.Add(new TradingLimitBreachResult(
                     "SingleTradeTurnoverLimit",
                     singleTradeTurnoverLimit,
-                    observed,
+                    observedWeight,
                     message));
             }
         }
 
         if (limits.TotalTurnoverLimit is decimal totalTurnoverLimit)
         {
-            var observed = metrics.Sum(metric => ComputeTurnover(metric.AbsoluteSize));
-            if (observed > totalTurnoverLimit)
+            var observedWeight = metrics.Sum(metric => metric.AbsoluteSize);
+            if (observedWeight > totalTurnoverLimit)
             {
-                var message = aumDecimal.HasValue
-                    ? string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Total turnover {0} exceeds limit {1} using AUM {2}.",
-                        observed,
-                        totalTurnoverLimit,
-                        aumDecimal.Value)
-                    : string.Format(
-                        CultureInfo.InvariantCulture,
-                        "Total turnover {0} exceeds limit {1}.",
-                        observed,
-                        totalTurnoverLimit);
+                var message = FormatTurnoverMessage(
+                    "Total turnover weight exceeds limit",
+                    observedWeight,
+                    totalTurnoverLimit,
+                    aumDecimal);
 
                 breaches.Add(new TradingLimitBreachResult(
                     "TotalTurnoverLimit",
                     totalTurnoverLimit,
-                    observed,
+                    observedWeight,
                     message));
             }
         }

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Net;
@@ -18,10 +19,8 @@ public class OrderSenderTests
     [Fact]
     public async Task SendOrdersAsync_SubmitsLatestWeightsToWakett()
     {
-        HttpRequestMessage? captured = null;
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
-            .Callback<HttpRequestMessage, CancellationToken>((message, _) => captured = message)
             .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
             {
                 Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
@@ -164,6 +163,83 @@ public class OrderSenderTests
         Assert.Single(sender.LoggedBreaches);
         var breach = sender.LoggedBreaches[0];
         Assert.Equal("SingleTradeGrossLimit", breach.LimitType);
+    }
+
+    [Fact]
+    public async Task SendOrdersAsync_UsesWeightScaleForTurnoverLimits()
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"ts\":\"\",\"orders\":[]}")
+            });
+
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Aum"] = "2500000"
+        });
+
+        var symbolMap = new Dictionary<int, string>
+        {
+            [58] = "EURUSD"
+        };
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var tradingLimit = TestOrderSender.CreateTradingLimit(
+            singleTradeTurnover: 0.10m,
+            totalTurnover: 0.12m);
+
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 },
+            tradingLimit);
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+
+        Assert.Equal(2, sender.LoggedBreaches.Count);
+
+        var single = sender.LoggedBreaches[0];
+        Assert.Equal("SingleTradeTurnoverLimit", single.LimitType);
+        Assert.Equal(0.10m, single.LimitValue);
+        Assert.Equal(0.15m, single.ObservedValue);
+        Assert.Contains("weight", single.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Equivalent notional", single.Message, StringComparison.OrdinalIgnoreCase);
+
+        var total = sender.LoggedBreaches[1];
+        Assert.Equal("TotalTurnoverLimit", total.LimitType);
+        Assert.Equal(0.12m, total.LimitValue);
+        Assert.Equal(0.15m, total.ObservedValue);
+        Assert.Contains("weight", total.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("Equivalent notional", total.Message, StringComparison.OrdinalIgnoreCase);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- treat turnover trading limits as weights so that observed values match the order percentage scale
- include equivalent notional context in turnover breach messages when an AUM is configured
- add a unit test covering the new turnover weight behaviour

## Testing
- not run (dotnet CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68dbccc3de788333959e0af355fe9257