### PR TITLE
Align Wakett workflow to :06 minute offset

### DIFF
--- a/src/TradingDaemon/Models/WakettAutomationOptions.cs
+++ b/src/TradingDaemon/Models/WakettAutomationOptions.cs
@@ -2,7 +2,7 @@ namespace TradingDaemon.Models;
 
 public sealed class WakettAutomationOptions
 {
-    public int WorkflowMinuteOffset { get; set; } = 2;
+    public int WorkflowMinuteOffset { get; set; } = 6;
 
     public int FillIntervalMinutes { get; set; } = 10;
 

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -263,32 +263,15 @@ public class WakettPriceFetcher
                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal,
                 out var parsed))
         {
-            return AdjustTimestampForDebugging(parsed.UtcDateTime);
+            return parsed.UtcDateTime;
         }
 
         if (requestedTimestamp.HasValue)
         {
-            return AdjustTimestampForDebugging(requestedTimestamp.Value.UtcDateTime);
+            return requestedTimestamp.Value.UtcDateTime;
         }
 
-        return AdjustTimestampForDebugging(fallbackUtc);
-    }
-
-    private static DateTime AdjustTimestampForDebugging(DateTime timestampUtc)
-    {
-        if (timestampUtc.Minute == 6)
-        {
-            return new DateTime(
-                timestampUtc.Year,
-                timestampUtc.Month,
-                timestampUtc.Day,
-                timestampUtc.Hour,
-                0,
-                0,
-                DateTimeKind.Utc);
-        }
-
-        return timestampUtc;
+        return fallbackUtc;
     }
 
     internal static string NormalizeSymbol(string symbol)

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -139,7 +139,7 @@
   },
   "Automation": {
     "Wakett": {
-      "WorkflowMinuteOffset": 2,
+      "WorkflowMinuteOffset": 6,
       "FillIntervalMinutes": 10,
       "FillAccount": "",
       "FillStrategy": null

--- a/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
@@ -128,7 +128,7 @@ public class WakettPriceFetcherTests
     }
 
     [Fact]
-    public void DetermineTimestampUtc_AdjustsResponseTimestampForDebugging()
+    public void DetermineTimestampUtc_PreservesResponseTimestampMinuteOffset()
     {
         var responseTs = "2024-03-01T12:06:00Z";
         var requestTs = new DateTimeOffset(2024, 3, 1, 11, 0, 0, TimeSpan.Zero);
@@ -136,7 +136,7 @@ public class WakettPriceFetcherTests
 
         var result = WakettPriceFetcher.DetermineTimestampUtc(responseTs, requestTs, fallback);
 
-        Assert.Equal(new DateTime(2024, 3, 1, 12, 0, 0, DateTimeKind.Utc), result);
+        Assert.Equal(new DateTime(2024, 3, 1, 12, 6, 0, DateTimeKind.Utc), result);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- request hourly prices from Wakett at the :06 minute mark while persisting the returned :06 timestamps
- default the Wakett automation workflow configuration to trigger six minutes past the hour

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe4ddcd8883339ef4260881883d11