### PR TITLE
Log missing Wakett bar timestamps when prices incomplete

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -167,6 +167,11 @@ public class WakettPriceFetcher
         _logger.LogWarning(
             "Detected {Count} missing Wakett price bar(s) within the last 24 trading hours.",
             missingBars.Count);
+        _logger.LogWarning(
+            "Missing bar timestamps (UTC): {BarTimes}",
+            string.Join(", ", missingBars
+                .OrderBy(t => t)
+                .Select(t => t.ToString("yyyy-MM-dd HH:mm"))));
         return false;
     }
 


### PR DESCRIPTION
## Summary
- log the specific Wakett bar timestamps that are missing when recent prices are incomplete

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dbef95effc8333842734e69505be82