### PR TITLE
Restore stored procedure execution after staging FX prices

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -65,7 +65,7 @@ public class PriceFetcher
 
         // Load newly staged raw bars into the PriceBar table so that subsequent
         // queries include the latest data.
-        await connection.ExecuteAsync("EXEC mkt.LoadRawFromStage @TimeframeMinute = 60");
+        await PriceProcessingProcedures.LoadRawFromStageAsync(connection, 60);
 
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only
@@ -116,8 +116,7 @@ public class PriceFetcher
             }
 
             // Move staged flat bars into the main table for each session.
-            await connection.ExecuteAsync(
-                    $"EXEC mkt.LoadFlatFromMinimal @TimeframeMinute = 60");
+            await PriceProcessingProcedures.LoadFlatFromMinimalAsync(connection, 60);
         }
     }
 

--- a/src/TradingDaemon/Services/PriceProcessingProcedures.cs
+++ b/src/TradingDaemon/Services/PriceProcessingProcedures.cs
@@ -1,0 +1,39 @@
+using System.Data;
+using System.Threading;
+using Dapper;
+
+namespace TradingDaemon.Services;
+
+internal static class PriceProcessingProcedures
+{
+    private const string LoadRawFromStageProc = "mkt.LoadRawFromStage";
+    private const string LoadFlatFromMinimalProc = "mkt.LoadFlatFromMinimal";
+
+    public static Task LoadRawFromStageAsync(
+        IDbConnection connection,
+        int timeframeMinute,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new CommandDefinition(
+            LoadRawFromStageProc,
+            new { TimeframeMinute = timeframeMinute },
+            commandType: CommandType.StoredProcedure,
+            cancellationToken: cancellationToken);
+
+        return connection.ExecuteAsync(command);
+    }
+
+    public static Task LoadFlatFromMinimalAsync(
+        IDbConnection connection,
+        int timeframeMinute,
+        CancellationToken cancellationToken = default)
+    {
+        var command = new CommandDefinition(
+            LoadFlatFromMinimalProc,
+            new { TimeframeMinute = timeframeMinute },
+            commandType: CommandType.StoredProcedure,
+            cancellationToken: cancellationToken);
+
+        return connection.ExecuteAsync(command);
+    }
+}

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -660,7 +660,7 @@ public class WakettPriceFetcher
 
         if (recordList.Count > 0)
         {
-            await connection.ExecuteAsync("EXEC mkt.LoadRawFromStage @TimeframeMinute = 60");
+            await PriceProcessingProcedures.LoadRawFromStageAsync(connection, 60, cancellationToken);
 
             const string selectRaw =
                 "SELECT SecurityId, BarTimeUtc, [Close] FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds";
@@ -723,7 +723,7 @@ public class WakettPriceFetcher
                 }
             }
 
-            await connection.ExecuteAsync("EXEC mkt.LoadFlatFromMinimal @TimeframeMinute = 60");
+            await PriceProcessingProcedures.LoadFlatFromMinimalAsync(connection, 60, cancellationToken);
         }
     }
 


### PR DESCRIPTION
## Summary
- execute the Intraday load stored procedures after staging prices via a shared helper
- refactor both price fetchers to call the shared stored procedure invocations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dbf3be0f5c8333a0721126f8875a80