### PR TITLE
Align Wakett price fetch minute offset with workflow schedule

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -12,6 +12,7 @@ using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
 
@@ -23,9 +24,12 @@ public class WakettPriceFetcher
     private readonly DapperContext _context;
     private readonly IConfiguration _config;
     private readonly ILogger<WakettPriceFetcher> _logger;
+    private readonly WakettAutomationOptions? _automationOptions;
 
     private int PriceMinuteOffset => Math.Clamp(
-        _config.GetValue<int?>("ExternalApis:WakettApi:PriceMinuteOffset") ?? 6,
+        _automationOptions?.WorkflowMinuteOffset
+            ?? _config.GetValue<int?>("ExternalApis:WakettApi:PriceMinuteOffset")
+            ?? 6,
         0,
         59);
 
@@ -33,12 +37,14 @@ public class WakettPriceFetcher
         WakettApiClient client,
         DapperContext context,
         IConfiguration config,
-        ILogger<WakettPriceFetcher> logger)
+        ILogger<WakettPriceFetcher> logger,
+        IOptions<WakettAutomationOptions>? automationOptions = null)
     {
         _client = client;
         _context = context;
         _config = config;
         _logger = logger;
+        _automationOptions = automationOptions?.Value;
     }
 
     public async Task<WakettPriceUploadResult?> FetchAndStoreAsync(


### PR DESCRIPTION
## Summary
- align the Wakett price fetcher to use the automation workflow minute offset so price requests wait until the configured time

## Testing
- dotnet test *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dbff4b56048333bd75933c7cd71f06