### PR TITLE
Filter flattened bars by minute offset

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -686,9 +686,10 @@ public class WakettPriceFetcher
         {
             await PriceProcessingProcedures.LoadRawFromStageAsync(connection, 60, cancellationToken);
 
-            const string selectRaw =
-                "SELECT SecurityId, BarTimeUtc, [Close] FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds";
-            var existing = (await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityKeys }))
+            var minuteOffset = PriceMinuteOffset;
+            var selectRaw =
+                "SELECT SecurityId, BarTimeUtc, [Close] FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+            var existing = (await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityKeys, MinuteOffset = minuteOffset }))
                 .GroupBy(r => (r.SecurityId, r.BarTimeUtc))
                 .Select(g => g.Last())
                 .ToList();
@@ -697,7 +698,6 @@ public class WakettPriceFetcher
             foreach (var grp in existing.GroupBy(r => r.SecurityId))
             {
                 var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
-                var minuteOffset = PriceMinuteOffset;
                 var rawEu = RawNMin(ordered, 60, "EU", minuteOffset);
                 var flatEu = Flatten(rawEu, SessionBounds["EU"].Zone)
                     .Select(r => new FlatPrice


### PR DESCRIPTION
## Summary
- filter flattened bar source data to only include records whose minute component matches the configured minute offset
- reuse the configured offset when flattening bars for EU and US sessions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc06cb7fc08333b395d37a6c358901