### PR TITLE
Fix Wakett automation scheduling and price offset

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -76,7 +76,8 @@ public sealed class WakettAutomationService : BackgroundService
                     sessionActive = true;
                     await RunFillCheckAsync(stoppingToken);
                     nextWorkflowUtc = GetNextWorkflowRunUtc(nowUtc);
-                    nextFillUtc = GetNextFillCheckUtc(_timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1));
+                    var fillCompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+                    nextFillUtc = GetNextFillCheckAfter(fillCompletedUtc);
                 }
 
                 if (nowUtc >= nextWorkflowUtc)
@@ -96,7 +97,8 @@ public sealed class WakettAutomationService : BackgroundService
                 if (nowUtc >= nextFillUtc)
                 {
                     await RunFillCheckAsync(stoppingToken);
-                    nextFillUtc = GetNextFillCheckUtc(_timeProvider.GetUtcNow().UtcDateTime.AddSeconds(1));
+                    var fillCompletedUtc = _timeProvider.GetUtcNow().UtcDateTime;
+                    nextFillUtc = GetNextFillCheckAfter(fillCompletedUtc);
                 }
 
                 var nextEvent = nextWorkflowUtc < nextFillUtc ? nextWorkflowUtc : nextFillUtc;
@@ -274,21 +276,7 @@ public sealed class WakettAutomationService : BackgroundService
             return GetFirstFillCheckUtc(nextSession);
         }
 
-        var interval = Math.Max(1, _options.FillIntervalMinutes);
-        var local = TimeZoneInfo.ConvertTimeFromUtc(referenceUtc, NewYorkTimeZone);
-        var endLocal = GetSessionEndLocal(local);
-        var minute = local.Minute;
-        var remainder = minute % interval;
-        var delta = remainder == 0 && local.Second == 0 ? interval : interval - remainder;
-        var candidate = new DateTime(local.Year, local.Month, local.Day, local.Hour, minute, 0).AddMinutes(delta);
-
-        if (candidate > endLocal)
-        {
-            var nextSession = GetNextSessionStartUtc(referenceUtc);
-            return GetFirstFillCheckUtc(nextSession);
-        }
-
-        return TimeZoneInfo.ConvertTimeToUtc(candidate, NewYorkTimeZone);
+        return GetNextFillCheckAfter(referenceUtc);
     }
 
     private DateTime GetFirstWorkflowRunUtc(DateTime sessionStartUtc)
@@ -302,6 +290,20 @@ public sealed class WakettAutomationService : BackgroundService
         }
 
         return TimeZoneInfo.ConvertTimeToUtc(firstLocal, NewYorkTimeZone);
+    }
+
+    private DateTime GetNextFillCheckAfter(DateTime lastFillUtc)
+    {
+        var interval = Math.Max(1, _options.FillIntervalMinutes);
+        var candidate = lastFillUtc.AddMinutes(interval);
+
+        if (!IsWithinSession(candidate))
+        {
+            var nextSession = GetNextSessionStartUtc(lastFillUtc);
+            return GetFirstFillCheckUtc(nextSession);
+        }
+
+        return candidate;
     }
 
     private DateTime GetFirstFillCheckUtc(DateTime sessionStartUtc)

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -28,11 +28,23 @@ public class WakettPriceFetcher
     private readonly WakettAutomationOptions? _automationOptions;
 
 
-    private int PriceMinuteOffset => Math.Clamp(
-        _config.GetValue<int?>("ExternalApis:WakettApi:PriceMinuteOffset")
-            ?? 6,
-        0,
-        59);
+    private int PriceMinuteOffset
+    {
+        get
+        {
+            var automationOffset = _automationOptions?.WorkflowMinuteOffset;
+            if (automationOffset.HasValue)
+            {
+                return Math.Clamp(automationOffset.Value, 0, 59);
+            }
+
+            return Math.Clamp(
+                _config.GetValue<int?>("ExternalApis:WakettApi:PriceMinuteOffset")
+                    ?? 6,
+                0,
+                59);
+        }
+    }
 
     public WakettPriceFetcher(
         WakettApiClient client,

--- a/tests/TradingDaemon.Tests/WakettAutomationServiceTests.cs
+++ b/tests/TradingDaemon.Tests/WakettAutomationServiceTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using TradingDaemon.Models;
+using TradingDaemon.Services;
+using Xunit;
+
+public sealed class WakettAutomationServiceTests
+{
+    private static TimeZoneInfo NewYorkTimeZone
+        => TimeZoneInfo.FindSystemTimeZoneById(
+            OperatingSystem.IsWindows() ? "Eastern Standard Time" : "America/New_York");
+
+    [Fact]
+    public void GetNextFillCheckAfter_UsesFixedIntervalWithinSession()
+    {
+        var service = CreateService();
+        var method = typeof(WakettAutomationService).GetMethod(
+            "GetNextFillCheckAfter",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var lastFillLocal = new DateTime(2024, 5, 1, 10, 2, 0);
+        var lastFillUtc = TimeZoneInfo.ConvertTimeToUtc(lastFillLocal, NewYorkTimeZone);
+
+        var nextFillUtc = (DateTime)method.Invoke(service, new object[] { lastFillUtc })!;
+        var nextFillLocal = TimeZoneInfo.ConvertTimeFromUtc(nextFillUtc, NewYorkTimeZone);
+
+        Assert.Equal(new DateTime(2024, 5, 1, 10, 12, 0), nextFillLocal);
+    }
+
+    [Fact]
+    public void GetNextFillCheckAfter_MovesToNextSessionWhenNeeded()
+    {
+        var service = CreateService();
+        var method = typeof(WakettAutomationService).GetMethod(
+            "GetNextFillCheckAfter",
+            BindingFlags.Instance | BindingFlags.NonPublic)!;
+
+        var lastFillLocal = new DateTime(2024, 5, 1, 15, 55, 0);
+        var lastFillUtc = TimeZoneInfo.ConvertTimeToUtc(lastFillLocal, NewYorkTimeZone);
+
+        var nextFillUtc = (DateTime)method.Invoke(service, new object[] { lastFillUtc })!;
+        var nextFillLocal = TimeZoneInfo.ConvertTimeFromUtc(nextFillUtc, NewYorkTimeZone);
+
+        Assert.Equal(new DateTime(2024, 5, 2, 9, 0, 0), nextFillLocal);
+    }
+
+    private static WakettAutomationService CreateService()
+    {
+        var options = Options.Create(new WakettAutomationOptions
+        {
+            FillIntervalMinutes = 10,
+            WorkflowMinuteOffset = 8,
+            FillAccount = "Test"
+        });
+
+        return new WakettAutomationService(
+            Mock.Of<WakettPriceFetcher>(),
+            Mock.Of<WeightCalculator>(),
+            Mock.Of<OrderSender>(),
+            Mock.Of<WakettTradeFetcher>(),
+            Mock.Of<IHostApplicationLifetime>(),
+            options,
+            Mock.Of<ILogger<WakettAutomationService>>(),
+            new ConfigurationBuilder().Build(),
+            TimeProvider.System);
+    }
+}

--- a/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/WakettPriceFetcherTests.cs
@@ -1,8 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
+using TradingDaemon.Data;
 using TradingDaemon.Models;
 using TradingDaemon.Services;
 using Xunit;
@@ -171,5 +175,66 @@ public class WakettPriceFetcherTests
         Assert.Equal(new DateTime(2024, 3, 1, 13, 0, 0, DateTimeKind.Utc), hours[0]);
         Assert.Equal(endHour, hours[^1]);
         Assert.DoesNotContain(hours, h => h.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday);
+    }
+
+    [Fact]
+    public void PriceMinuteOffset_PrefersAutomationOptions()
+    {
+        var config = BuildConfiguration();
+        var options = Options.Create(new WakettAutomationOptions { WorkflowMinuteOffset = 8 });
+
+        var fetcher = CreateFetcher(config, options);
+        var offset = GetPriceMinuteOffset(fetcher);
+
+        Assert.Equal(8, offset);
+    }
+
+    [Fact]
+    public void PriceMinuteOffset_FallsBackToConfigurationWhenAutomationOptionsMissing()
+    {
+        var config = BuildConfiguration();
+
+        var fetcher = CreateFetcher(config, null);
+        var offset = GetPriceMinuteOffset(fetcher);
+
+        Assert.Equal(6, offset);
+    }
+
+    private static WakettPriceFetcher CreateFetcher(
+        IConfiguration config,
+        IOptions<WakettAutomationOptions>? automationOptions)
+    {
+        var httpClientFactory = Mock.Of<IHttpClientFactory>();
+        var apiClient = new WakettApiClient(httpClientFactory);
+        var context = new DapperContext(config);
+
+        return new WakettPriceFetcher(
+            apiClient,
+            context,
+            config,
+            Mock.Of<ILogger<WakettPriceFetcher>>(),
+            automationOptions);
+    }
+
+    private static IConfiguration BuildConfiguration()
+    {
+        var values = new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:PriceMinuteOffset"] = "6",
+            ["ConnectionStrings:DefaultConnection"] = "Server=.;Database=Test;Trusted_Connection=True;"
+        };
+
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(values)
+            .Build();
+    }
+
+    private static int GetPriceMinuteOffset(WakettPriceFetcher fetcher)
+    {
+        var property = typeof(WakettPriceFetcher).GetProperty(
+            "PriceMinuteOffset",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!;
+
+        return (int)property.GetValue(fetcher)!;
     }
 }


### PR DESCRIPTION
## Summary
- ensure Wakett automation schedules subsequent fill checks relative to the last run so the cadence stays at the configured interval
- prefer the automation workflow offset when determining Wakett price request minute offsets
- add unit tests covering the revised fill scheduling helper and price minute offset selection

## Testing
- dotnet test *(fails: `dotnet: command not found` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd10749ac48333840e09fbb8ddee60