### PR TITLE
Prevent duplicate Wakett orders

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -114,6 +114,22 @@ public class OrderSender
             return;
         }
 
+        var scheduledTimestamp = ResolveScheduledTimestamp(orderTimestampUtc);
+        var existingOrderSymbols = await LoadExistingOrderSymbolsAsync(
+            connection,
+            scheduledTimestamp,
+            builtOrders,
+            cancellationToken);
+
+        if (existingOrderSymbols.Count > 0)
+        {
+            _logger.LogInformation(
+                "Skipping Wakett order submission for scheduled timestamp {ScheduledTimestamp} because existing orders were found for symbol(s): {Symbols}.",
+                scheduledTimestamp,
+                string.Join(", ", existingOrderSymbols));
+            return;
+        }
+
         var aum = aumOverride ?? ResolveAum();
 
         var tradingLimits = await LoadTradingLimitsAsync(connection, cancellationToken);
@@ -337,6 +353,66 @@ VALUES
         {
             _logger.LogError(ex, "Failed to persist Wakett order response results.");
         }
+    }
+
+    protected virtual async Task<IReadOnlyCollection<string>> LoadExistingOrderSymbolsAsync(
+        IDbConnection connection,
+        DateTimeOffset scheduledTimestamp,
+        IEnumerable<(int SecurityId, WakettOrderItem Order)> builtOrders,
+        CancellationToken cancellationToken)
+    {
+        var symbols = builtOrders
+            .Select(order => order.Order.symbol)
+            .Where(symbol => !string.IsNullOrWhiteSpace(symbol))
+            .Select(symbol => symbol!.Trim().ToUpperInvariant())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (symbols.Length == 0)
+        {
+            return Array.Empty<string>();
+        }
+
+        const string selectSql = @"SELECT Symbol FROM [wakett].[Order]
+WHERE ModelId = @ModelId AND ScheduledTimestamp = @ScheduledTimestamp AND Symbol IN @Symbols;";
+
+        try
+        {
+            var definition = new CommandDefinition(
+                selectSql,
+                new
+                {
+                    ModelId = TargetModelId,
+                    ScheduledTimestamp = scheduledTimestamp,
+                    Symbols = symbols
+                },
+                cancellationToken: cancellationToken);
+
+            var existing = await connection.QueryAsync<string>(definition);
+
+            return existing
+                .Where(symbol => !string.IsNullOrWhiteSpace(symbol))
+                .Select(symbol => symbol.Trim().ToUpperInvariant())
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to load existing Wakett order symbols.");
+            return Array.Empty<string>();
+        }
+    }
+
+    private static DateTimeOffset ResolveScheduledTimestamp(DateTime orderTimestampUtc)
+    {
+        var formattedTimestamp = FormatTimestamp(orderTimestampUtc);
+        return TryParseResponseTimestamp(formattedTimestamp, out var parsedTimestamp)
+            ? parsedTimestamp
+            : new DateTimeOffset(DateTime.SpecifyKind(orderTimestampUtc, DateTimeKind.Utc));
     }
 
     protected virtual async Task LogTradingLimitBreachesAsync(

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -106,6 +106,60 @@ public class OrderSenderTests
     }
 
     [Fact]
+    public async Task SendOrdersAsync_DoesNotSendWhenOrdersAlreadyExist()
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("http://wakett") };
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient("WakettApi") == client);
+        var apiClient = new WakettApiClient(factory);
+
+        var now = new DateTimeOffset(2024, 1, 2, 16, 30, 0, TimeSpan.Zero);
+        var barTimeUtc = now.AddMinutes(-60).UtcDateTime;
+        var weights = new List<OrderSender.TheoreticalWeightRow>
+        {
+            new() { SecurityId = 58, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = 0.15m },
+            new() { SecurityId = 61, ModelId = 1, BarTimeUtc = barTimeUtc, ModelRunId = 10, Weight = -0.05m }
+        };
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Aum"] = "2500000"
+        });
+
+        var symbolMap = new Dictionary<int, string>
+        {
+            [58] = "EURUSD",
+            [61] = "EURCHF",
+            [136] = "USDCHF"
+        };
+
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+
+        var logger = Mock.Of<ILogger<OrderSender>>();
+        var timeProvider = new TestTimeProvider(now);
+
+        var sender = new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            timeProvider,
+            weights,
+            symbolMap,
+            new OrderSender.ModelScheduleRow { Offset = 60, BarSize = 0 },
+            existingOrderSymbols: new[] { "EUR/USD" });
+
+        await sender.SendOrdersAsync();
+
+        handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Fact]
     public async Task SendOrdersAsync_DoesNotSendWhenTradingLimitBreached()
     {
         var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
@@ -718,6 +772,7 @@ public class OrderSenderTests
         private readonly ModelScheduleRow? _schedule;
         private readonly TradingLimitRow? _tradingLimit;
         private readonly List<TradingLimitBreachResult> _loggedBreaches = new();
+        private readonly IReadOnlyCollection<string> _existingOrderSymbols;
 
         public TestOrderSender(
             WakettApiClient client,
@@ -728,13 +783,15 @@ public class OrderSenderTests
             IReadOnlyList<TheoreticalWeightRow> weights,
             IReadOnlyDictionary<int, string> symbolMap,
             ModelScheduleRow? schedule,
-            TradingLimitRow? tradingLimit = null)
+            TradingLimitRow? tradingLimit = null,
+            IReadOnlyCollection<string>? existingOrderSymbols = null)
             : base(client, context, logger, configuration, timeProvider)
         {
             _weights = weights;
             _symbolMap = symbolMap;
             _schedule = schedule;
             _tradingLimit = tradingLimit;
+            _existingOrderSymbols = existingOrderSymbols ?? Array.Empty<string>();
         }
 
         public IReadOnlyList<TradingLimitBreachResult> LoggedBreaches => _loggedBreaches;
@@ -785,6 +842,13 @@ public class OrderSenderTests
             _loggedBreaches.AddRange(breaches);
             return Task.CompletedTask;
         }
+
+        protected override Task<IReadOnlyCollection<string>> LoadExistingOrderSymbolsAsync(
+            IDbConnection connection,
+            DateTimeOffset scheduledTimestamp,
+            IEnumerable<(int SecurityId, WakettOrderItem Order)> builtOrders,
+            CancellationToken cancellationToken)
+            => Task.FromResult(_existingOrderSymbols);
     }
 
     private sealed class TestTimeProvider : TimeProvider


### PR DESCRIPTION
## Summary
- add a database check to avoid resubmitting Wakett orders that already exist for the scheduled timestamp and symbol
- log and skip the Wakett API call when duplicates are found
- extend the order sender tests with coverage for the duplicate scenario and support for injecting existing orders

## Testing
- dotnet test *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de276283508333aacfb1eb2aa7585a