### PR TITLE
Adjust workflow minute offset to :59

### DIFF
--- a/src/TradingDaemon/Models/WakettAutomationOptions.cs
+++ b/src/TradingDaemon/Models/WakettAutomationOptions.cs
@@ -3,7 +3,7 @@ namespace TradingDaemon.Models;
 public sealed class WakettAutomationOptions
 {
 
-    public int WorkflowMinuteOffset { get; set; } = 8;
+    public int WorkflowMinuteOffset { get; set; } = 59;
 
 
     public int FillIntervalMinutes { get; set; } = 10;

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -141,7 +141,7 @@
   "Automation": {
     "Wakett": {
 
-      "WorkflowMinuteOffset": 8,
+      "WorkflowMinuteOffset": 59,
 
       "FillIntervalMinutes": 10,
       "FillAccount": "subacc4",


### PR DESCRIPTION
## Summary
- update the Wakett automation options to default the workflow minute offset to :59
- align the application configuration with the new :59 workflow start time

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de3cdb1960833385e139db7106a04c