### PR TITLE
Send PnL email notifications via SES

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,6 +1,7 @@
 using Dapper;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
+using TradingDaemon.Services;
 
 namespace TradingDaemon.Controllers;
 
@@ -18,7 +19,7 @@ public static class FillController
             return Results.Created($"/api/fills/{fill.Id}", fill);
         });
 
-        app.MapGet("/api/pnl", async (DateTime date, DapperContext context) =>
+        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillController> logger) =>
         {
             using var connection = context.CreateConnection();
             var fillsSql = "SELECT * FROM fills WHERE DATE(timestamp) = @Date";
@@ -31,6 +32,16 @@ public static class FillController
             var pnl = (from f in fills
                        join w in weights on f.Symbol equals w.Symbol
                        select f.Quantity * (w.Value - f.Price)).Sum();
+
+            try
+            {
+                await emailNotificationService.SendPnLReportAsync(date.Date, pnl);
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send PnL email notification");
+                return Results.Problem("Failed to send PnL email notification.", statusCode: StatusCodes.Status500InternalServerError);
+            }
 
             return Results.Ok(new { Date = date.Date, PnL = pnl });
         });

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -49,6 +49,8 @@ builder.Services.AddTransient<WakettApiClient>();
 builder.Services.AddTransient<WakettPriceFetcher>();
 builder.Services.AddTransient<WakettTradeFetcher>();
 
+builder.Services.AddSingleton<IEmailNotificationService, EmailNotificationService>();
+
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -1,0 +1,89 @@
+using Amazon;
+using Amazon.SimpleEmail;
+using Amazon.SimpleEmail.Model;
+
+namespace TradingDaemon.Services;
+
+public interface IEmailNotificationService
+{
+    Task SendPnLReportAsync(DateTime date, decimal pnl, CancellationToken cancellationToken = default);
+}
+
+public class EmailNotificationService : IEmailNotificationService, IDisposable
+{
+    private readonly IAmazonSimpleEmailService _sesClient;
+    private readonly ILogger<EmailNotificationService> _logger;
+    private readonly string _fromAddress;
+    private readonly IReadOnlyList<string> _recipients;
+    private bool _disposedValue;
+
+    public EmailNotificationService(IConfiguration configuration, ILogger<EmailNotificationService> logger)
+    {
+        _logger = logger;
+
+        var regionName = configuration["AWS:Region"] ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "eu-west-2";
+        _sesClient = new AmazonSimpleEmailServiceClient(RegionEndpoint.GetBySystemName(regionName));
+
+        _fromAddress = configuration["Email:From"] ?? "intraday_bot@quantumqb.com";
+        var recipients = configuration.GetSection("Email:Recipients").Get<string[]>() ?? Array.Empty<string>();
+        _recipients = Array.AsReadOnly(recipients);
+
+        if (_recipients.Count == 0)
+        {
+            _logger.LogWarning("No email recipients configured. PnL emails will be skipped.");
+        }
+    }
+
+    public async Task SendPnLReportAsync(DateTime date, decimal pnl, CancellationToken cancellationToken = default)
+    {
+        if (_recipients.Count == 0)
+        {
+            return;
+        }
+
+        var subject = $"Intraday PnL for {date:yyyy-MM-dd}";
+        var bodyText = $"Date: {date:yyyy-MM-dd}\nPnL: {pnl:F2}";
+        var bodyHtml = $"<html><body><h1>Intraday PnL</h1><p><strong>Date:</strong> {date:yyyy-MM-dd}</p><p><strong>PnL:</strong> {pnl:F2}</p></body></html>";
+
+        var request = new SendEmailRequest
+        {
+            Source = _fromAddress,
+            Destination = new Destination
+            {
+                ToAddresses = _recipients.ToList()
+            },
+            Message = new Message
+            {
+                Subject = new Content(subject),
+                Body = new Body
+                {
+                    Text = new Content(bodyText),
+                    Html = new Content(bodyHtml)
+                }
+            }
+        };
+
+        _logger.LogInformation("Sending PnL email to {Recipients} with subject {Subject}", string.Join(", ", _recipients), subject);
+
+        await _sesClient.SendEmailAsync(request, cancellationToken);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                _sesClient.Dispose();
+            }
+
+            _disposedValue = true;
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(disposing: true);
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/TradingDaemon/TradingDaemon.csproj
+++ b/src/TradingDaemon/TradingDaemon.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Dapper" Version="2.0.123" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.2.0" />
     <PackageReference Include="AWSSDK.SecretsManager" Version="3.7.300.35" />
+    <PackageReference Include="AWSSDK.SimpleEmail" Version="3.7.301.5" />
     <PackageReference Include="Polly" Version="8.6.2" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -132,6 +132,12 @@
       "StartDate": "2022-01-01"
     }
   ],
+  "Email": {
+    "From": "intraday_bot@quantumqb.com",
+    "Recipients": [
+      "phu@quantumqb.com"
+    ]
+  },
     "Quartz"
     :
     {


### PR DESCRIPTION
## Summary
- add an SES-backed email notification service for sending PnL reports
- wire the PnL endpoint to send the computed value to the configured recipients
- register configuration defaults for the intraday bot sender and Phu recipient

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de495fb0b08333a1f909aca0b63732