### PR TITLE
Use non-static logger for PnL endpoint

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,4 +1,5 @@
 using Dapper;
+using Microsoft.Extensions.Logging;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
 
@@ -18,14 +19,14 @@ public static class FillController
             return Results.Created($"/api/fills/{fill.Id}", fill);
         });
 
-        app.MapGet("/api/pnl", async (DateTime date, DapperContext context) =>
+        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, ILogger<FillEndpointsLogger> logger) =>
         {
             using var connection = context.CreateConnection();
             var fillsSql = "SELECT * FROM fills WHERE DATE(timestamp) = @Date";
-            Console.WriteLine($"Executing SQL: {fillsSql}");
+            logger.LogInformation("Executing SQL: {Sql}", fillsSql);
             var fills = await connection.QueryAsync<Fill>(fillsSql, new { Date = date.Date });
             var weightsSql = "SELECT * FROM weights WHERE DATE(asof) = @Date";
-            Console.WriteLine($"Executing SQL: {weightsSql}");
+            logger.LogInformation("Executing SQL: {Sql}", weightsSql);
             var weights = await connection.QueryAsync<Weight>(weightsSql, new { Date = date.Date });
 
             var pnl = (from f in fills
@@ -35,4 +36,8 @@ public static class FillController
             return Results.Ok(new { Date = date.Date, PnL = pnl });
         });
     }
+}
+
+internal sealed class FillEndpointsLogger
+{
 }


### PR DESCRIPTION
## Summary
- inject a non-static logger into the /api/pnl endpoint
- log executed SQL statements with the new FillEndpointsLogger helper type

## Testing
- `dotnet build src/TradingDaemon/TradingDaemon.csproj --configuration Release` *(fails: dotnet command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de4e20acb88333b4d26f3a8c19e5aa