### PR TITLE
Fix logger type for fill endpoint registration

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -21,7 +21,7 @@ public static class FillController
         });
 
 
-        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillController> logger) =>
+        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillEndpointsLogger> logger) =>
 
         {
             using var connection = context.CreateConnection();


### PR DESCRIPTION
## Summary
- update the fill endpoint registration to use a non-static type for the logger generic argument

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de535198808333b630f68418325e3b