### PR TITLE
Add test email endpoint with swagger documentation

### DIFF
--- a/src/TradingDaemon/Controllers/EmailController.cs
+++ b/src/TradingDaemon/Controllers/EmailController.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Models;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class EmailController
+{
+    public static void MapEmailEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/email/test", async Task<Results<Ok<TestEmailResponse>, ProblemHttpResult>> (TestEmailRequest? request, IEmailNotificationService emailService, ILogger<EmailEndpointsLogger> logger, CancellationToken cancellationToken) =>
+        {
+            try
+            {
+                await emailService.SendTestEmailAsync(request?.Subject, request?.Body, cancellationToken);
+                return TypedResults.Ok(new TestEmailResponse("TestEmailSent"));
+            }
+            catch (Exception ex)
+            {
+                logger.LogError(ex, "Failed to send test email");
+                return TypedResults.Problem("Failed to send test email.", statusCode: StatusCodes.Status500InternalServerError);
+            }
+        })
+        .WithName("SendTestEmail")
+        .Produces<TestEmailResponse>()
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Send a test email";
+            op.Description = "Sends a basic test email using the configured Amazon SES settings.";
+            op.Responses["200"] = new OpenApiResponse
+            {
+                Description = "The test email was sent successfully.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(TestEmailResponse)
+                            }
+                        }
+                    }
+                }
+            };
+
+            op.RequestBody = new OpenApiRequestBody
+            {
+                Required = false,
+                Description = "Optional subject and body overrides for the test email.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(TestEmailRequest)
+                            }
+                        }
+                    }
+                }
+            };
+
+            return op;
+        });
+    }
+}
+
+public sealed record TestEmailRequest(string? Subject, string? Body);
+
+public sealed record TestEmailResponse(string Status);
+
+internal sealed class EmailEndpointsLogger;

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -81,5 +81,6 @@ app.MapOrderEndpoints();
 app.MapTradingEndpoints();
 app.MapReportEndpoints();
 app.MapWakettEndpoints();
+app.MapEmailEndpoints();
 
 app.Run();

--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -1,3 +1,5 @@
+using System.Linq;
+using System.Net;
 using Amazon;
 using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
@@ -7,6 +9,7 @@ namespace TradingDaemon.Services;
 public interface IEmailNotificationService
 {
     Task SendPnLReportAsync(DateTime date, decimal pnl, CancellationToken cancellationToken = default);
+    Task SendTestEmailAsync(string? subject = null, string? body = null, CancellationToken cancellationToken = default);
 }
 
 public class EmailNotificationService : IEmailNotificationService, IDisposable
@@ -45,6 +48,31 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
         var bodyText = $"Date: {date:yyyy-MM-dd}\nPnL: {pnl:F2}";
         var bodyHtml = $"<html><body><h1>Intraday PnL</h1><p><strong>Date:</strong> {date:yyyy-MM-dd}</p><p><strong>PnL:</strong> {pnl:F2}</p></body></html>";
 
+        await SendEmailInternalAsync(subject, bodyText, bodyHtml, cancellationToken);
+    }
+
+    public async Task SendTestEmailAsync(string? subject = null, string? body = null, CancellationToken cancellationToken = default)
+    {
+        if (_recipients.Count == 0)
+        {
+            _logger.LogWarning("Skipping test email send because no recipients are configured.");
+            return;
+        }
+
+        var emailSubject = string.IsNullOrWhiteSpace(subject)
+            ? "TradingDaemon Email Test"
+            : subject!;
+        var bodyText = string.IsNullOrWhiteSpace(body)
+            ? "This is a test email from the TradingDaemon service."
+            : body!;
+        var sanitizedHtmlBody = WebUtility.HtmlEncode(bodyText).Replace("\n", "<br />");
+        var bodyHtml = $"<html><body><p>{sanitizedHtmlBody}</p></body></html>";
+
+        await SendEmailInternalAsync(emailSubject, bodyText, bodyHtml, cancellationToken);
+    }
+
+    private async Task SendEmailInternalAsync(string subject, string bodyText, string bodyHtml, CancellationToken cancellationToken)
+    {
         var request = new SendEmailRequest
         {
             Source = _fromAddress,
@@ -63,7 +91,7 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
             }
         };
 
-        _logger.LogInformation("Sending PnL email to {Recipients} with subject {Subject}", string.Join(", ", _recipients), subject);
+        _logger.LogInformation("Sending email to {Recipients} with subject {Subject}", string.Join(", ", _recipients), subject);
 
         await _sesClient.SendEmailAsync(request, cancellationToken);
     }


### PR DESCRIPTION
## Summary
- add a minimal API endpoint that triggers a test email send and documents it in Swagger
- extend the email notification service with reusable sending logic and support for test emails

## Testing
- `dotnet build` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de586f9b248333934b29273c8ea827