### PR TITLE
Fix email recipient configuration fallback

### DIFF
--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -27,8 +27,15 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
         var regionName = configuration["AWS:Region"] ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "eu-west-2";
         _sesClient = new AmazonSimpleEmailServiceClient(RegionEndpoint.GetBySystemName(regionName));
 
-        _fromAddress = configuration["Email:From"] ?? "intraday_bot@quantumqb.com";
-        var recipients = configuration.GetSection("Email:Recipients").Get<string[]>() ?? Array.Empty<string>();
+        _fromAddress = configuration["Email:From"]
+            ?? configuration["Automation:Email:From"]
+            ?? "intraday_bot@quantumqb.com";
+
+        var recipients = configuration.GetSection("Email:Recipients").Get<string[]>();
+        if (recipients is null || recipients.Length == 0)
+        {
+            recipients = configuration.GetSection("Automation:Email:Recipients").Get<string[]>() ?? Array.Empty<string>();
+        }
         _recipients = Array.AsReadOnly(recipients);
 
         if (_recipients.Count == 0)


### PR DESCRIPTION
## Summary
- read the Automation:Email configuration section when top-level email settings are not present
- ensure the notification service has a default from address and recipients from either configuration scope

## Testing
- dotnet test *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de5afefc2c8333ab10453bdaacf9c3