### PR TITLE
Expose email test error details

### DIFF
--- a/src/TradingDaemon/Controllers/EmailController.cs
+++ b/src/TradingDaemon/Controllers/EmailController.cs
@@ -20,7 +20,10 @@ public static class EmailController
             catch (Exception ex)
             {
                 logger.LogError(ex, "Failed to send test email");
-                return TypedResults.Problem("Failed to send test email.", statusCode: StatusCodes.Status500InternalServerError);
+                return TypedResults.Problem(
+                    title: "Failed to send test email.",
+                    detail: ex.Message,
+                    statusCode: StatusCodes.Status500InternalServerError);
             }
         })
         .WithName("SendTestEmail")


### PR DESCRIPTION
## Summary
- return the exception message in the test email failure response so clients can see the failure details

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de5d7d4c948333bcd7637940c803c3