### PR TITLE
Fix scheduler report fallback handling

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,8 +1,11 @@
+using System.Collections.Generic;
+using System.Linq;
 using Dapper;
 using Microsoft.Extensions.Logging;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
 using TradingDaemon.Services;
+using TradingDaemon.Utils;
 
 namespace TradingDaemon.Controllers;
 
@@ -36,9 +39,44 @@ public static class FillController
                        join w in weights on f.Symbol equals w.Symbol
                        select f.Quantity * (w.Value - f.Price)).Sum();
 
+            var positionGroups = fills
+                .GroupBy(f => f.Symbol)
+                .Select(group => new
+                {
+                    Symbol = group.Key,
+                    Quantity = group.Sum(f => f.Quantity),
+                    LastPrice = group.OrderByDescending(f => f.Timestamp).FirstOrDefault()?.Price
+                })
+                .Where(p => p.Quantity != 0m)
+                .ToList();
+
+            var positions = new List<PnlReportPosition>();
+            foreach (var position in positionGroups)
+            {
+                if (!CurrencyPairParser.TryParse(position.Symbol, out var pair))
+                {
+                    continue;
+                }
+
+                decimal? lastPrice = position.LastPrice;
+                decimal? usdValue = lastPrice.HasValue ? position.Quantity * lastPrice.Value : null;
+
+                positions.Add(new PnlReportPosition(
+                    pair.FormattedSymbol,
+                    pair.BaseCurrency,
+                    pair.QuoteCurrency,
+                    position.Quantity,
+                    lastPrice,
+                    usdValue));
+            }
+
+            var grossMarketValue = positions.Sum(p => Math.Abs(p.MarketValueUsd ?? 0m));
+            var totalNetExposure = positions.Sum(p => p.MarketValueUsd ?? 0m);
+            var report = new PnlReport(DateOnly.FromDateTime(date.Date), pnl, grossMarketValue, totalNetExposure, positions);
+
             try
             {
-                await emailNotificationService.SendPnLReportAsync(date.Date, pnl);
+                await emailNotificationService.SendPnLReportAsync(report);
             }
             catch (Exception ex)
             {
@@ -46,7 +84,14 @@ public static class FillController
                 return Results.Problem("Failed to send PnL email notification.", statusCode: StatusCodes.Status500InternalServerError);
             }
 
-            return Results.Ok(new { Date = date.Date, PnL = pnl });
+            return Results.Ok(new
+            {
+                Date = date.Date,
+                PnL = pnl,
+                GrossMarketValue = grossMarketValue,
+                TotalNetExposure = totalNetExposure,
+                Positions = positions
+            });
         });
     }
 }

--- a/src/TradingDaemon/Models/PnlReport.cs
+++ b/src/TradingDaemon/Models/PnlReport.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace TradingDaemon.Models;
+
+public sealed record PnlReport(
+    DateOnly TradingDate,
+    decimal Pnl,
+    decimal GrossMarketValue,
+    decimal TotalNetExposure,
+    IReadOnlyList<PnlReportPosition> Positions);
+
+public sealed record PnlReportPosition(
+    string Symbol,
+    string BaseCurrency,
+    string QuoteCurrency,
+    decimal NetQuantity,
+    decimal? LastPrice,
+    decimal? MarketValueUsd);

--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -1,14 +1,17 @@
-using System.Linq;
 using System.Net;
+using System.Globalization;
+using System.Linq;
+using System.Text;
 using Amazon;
 using Amazon.SimpleEmail;
 using Amazon.SimpleEmail.Model;
+using TradingDaemon.Models;
 
 namespace TradingDaemon.Services;
 
 public interface IEmailNotificationService
 {
-    Task SendPnLReportAsync(DateTime date, decimal pnl, CancellationToken cancellationToken = default);
+    Task SendPnLReportAsync(PnlReport report, CancellationToken cancellationToken = default);
     Task SendTestEmailAsync(string? subject = null, string? body = null, CancellationToken cancellationToken = default);
 }
 
@@ -44,19 +47,100 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
         }
     }
 
-    public async Task SendPnLReportAsync(DateTime date, decimal pnl, CancellationToken cancellationToken = default)
+    public async Task SendPnLReportAsync(PnlReport report, CancellationToken cancellationToken = default)
     {
         if (_recipients.Count == 0)
         {
             return;
         }
 
-        var subject = $"Intraday PnL for {date:yyyy-MM-dd}";
-        var bodyText = $"Date: {date:yyyy-MM-dd}\nPnL: {pnl:F2}";
-        var bodyHtml = $"<html><body><h1>Intraday PnL</h1><p><strong>Date:</strong> {date:yyyy-MM-dd}</p><p><strong>PnL:</strong> {pnl:F2}</p></body></html>";
+        var subject = $"Intraday PnL for {report.TradingDate:yyyy-MM-dd}";
+        var bodyText = BuildPlainTextBody(report);
+        var bodyHtml = BuildHtmlBody(report);
 
         await SendEmailInternalAsync(subject, bodyText, bodyHtml, cancellationToken);
     }
+
+    private static string BuildPlainTextBody(PnlReport report)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Date: {report.TradingDate:yyyy-MM-dd}");
+        sb.AppendLine($"PnL: {FormatCurrency(report.Pnl)}");
+        sb.AppendLine($"Gross Market Value: {FormatCurrency(report.GrossMarketValue)}");
+        sb.AppendLine($"Total Net Exposure: {FormatCurrency(report.TotalNetExposure)}");
+        sb.AppendLine();
+        sb.AppendLine("Positions:");
+
+        if (report.Positions.Count == 0)
+        {
+            sb.AppendLine("  (no open positions)");
+        }
+        else
+        {
+            foreach (var position in report.Positions.OrderByDescending(p => Math.Abs(p.MarketValueUsd ?? 0m)))
+            {
+                sb.Append("  - ");
+                sb.Append(position.Symbol);
+                sb.Append(": Qty=");
+                sb.Append(position.NetQuantity.ToString("F2", CultureInfo.InvariantCulture));
+                sb.Append(", Price=");
+                sb.Append(FormatOptionalNumber(position.LastPrice));
+                sb.Append(", USD Value=");
+                sb.Append(FormatOptionalCurrency(position.MarketValueUsd));
+                sb.AppendLine();
+            }
+        }
+
+        return sb.ToString();
+    }
+
+    private static string BuildHtmlBody(PnlReport report)
+    {
+        var sb = new StringBuilder();
+        sb.Append("<html><body><h1>Intraday PnL</h1>");
+        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>Date:</strong> {0:yyyy-MM-dd}</p>", report.TradingDate);
+        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>PnL:</strong> {0}</p>", FormatCurrency(report.Pnl));
+        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>Gross Market Value:</strong> {0}</p>", FormatCurrency(report.GrossMarketValue));
+        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>Total Net Exposure:</strong> {0}</p>", FormatCurrency(report.TotalNetExposure));
+
+        sb.Append("<h2>Positions</h2>");
+
+        if (report.Positions.Count == 0)
+        {
+            sb.Append("<p>No open positions.</p>");
+        }
+        else
+        {
+            sb.Append("<table border=\"1\" cellpadding=\"6\" cellspacing=\"0\">");
+            sb.Append("<thead><tr><th>Symbol</th><th>Quantity</th><th>Price</th><th>USD Value</th></tr></thead><tbody>");
+            foreach (var position in report.Positions.OrderByDescending(p => Math.Abs(p.MarketValueUsd ?? 0m)))
+            {
+                sb.Append("<tr>");
+                sb.AppendFormat(CultureInfo.InvariantCulture, "<td>{0}</td>", WebUtility.HtmlEncode(position.Symbol));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "<td>{0}</td>", position.NetQuantity.ToString("F2", CultureInfo.InvariantCulture));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "<td>{0}</td>", WebUtility.HtmlEncode(FormatOptionalNumber(position.LastPrice)));
+                sb.AppendFormat(CultureInfo.InvariantCulture, "<td>{0}</td>", WebUtility.HtmlEncode(FormatOptionalCurrency(position.MarketValueUsd)));
+                sb.Append("</tr>");
+            }
+            sb.Append("</tbody></table>");
+        }
+
+        sb.Append("</body></html>");
+        return sb.ToString();
+    }
+
+    private static string FormatCurrency(decimal value)
+        => value.ToString("F2", CultureInfo.InvariantCulture);
+
+    private static string FormatOptionalCurrency(decimal? value)
+        => value.HasValue
+            ? value.Value.ToString("F2", CultureInfo.InvariantCulture)
+            : "n/a";
+
+    private static string FormatOptionalNumber(decimal? value)
+        => value.HasValue
+            ? value.Value.ToString("F5", CultureInfo.InvariantCulture)
+            : "n/a";
 
     public async Task SendTestEmailAsync(string? subject = null, string? body = null, CancellationToken cancellationToken = default)
     {

--- a/src/TradingDaemon/Services/PnlReportService.cs
+++ b/src/TradingDaemon/Services/PnlReportService.cs
@@ -1,8 +1,13 @@
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
 using System.Threading;
 using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
 using TradingDaemon.Data;
+using TradingDaemon.Models;
+using TradingDaemon.Utils;
 
 namespace TradingDaemon.Services;
 
@@ -67,13 +72,61 @@ WHERE
     f.TradeTimestamp >= @StartUtc
     AND f.TradeTimestamp < @EndUtc;";
 
+    private const string SymbolSql = @"SELECT SecurityId, Symbol
+FROM [Intraday].[core].[Security]
+WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
+
+    private const string LatestPricesSql = @"SELECT SecurityId, [Close]
+FROM (
+    SELECT
+        pb.SecurityId,
+        pb.[Close],
+        ROW_NUMBER() OVER (PARTITION BY pb.SecurityId ORDER BY pb.BarTimeUtc DESC) AS rn
+    FROM [Intraday].[mkt].[PriceBar] pb
+    WHERE pb.TimeframeMinute = 60 AND pb.SecurityId IN @SecurityIds
+) src
+WHERE src.rn = 1;";
+
+    private const string PositionsSql = @"WITH Aggregated AS (
+    SELECT
+        f.SymbolId,
+        SUM(
+            CASE
+                WHEN UPPER(f.Side) IN ('SELL', 'S', 'SHORT', 'SS') THEN -1
+                WHEN UPPER(f.Side) IN ('BUY', 'B', 'LONG', 'L') THEN 1
+                ELSE CASE WHEN f.ExecuteSize < 0 THEN -1 ELSE 1 END
+            END * COALESCE(f.ExecuteSize, 0)
+        ) AS NetQuantity
+    FROM [wakett].[Fill] f
+    WHERE
+        f.TradeTimestamp >= @StartUtc
+        AND f.TradeTimestamp < @EndUtc
+    GROUP BY f.SymbolId
+), LatestFill AS (
+    SELECT
+        f.SymbolId,
+        COALESCE(f.ExecutePrice, 0) AS ExecutePrice,
+        ROW_NUMBER() OVER (PARTITION BY f.SymbolId ORDER BY f.TradeTimestamp DESC) AS rn
+    FROM [wakett].[Fill] f
+    WHERE
+        f.TradeTimestamp >= @StartUtc
+        AND f.TradeTimestamp < @EndUtc
+)
+SELECT
+    a.SymbolId,
+    a.NetQuantity,
+    lf.ExecutePrice AS LastExecutePrice
+FROM Aggregated a
+LEFT JOIN LatestFill lf ON lf.SymbolId = a.SymbolId AND lf.rn = 1
+WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
+
     public PnlReportService(DapperContext context, ILogger<PnlReportService> logger)
     {
         _context = context;
         _logger = logger;
     }
 
-    public async Task<decimal> ComputeAndStoreCurrentDayPnlAsync(DateTime? clock = null, CancellationToken cancellationToken = default)
+    public async Task<PnlReport> ComputeAndStoreCurrentDayPnlAsync(DateTime? clock = null, CancellationToken cancellationToken = default)
     {
         var nowUtc = (clock ?? DateTime.UtcNow).ToUniversalTime();
         var tradingDate = DateOnly.FromDateTime(nowUtc);
@@ -101,10 +154,20 @@ WHERE
                 },
                 cancellationToken: cancellationToken));
 
+        var symbolInfos = await LoadSymbolInfosAsync(connection, cancellationToken);
+        var priceLookup = symbolInfos.Count > 0
+            ? await LoadLatestPricesAsync(connection, symbolInfos.Keys, cancellationToken)
+            : new Dictionary<int, decimal?>();
+        var positions = await LoadPositionsAsync(connection, startUtc, endUtc, cancellationToken);
+        var reportPositions = BuildReportPositions(symbolInfos, priceLookup, positions);
+
+        var grossMarketValue = reportPositions.Sum(p => Math.Abs(p.MarketValueUsd ?? 0m));
+        var totalNetExposure = reportPositions.Sum(p => p.MarketValueUsd ?? 0m);
+
         _logger.LogInformation("Computed current day PnL for {Date}: {PnL}", tradingDate, pnlValue);
         Console.WriteLine($"Current day PnL: {pnlValue}");
 
-        return pnlValue;
+        return new PnlReport(tradingDate, pnlValue, grossMarketValue, totalNetExposure, reportPositions);
     }
 
     private async Task EnsureStorageAsync(SqlConnection connection, CancellationToken cancellationToken)
@@ -132,4 +195,202 @@ WHERE
             SchemaSemaphore.Release();
         }
     }
+
+    private async Task<Dictionary<int, CurrencyPair>> LoadSymbolInfosAsync(IDbConnection connection, CancellationToken cancellationToken)
+    {
+        var definition = new CommandDefinition(SymbolSql, cancellationToken: cancellationToken);
+        var rows = await connection.QueryAsync<SecuritySymbolRow>(definition);
+
+        var result = new Dictionary<int, CurrencyPair>();
+        foreach (var row in rows)
+        {
+            if (!CurrencyPairParser.TryParse(row.Symbol, out var pair))
+            {
+                continue;
+            }
+
+            result[row.SecurityId] = pair;
+        }
+
+        return result;
+    }
+
+    private async Task<Dictionary<int, decimal?>> LoadLatestPricesAsync(IDbConnection connection, IEnumerable<int> securityIds, CancellationToken cancellationToken)
+    {
+        var ids = securityIds.Distinct().ToArray();
+        if (ids.Length == 0)
+        {
+            return new Dictionary<int, decimal?>();
+        }
+
+        var definition = new CommandDefinition(LatestPricesSql, new { SecurityIds = ids }, cancellationToken: cancellationToken);
+        var rows = await connection.QueryAsync<LatestPriceRow>(definition);
+
+        return rows.ToDictionary(row => row.SecurityId, row => row.Close);
+    }
+
+    private async Task<IReadOnlyCollection<PositionRow>> LoadPositionsAsync(IDbConnection connection, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken)
+    {
+        var definition = new CommandDefinition(PositionsSql, new { StartUtc = startUtc, EndUtc = endUtc }, cancellationToken: cancellationToken);
+        var rows = await connection.QueryAsync<PositionRow>(definition);
+        return rows.ToList();
+    }
+
+    private IReadOnlyList<PnlReportPosition> BuildReportPositions(
+        IReadOnlyDictionary<int, CurrencyPair> symbolInfos,
+        IReadOnlyDictionary<int, decimal?> priceLookup,
+        IReadOnlyCollection<PositionRow> positions)
+    {
+        var conversionGraph = BuildConversionGraph(symbolInfos, priceLookup, positions);
+        var positionsList = new List<PnlReportPosition>();
+
+        foreach (var position in positions)
+        {
+            if (!symbolInfos.TryGetValue(position.SymbolId, out var pair))
+            {
+                _logger.LogDebug("Skipping position for unknown security {SecurityId}.", position.SymbolId);
+                continue;
+            }
+
+            var price = priceLookup.TryGetValue(position.SymbolId, out var latest) && latest.HasValue && latest.Value != 0m
+                ? latest.Value
+                : (position.LastExecutePrice is { } last && last != 0m ? last : (decimal?)null);
+
+            decimal? marketValueUsd = null;
+
+            if (TryGetConversionRate(pair.BaseCurrency, "USD", conversionGraph, out var baseToUsd))
+            {
+                marketValueUsd = position.NetQuantity * baseToUsd;
+            }
+            else if (price.HasValue && TryGetConversionRate(pair.QuoteCurrency, "USD", conversionGraph, out var quoteToUsd))
+            {
+                var quoteAmount = -position.NetQuantity * price.Value;
+                marketValueUsd = quoteAmount * quoteToUsd;
+            }
+
+            positionsList.Add(new PnlReportPosition(
+                pair.FormattedSymbol,
+                pair.BaseCurrency,
+                pair.QuoteCurrency,
+                position.NetQuantity,
+                price,
+                marketValueUsd));
+        }
+
+        return positionsList
+            .OrderByDescending(p => Math.Abs(p.MarketValueUsd ?? 0m))
+            .ThenBy(p => p.Symbol, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static Dictionary<string, List<(string Target, decimal Rate)>> BuildConversionGraph(
+        IReadOnlyDictionary<int, CurrencyPair> symbolInfos,
+        IReadOnlyDictionary<int, decimal?> priceLookup,
+        IReadOnlyCollection<PositionRow> positions)
+    {
+        var graph = new Dictionary<string, List<(string Target, decimal Rate)>>(StringComparer.OrdinalIgnoreCase);
+        var positionLookup = positions.ToDictionary(p => p.SymbolId);
+
+        foreach (var kvp in symbolInfos)
+        {
+            var price = priceLookup.TryGetValue(kvp.Key, out var close) && close.HasValue && close.Value != 0m
+                ? close.Value
+                : (positionLookup.TryGetValue(kvp.Key, out var pos) && pos.LastExecutePrice is { } last && last != 0m ? last : (decimal?)null);
+
+            if (!price.HasValue || price.Value == 0m)
+            {
+                continue;
+            }
+
+            AddEdge(graph, kvp.Value.BaseCurrency, kvp.Value.QuoteCurrency, price.Value);
+            if (price.Value != 0m)
+            {
+                AddEdge(graph, kvp.Value.QuoteCurrency, kvp.Value.BaseCurrency, 1m / price.Value);
+            }
+        }
+
+        graph.TryAdd("USD", new List<(string, decimal)>());
+        return graph;
+    }
+
+    private static void AddEdge(
+        IDictionary<string, List<(string Target, decimal Rate)>> graph,
+        string from,
+        string to,
+        decimal rate)
+    {
+        if (rate == 0m)
+        {
+            return;
+        }
+
+        if (!graph.TryGetValue(from, out var edges))
+        {
+            edges = new List<(string Target, decimal Rate)>();
+            graph[from] = edges;
+        }
+
+        edges.Add((to, rate));
+    }
+
+    private static bool TryGetConversionRate(
+        string source,
+        string target,
+        IReadOnlyDictionary<string, List<(string Target, decimal Rate)>> graph,
+        out decimal rate)
+    {
+        if (string.Equals(source, target, StringComparison.OrdinalIgnoreCase))
+        {
+            rate = 1m;
+            return true;
+        }
+
+        if (!graph.TryGetValue(source, out var initialEdges) || initialEdges.Count == 0)
+        {
+            rate = 0m;
+            return false;
+        }
+
+        var queue = new Queue<(string Currency, decimal Accumulated)>();
+        var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { source };
+
+        foreach (var edge in initialEdges)
+        {
+            queue.Enqueue((edge.Target, edge.Rate));
+        }
+
+        while (queue.Count > 0)
+        {
+            var (currency, accumulated) = queue.Dequeue();
+            if (!visited.Add(currency))
+            {
+                continue;
+            }
+
+            if (string.Equals(currency, target, StringComparison.OrdinalIgnoreCase))
+            {
+                rate = accumulated;
+                return true;
+            }
+
+            if (!graph.TryGetValue(currency, out var edges))
+            {
+                continue;
+            }
+
+            foreach (var edge in edges)
+            {
+                queue.Enqueue((edge.Target, accumulated * edge.Rate));
+            }
+        }
+
+        rate = 0m;
+        return false;
+    }
+
+    private sealed record SecuritySymbolRow(int SecurityId, string Symbol);
+
+    private sealed record LatestPriceRow(int SecurityId, decimal? Close);
+
+    private sealed record PositionRow(int SymbolId, decimal NetQuantity, decimal? LastExecutePrice);
 }

--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -1,3 +1,4 @@
+using System;
 using Quartz;
 
 namespace TradingDaemon.Services;
@@ -40,20 +41,41 @@ public class TradingJob : IJob
     private readonly WeightCalculator _weightCalculator;
     private readonly OrderSender _orderSender;
     private readonly PnlReportService _pnlReportService;
+    private readonly IEmailNotificationService _emailNotificationService;
 
-    public TradingJob(PriceFetcher priceFetcher, WeightCalculator weightCalculator, OrderSender orderSender, PnlReportService pnlReportService)
+    public TradingJob(
+        PriceFetcher priceFetcher,
+        WeightCalculator weightCalculator,
+        OrderSender orderSender,
+        PnlReportService pnlReportService,
+        IEmailNotificationService emailNotificationService)
     {
         _priceFetcher = priceFetcher;
         _weightCalculator = weightCalculator;
         _orderSender = orderSender;
         _pnlReportService = pnlReportService;
+        _emailNotificationService = emailNotificationService;
     }
 
     public async Task Execute(IJobExecutionContext context)
     {
         await _priceFetcher.FetchAndStoreAsync();
-        await _pnlReportService.ComputeAndStoreCurrentDayPnlAsync(cancellationToken: context.CancellationToken);
+        var report = await _pnlReportService.ComputeAndStoreCurrentDayPnlAsync(cancellationToken: context.CancellationToken);
+
+        if (ShouldSendReport(context))
+        {
+            await _emailNotificationService.SendPnLReportAsync(report, context.CancellationToken);
+        }
+
         await _weightCalculator.CalculateAndStoreAsync();
         await _orderSender.SendOrdersAsync();
+    }
+
+    private static bool ShouldSendReport(IJobExecutionContext context)
+    {
+        var scheduled = context.ScheduledFireTimeUtc
+            ?? (DateTimeOffset?)context.FireTimeUtc
+            ?? DateTimeOffset.UtcNow;
+        return scheduled.Minute == 0;
     }
 }

--- a/src/TradingDaemon/Utils/CurrencyPairParser.cs
+++ b/src/TradingDaemon/Utils/CurrencyPairParser.cs
@@ -1,0 +1,50 @@
+namespace TradingDaemon.Utils;
+
+internal static class CurrencyPairParser
+{
+    public static bool TryParse(string? symbol, out CurrencyPair pair)
+    {
+        pair = default!;
+
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            return false;
+        }
+
+        var trimmed = symbol.Trim();
+        var normalized = trimmed.ToUpperInvariant();
+
+        string baseCurrency;
+        string quoteCurrency;
+
+        if (normalized.Contains('/'))
+        {
+            var parts = normalized.Split('/');
+            if (parts.Length != 2 || parts[0].Length != 3 || parts[1].Length != 3)
+            {
+                return false;
+            }
+
+            baseCurrency = parts[0];
+            quoteCurrency = parts[1];
+        }
+        else if (normalized.Length == 6)
+        {
+            baseCurrency = normalized[..3];
+            quoteCurrency = normalized[3..6];
+        }
+        else
+        {
+            return false;
+        }
+
+        pair = new CurrencyPair(trimmed, baseCurrency, quoteCurrency);
+        return true;
+    }
+}
+
+internal sealed record CurrencyPair(string OriginalSymbol, string BaseCurrency, string QuoteCurrency)
+{
+    public string FormattedSymbol => $"{BaseCurrency}/{QuoteCurrency}";
+    public string ReversedFormattedSymbol => $"{QuoteCurrency}/{BaseCurrency}";
+}


### PR DESCRIPTION
## Summary
- adjust the scheduler's report timing fallback to avoid invalid null-coalescing between non-nullable DateTimeOffset values
- ensure the job still falls back to FireTimeUtc and current time when scheduled timestamps are missing

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68de62a0cec483338afe3a336f617af9