### PR TITLE
Fix scheduler configuration for PnL email job

### DIFF
--- a/src/TradingDaemon/Options/SchedulerOptions.cs
+++ b/src/TradingDaemon/Options/SchedulerOptions.cs
@@ -1,0 +1,7 @@
+namespace TradingDaemon.Options;
+
+public class SchedulerOptions
+{
+    public string? Cron { get; set; }
+    public string? TimeZone { get; set; }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -1,3 +1,5 @@
+using Quartz.Impl;
+using Quartz.Spi;
 using Serilog;
 using TradingDaemon.Controllers;
 using TradingDaemon.Data;
@@ -5,6 +7,7 @@ using TradingDaemon.Logging;
 using TradingDaemon.Services;
 using TradingDaemon.Models;
 using TradingDaemon.Utils;
+using TradingDaemon.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -50,12 +53,17 @@ builder.Services.AddTransient<ReportRunner>();
 builder.Services.AddTransient<WakettApiClient>();
 builder.Services.AddTransient<WakettPriceFetcher>();
 builder.Services.AddTransient<WakettTradeFetcher>();
+builder.Services.AddTransient<TradingJob>();
 
 
 builder.Services.Configure<WakettAutomationOptions>(builder.Configuration.GetSection("Automation:Wakett"));
 builder.Services.AddHostedService<WakettAutomationService>();
 
 builder.Services.AddSingleton<IEmailNotificationService, EmailNotificationService>();
+builder.Services.Configure<SchedulerOptions>(builder.Configuration.GetSection("Quartz"));
+builder.Services.AddSingleton<ISchedulerFactory, StdSchedulerFactory>();
+builder.Services.AddSingleton<IJobFactory, DependencyInjectionJobFactory>();
+builder.Services.AddHostedService<SchedulerService>();
 
 
 

--- a/src/TradingDaemon/Services/DependencyInjectionJobFactory.cs
+++ b/src/TradingDaemon/Services/DependencyInjectionJobFactory.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+using Quartz;
+using Quartz.Spi;
+
+namespace TradingDaemon.Services;
+
+public sealed class DependencyInjectionJobFactory : IJobFactory
+{
+    private readonly IServiceProvider _serviceProvider;
+
+    public DependencyInjectionJobFactory(IServiceProvider serviceProvider)
+    {
+        _serviceProvider = serviceProvider;
+    }
+
+    public IJob NewJob(TriggerFiredBundle bundle, IScheduler scheduler)
+    {
+        var jobType = bundle.JobDetail.JobType;
+        return (IJob)_serviceProvider.GetRequiredService(jobType);
+    }
+
+    public void ReturnJob(IJob job)
+    {
+        if (job is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
+    }
+}

--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -1,27 +1,51 @@
 using System;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Quartz;
+using Quartz.Spi;
+using TradingDaemon.Options;
 
 namespace TradingDaemon.Services;
 
 public class SchedulerService : IHostedService
 {
     private readonly ISchedulerFactory _schedulerFactory;
+    private readonly IJobFactory _jobFactory;
+    private readonly IOptionsMonitor<SchedulerOptions> _optionsMonitor;
+    private readonly ILogger<SchedulerService> _logger;
     private IScheduler? _scheduler;
 
-    public SchedulerService(ISchedulerFactory schedulerFactory)
+    public SchedulerService(
+        ISchedulerFactory schedulerFactory,
+        IJobFactory jobFactory,
+        IOptionsMonitor<SchedulerOptions> optionsMonitor,
+        ILogger<SchedulerService> logger)
     {
         _schedulerFactory = schedulerFactory;
+        _jobFactory = jobFactory;
+        _optionsMonitor = optionsMonitor;
+        _logger = logger;
     }
 
     public async Task StartAsync(CancellationToken cancellationToken)
     {
         _scheduler = await _schedulerFactory.GetScheduler(cancellationToken);
+        _scheduler.JobFactory = _jobFactory;
+
+        var schedulerOptions = _optionsMonitor.CurrentValue;
+        var cron = string.IsNullOrWhiteSpace(schedulerOptions.Cron)
+            ? "0 0/30 7-19 ? * *"
+            : schedulerOptions.Cron;
+        var timeZoneId = string.IsNullOrWhiteSpace(schedulerOptions.TimeZone)
+            ? TimeZoneInfo.Utc.Id
+            : schedulerOptions.TimeZone;
+
+        var timeZone = ResolveTimeZone(timeZoneId);
 
         var job = JobBuilder.Create<TradingJob>().WithIdentity("TradingJob").Build();
-        var cron = "0 0/30 7-19 ? * *";
-        var tz = TimeZoneInfo.FindSystemTimeZoneById("GMT Standard Time");
         var trigger = TriggerBuilder.Create()
-            .WithSchedule(CronScheduleBuilder.CronSchedule(cron).InTimeZone(tz))
+            .WithIdentity("TradingJobTrigger")
+            .WithSchedule(CronScheduleBuilder.CronSchedule(cron).InTimeZone(timeZone))
             .Build();
 
         await _scheduler.ScheduleJob(job, trigger, cancellationToken);
@@ -32,6 +56,46 @@ public class SchedulerService : IHostedService
     {
         if (_scheduler != null)
             await _scheduler.Shutdown(cancellationToken);
+    }
+
+    private TimeZoneInfo ResolveTimeZone(string timeZoneId)
+    {
+        try
+        {
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch ((TimeZoneNotFoundException or InvalidTimeZoneException) ex) when (TryResolveAlternate(timeZoneId, out var timeZone))
+        {
+            _logger.LogWarning(ex, "Falling back to alternate time zone ID {Fallback} for configured ID {Configured}", timeZone.Id, timeZoneId);
+            return timeZone;
+        }
+
+        throw;
+    }
+
+    private static bool TryResolveAlternate(string timeZoneId, out TimeZoneInfo timeZone)
+    {
+        if (!TimeZoneInfo.TryConvertWindowsIdToIanaId(timeZoneId, out var ianaId))
+        {
+            timeZone = null!;
+            return false;
+        }
+
+        try
+        {
+            timeZone = TimeZoneInfo.FindSystemTimeZoneById(ianaId);
+            return true;
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            timeZone = null!;
+            return false;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            timeZone = null!;
+            return false;
+        }
     }
 }
 

--- a/tests/TradingDaemon.Tests/SchedulerServiceTests.cs
+++ b/tests/TradingDaemon.Tests/SchedulerServiceTests.cs
@@ -1,8 +1,11 @@
 using Xunit;
 using Moq;
 using Quartz;
+using Quartz.Spi;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using TradingDaemon.Options;
 using TradingDaemon.Services;
-using Microsoft.Extensions.DependencyInjection;
 
 public class SchedulerServiceTests
 {
@@ -12,7 +15,16 @@ public class SchedulerServiceTests
         var schedulerFactory = new Mock<ISchedulerFactory>();
         var scheduler = new Mock<IScheduler>();
         schedulerFactory.Setup(f => f.GetScheduler(It.IsAny<CancellationToken>())).ReturnsAsync(scheduler.Object);
-        var service = new SchedulerService(schedulerFactory.Object, new ServiceCollection().BuildServiceProvider());
+
+        var jobFactory = new Mock<IJobFactory>();
+        var optionsMonitor = Mock.Of<IOptionsMonitor<SchedulerOptions>>(o => o.CurrentValue == new SchedulerOptions
+        {
+            Cron = "0 0/30 * * * ?",
+            TimeZone = "UTC"
+        });
+        var logger = Mock.Of<ILogger<SchedulerService>>();
+
+        var service = new SchedulerService(schedulerFactory.Object, jobFactory.Object, optionsMonitor, logger);
 
         await service.StartAsync(CancellationToken.None);
 


### PR DESCRIPTION
## Summary
- register Quartz scheduler infrastructure and hosted service so the trading job can run on schedule
- add a DI-backed job factory and scheduler options binding to support dependency injection and configuration-driven cron/time zone settings
- add resilient time zone resolution so Linux hosts can interpret the configured Windows time zone ID

## Testing
- `dotnet build` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfee0abb6c8333adeda7383272bd37