### PR TITLE
Allow automation to continue when prices incomplete

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -173,8 +173,8 @@ public sealed class WakettAutomationService : BackgroundService
 
         if (!pricesComplete)
         {
-            _logger.LogWarning("Skipping weight calculation and order submission because prices are incomplete.");
-            return;
+            _logger.LogWarning(
+                "Recent Wakett prices are incomplete; continuing automation workflow.");
         }
 
         try


### PR DESCRIPTION
## Summary
- continue the Wakett automation workflow even when recent prices are incomplete
- log a warning instead of skipping weight calculations and order submission

## Testing
- dotnet build TradingDaemon.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb56fee88333b4eb7f5e199d2ba6