### PR TITLE
Fix Dapper materialization for PnL report

### DIFF
--- a/src/TradingDaemon/Services/PnlReportService.cs
+++ b/src/TradingDaemon/Services/PnlReportService.cs
@@ -506,7 +506,12 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
         return false;
     }
 
-    private sealed record SecuritySymbolRow(int SecurityId, string Symbol);
+    private sealed record SecuritySymbolRow
+    {
+        public int SecurityId { get; init; }
+
+        public string? Symbol { get; init; }
+    }
 
     private sealed record LatestPriceRow(int SecurityId, decimal? Close);
 


### PR DESCRIPTION
## Summary
- update the PnL report security-symbol projection to use an init-only record that Dapper can materialize

## Testing
- dotnet build TradingDaemon.sln *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e5143ac6988333a3303b154a9262c5