### PR TITLE
Fix Dapper materialization error for latest prices

### DIFF
--- a/src/TradingDaemon/Services/PnlReportService.cs
+++ b/src/TradingDaemon/Services/PnlReportService.cs
@@ -513,7 +513,12 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
         public string? Symbol { get; init; }
     }
 
-    private sealed record LatestPriceRow(int SecurityId, decimal? Close);
+    private sealed record LatestPriceRow
+    {
+        public int SecurityId { get; init; }
+
+        public decimal? Close { get; init; }
+    }
 
     private sealed record PositionRow(string? SymbolId, string? Symbol, decimal NetQuantity, decimal? LastExecutePrice);
 


### PR DESCRIPTION
## Summary
- update the latest price projection record to expose init-only properties so Dapper can materialize query results

## Testing
- `dotnet build` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68e53492ec2c833384051bb4120620fa