### PR TITLE
Force EOF execution on flat Wakett orders

### DIFF
--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -28,6 +28,8 @@ public class WakettOrderRequest
 {
     public string? ts { get; set; }
     public double? aum { get; set; }
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? execution { get; set; }
     public List<WakettOrderItem> orders { get; set; } = new();
 }
 

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -119,7 +119,8 @@ public class OrderSender
         }
 
         var builtOrders = BuildOrders(latestWeights, symbolMap, allowedSymbols, orderTimestampUtc);
-        if (builtOrders.Count == 0 || builtOrders.All(order => order.Order.size?.value == 0d))
+        var isFlatOrderRequest = builtOrders.Count == 0 || builtOrders.All(order => order.Order.size?.value == 0d);
+        if (isFlatOrderRequest)
         {
             _logger.LogInformation("All Wakett order weights are zero. Submitting flat order request.");
         }
@@ -174,6 +175,7 @@ public class OrderSender
         {
             ts = FormatTimestamp(orderTimestampUtc),
             aum = aum,
+            execution = isFlatOrderRequest ? "EOF" : null,
             orders = orders
         };
 

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -87,6 +87,7 @@ public class OrderSenderTests
             0);
         Assert.Equal(OrderSender.FormatTimestamp(expectedOrderTimestampUtc), root.GetProperty("ts").GetString());
         Assert.Equal(2_500_000d, root.GetProperty("aum").GetDouble());
+        Assert.False(root.TryGetProperty("execution", out _));
 
         var orders = root.GetProperty("orders");
         Assert.Equal(2, orders.GetArrayLength());
@@ -176,6 +177,9 @@ public class OrderSenderTests
             "US",
             60,
             0);
+
+        Assert.True(root.TryGetProperty("execution", out var execution));
+        Assert.Equal("EOF", execution.GetString());
 
         var orders = root.GetProperty("orders");
         Assert.Equal(2, orders.GetArrayLength());


### PR DESCRIPTION
## Summary
- add the Wakett order execution field so requests can express execution instructions
- send flat Wakett order submissions with EOF execution to force closing positions
- extend order sender tests to assert execution is only set for flat submissions

## Testing
- dotnet test *(fails: dotnet CLI is not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a16abb2083338a5062183e0d7408)