### PR TITLE
Allow environment overrides for external API configuration

### DIFF
--- a/src/TradingDaemon/Data/DapperContext.cs
+++ b/src/TradingDaemon/Data/DapperContext.cs
@@ -1,9 +1,11 @@
+using System;
 using System.Data;
 using Amazon;
 using Amazon.SecretsManager;
 using Amazon.SecretsManager.Model;
 using Microsoft.Data.SqlClient;
 using System.Text.Json;
+using System.Globalization;
 
 namespace TradingDaemon.Data;
 
@@ -20,21 +22,49 @@ public class DapperContext
             return;
         }
 
-        var secretName = "qq-intraday-credentials";
+        var secretName = configuration["Database:SecretName"] ?? "qq-intraday-credentials";
         var region = configuration["AWS:Region"] ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "eu-west-2";
 
         using var client = new AmazonSecretsManagerClient(RegionEndpoint.GetBySystemName(region));
         var request = new GetSecretValueRequest { SecretId = secretName };
         var response = client.GetSecretValueAsync(request).GetAwaiter().GetResult();
-        var secretJson = response.SecretString ?? throw new InvalidOperationException("Secret string is empty");
+        var secretJson = response.SecretString ?? throw new InvalidOperationException($"Secret '{secretName}' is empty.");
         var doc = JsonDocument.Parse(secretJson).RootElement;
+
         var host = doc.GetProperty("host").GetString();
         var username = doc.GetProperty("username").GetString();
         var password = doc.GetProperty("password").GetString();
         var dbname = doc.TryGetProperty("database", out var dbEl) ? dbEl.GetString() : string.Empty;
-        var port = doc.TryGetProperty("port", out var portEl) ? Int32.Parse(portEl.GetString()) : 1433;
+        var port = doc.TryGetProperty("port", out var portEl)
+            ? int.Parse(portEl.GetString() ?? "1433", CultureInfo.InvariantCulture)
+            : 1433;
 
-        _connectionString = $"Server={host},{port};Database={dbname};User Id={username};Password={password};Encrypt=True;TrustServerCertificate=True;";
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            throw new InvalidOperationException($"Secret '{secretName}' does not contain a valid host value.");
+        }
+
+        if (string.IsNullOrWhiteSpace(username))
+        {
+            throw new InvalidOperationException($"Secret '{secretName}' does not contain a valid username value.");
+        }
+
+        if (password is null)
+        {
+            throw new InvalidOperationException($"Secret '{secretName}' does not contain a password value.");
+        }
+
+        var builder = new SqlConnectionStringBuilder
+        {
+            DataSource = $"{host},{port}",
+            InitialCatalog = dbname ?? string.Empty,
+            UserID = username,
+            Password = password,
+            Encrypt = true,
+            TrustServerCertificate = true
+        };
+
+        _connectionString = builder.ConnectionString;
     }
 
     public virtual IDbConnection CreateConnection()

--- a/src/TradingDaemon/Data/DatabaseObjectIdentifier.cs
+++ b/src/TradingDaemon/Data/DatabaseObjectIdentifier.cs
@@ -1,0 +1,20 @@
+namespace TradingDaemon.Data;
+
+public readonly record struct DatabaseObjectIdentifier(string Key)
+{
+    public override string ToString() => Key;
+}
+
+public static class DatabaseObjects
+{
+    public static readonly DatabaseObjectIdentifier IntradayModelNettedWeight = new("Intraday.model.NettedWeight");
+    public static readonly DatabaseObjectIdentifier IntradayModel = new("Intraday.model.Model");
+    public static readonly DatabaseObjectIdentifier IntradayCoreSecurity = new("Intraday.core.Security");
+    public static readonly DatabaseObjectIdentifier IntradayMarketPriceBar = new("Intraday.mkt.PriceBar");
+    public static readonly DatabaseObjectIdentifier IntradayMarketStageHistClose = new("Intraday.mkt.Stage_HistClose");
+    public static readonly DatabaseObjectIdentifier IntradayStagingFlatBar = new("Intraday.dbo.mkt_FlatBar_Staging");
+    public static readonly DatabaseObjectIdentifier WakettFill = new("wakett.Fill");
+    public static readonly DatabaseObjectIdentifier WakettTradingLimit = new("wakett.TradingLimit");
+    public static readonly DatabaseObjectIdentifier WakettTradingLimitBreachReport = new("wakett.TradingLimitBreachReport");
+    public static readonly DatabaseObjectIdentifier WakettOrder = new("wakett.Order");
+}

--- a/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
+++ b/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
@@ -1,0 +1,90 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Options;
+using TradingDaemon.Options;
+
+namespace TradingDaemon.Data;
+
+public interface IDatabaseObjectNameProvider
+{
+    string GetObjectName(DatabaseObjectIdentifier identifier);
+}
+
+public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
+{
+    private static readonly IReadOnlyDictionary<string, string> DefaultNames = new Dictionary<string, string>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        [DatabaseObjects.IntradayModelNettedWeight.Key] = "[Intraday].[model].[NettedWeight]",
+        [DatabaseObjects.IntradayModel.Key] = "[Intraday].[model].[Model]",
+        [DatabaseObjects.IntradayCoreSecurity.Key] = "[Intraday].[core].[Security]",
+        [DatabaseObjects.IntradayMarketPriceBar.Key] = "[Intraday].[mkt].[PriceBar]",
+        [DatabaseObjects.IntradayMarketStageHistClose.Key] = "[Intraday].[mkt].[Stage_HistClose]",
+        [DatabaseObjects.IntradayStagingFlatBar.Key] = "[Intraday].[dbo].[mkt_FlatBar_Staging]",
+        [DatabaseObjects.WakettFill.Key] = "[wakett].[Fill]",
+        [DatabaseObjects.WakettTradingLimit.Key] = "[wakett].[TradingLimit]",
+        [DatabaseObjects.WakettTradingLimitBreachReport.Key] = "[wakett].[TradingLimitBreachReport]",
+        [DatabaseObjects.WakettOrder.Key] = "[wakett].[Order]"
+    };
+
+    private readonly IReadOnlyDictionary<string, string> _names;
+
+    public DatabaseObjectNameProvider(IOptions<DatabaseObjectNameOptions>? optionsAccessor = null)
+    {
+        var names = new Dictionary<string, string>(DefaultNames, StringComparer.OrdinalIgnoreCase);
+        var options = optionsAccessor?.Value;
+
+        if (options is not null)
+        {
+            Merge(names, options.Objects);
+
+            var environment = ResolveEnvironment(options);
+            if (environment?.Objects is not null)
+            {
+                Merge(names, environment.Objects);
+            }
+        }
+
+        _names = names;
+    }
+
+    public string GetObjectName(DatabaseObjectIdentifier identifier)
+    {
+        if (!_names.TryGetValue(identifier.Key, out var value))
+        {
+            throw new InvalidOperationException($"Database object '{identifier.Key}' is not configured.");
+        }
+
+        return value;
+    }
+
+    private static void Merge(Dictionary<string, string> target, IDictionary<string, string>? source)
+    {
+        if (source is null)
+        {
+            return;
+        }
+
+        foreach (var pair in source)
+        {
+            if (string.IsNullOrWhiteSpace(pair.Key) || string.IsNullOrWhiteSpace(pair.Value))
+            {
+                continue;
+            }
+
+            target[pair.Key] = pair.Value;
+        }
+    }
+
+    private static DatabaseObjectNameEnvironment? ResolveEnvironment(DatabaseObjectNameOptions options)
+    {
+        if (string.IsNullOrWhiteSpace(options.ActiveEnvironment))
+        {
+            return null;
+        }
+
+        return options.Environments != null
+            && options.Environments.TryGetValue(options.ActiveEnvironment, out var environment)
+            ? environment
+            : null;
+    }
+}

--- a/src/TradingDaemon/Options/DatabaseObjectNameOptions.cs
+++ b/src/TradingDaemon/Options/DatabaseObjectNameOptions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+
+namespace TradingDaemon.Options;
+
+public class DatabaseObjectNameOptions
+{
+    public string? ActiveEnvironment { get; set; }
+        = "Prod";
+
+    public Dictionary<string, string> Objects { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+
+    public Dictionary<string, DatabaseObjectNameEnvironment> Environments { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+}
+
+public class DatabaseObjectNameEnvironment
+{
+    public Dictionary<string, string> Objects { get; set; }
+        = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -12,9 +12,16 @@ using TradingDaemon.Options;
 
 var builder = WebApplication.CreateBuilder(args);
 
+ConfigurationEnvironmentExtensions.ApplyEnvironmentOverrides(
+    builder.Configuration,
+    "ExternalApis",
+    builder.Configuration["Database:ActiveEnvironment"]);
+
 SerilogConfig.Configure(builder.Configuration);
 builder.Host.UseSerilog();
 
+builder.Services.Configure<DatabaseObjectNameOptions>(builder.Configuration.GetSection("Database"));
+builder.Services.AddSingleton<IDatabaseObjectNameProvider, DatabaseObjectNameProvider>();
 builder.Services.AddSingleton<DapperContext>();
 
 builder.Services.AddHttpClient("PriceApi", client =>

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -49,12 +49,19 @@ public class OrderSender
     private readonly ILogger<OrderSender> _logger;
     private readonly IConfiguration _configuration;
     private readonly TimeProvider _timeProvider;
+    private readonly string _nettedWeightTable;
+    private readonly string _modelTable;
+    private readonly string _securityTable;
+    private readonly string _tradingLimitTable;
+    private readonly string _orderTable;
+    private readonly string _tradingLimitBreachTable;
 
     public OrderSender(
         WakettApiClient wakettApiClient,
         DapperContext context,
         ILogger<OrderSender> logger,
         IConfiguration configuration,
+        IDatabaseObjectNameProvider databaseNameProvider,
         TimeProvider? timeProvider = null)
     {
         _wakettApiClient = wakettApiClient;
@@ -62,6 +69,12 @@ public class OrderSender
         _logger = logger;
         _configuration = configuration;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _nettedWeightTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayModelNettedWeight);
+        _modelTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayModel);
+        _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
+        _tradingLimitTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettTradingLimit);
+        _orderTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettOrder);
+        _tradingLimitBreachTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettTradingLimitBreachReport);
     }
 
     public async Task SendOrdersAsync(double? aumOverride = null, CancellationToken cancellationToken = default)
@@ -274,7 +287,7 @@ public class OrderSender
                 requestLookup[key] = order;
             }
 
-            const string insertSql = @"INSERT INTO [wakett].[Order]
+            var insertSql = $@"INSERT INTO {_orderTable}
 (
     ModelId,
     OrderCode,
@@ -383,7 +396,7 @@ VALUES
             return Array.Empty<string>();
         }
 
-        const string selectSql = @"SELECT Symbol FROM [wakett].[Order]
+        var selectSql = $@"SELECT Symbol FROM {_orderTable}
 WHERE ModelId = @ModelId AND ScheduledTimestamp = @ScheduledTimestamp AND Symbol IN @Symbols;";
 
         try
@@ -454,7 +467,7 @@ WHERE ModelId = @ModelId AND ScheduledTimestamp = @ScheduledTimestamp AND Symbol
 
             var aumValue = aum.HasValue ? (decimal?)aum.Value : null;
 
-            const string insertSql = @"INSERT INTO [wakett].[TradingLimitBreachReport]
+            var insertSql = $@"INSERT INTO {_tradingLimitBreachTable}
 (
     ModelId,
     LimitType,
@@ -908,13 +921,13 @@ VALUES
         IDbConnection connection,
         CancellationToken cancellationToken)
     {
-        const string sql = @"SELECT TOP (1000)
+        var sql = $@"SELECT TOP (1000)
     nw.SecurityId,
     nw.ModelId,
     nw.BarTimeUtc,
     nw.ModelRunId,
     nw.Weight
-FROM [Intraday].[model].[NettedWeight] nw
+FROM {_nettedWeightTable} nw
 WHERE nw.ModelId = @ModelId
 ORDER BY nw.BarTimeUtc DESC, nw.SecurityId";
 
@@ -931,10 +944,10 @@ ORDER BY nw.BarTimeUtc DESC, nw.SecurityId";
         IDbConnection connection,
         CancellationToken cancellationToken)
     {
-        const string sql = @"SELECT TOP (1)
+        var sql = $@"SELECT TOP (1)
     BarSize,
     Offset
-FROM [Intraday].[model].[Model]
+FROM {_modelTable}
 WHERE ModelId = @ModelId
 ORDER BY ModelId";
 
@@ -951,7 +964,7 @@ ORDER BY ModelId";
         IDbConnection connection,
         CancellationToken cancellationToken)
     {
-        const string sql = @"SELECT TOP (1)
+        var sql = $@"SELECT TOP (1)
     TradingLimitId,
     ModelId,
     SingleTradeGrossLimit,
@@ -959,7 +972,7 @@ ORDER BY ModelId";
     PortfolioNetLimit,
     SingleTradeTurnoverLimit,
     TotalTurnoverLimit
-FROM [wakett].[TradingLimit]
+FROM {_tradingLimitTable}
 WHERE ModelId = @ModelId
 ORDER BY TradingLimitId DESC;";
 
@@ -1002,8 +1015,8 @@ ORDER BY TradingLimitId DESC;";
         IDbConnection connection,
         CancellationToken cancellationToken)
     {
-        const string sql = @"SELECT SecurityId, Symbol
-FROM [Intraday].[core].[Security]
+        var sql = $@"SELECT SecurityId, Symbol
+FROM {_securityTable}
 WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
         var definition = new CommandDefinition(sql, cancellationToken: cancellationToken);

--- a/src/TradingDaemon/Services/PnlReportService.cs
+++ b/src/TradingDaemon/Services/PnlReportService.cs
@@ -47,7 +47,7 @@ WHEN NOT MATCHED THEN
     INSERT (TradingDate, CalculatedAtUtc, PnL)
     VALUES (source.TradingDate, source.CalculatedAtUtc, source.PnL);";
 
-    private const string PnlFillsSql = @"
+    private const string PnlFillsSqlTemplate = @"
 WITH FillWithSecurity AS (
     SELECT
         f.ExecuteSize,
@@ -57,14 +57,14 @@ WITH FillWithSecurity AS (
         f.SymbolId,
         f.Symbol,
         COALESCE(secById.SecurityId, secBySymbol.SecurityId) AS SecurityId
-    FROM [wakett].[Fill] f
+    FROM {WakettFill} f
     OUTER APPLY (
         SELECT
             TRY_CAST(NULLIF(LTRIM(RTRIM(f.SymbolId)), '') AS bigint) AS SymbolSecurityId,
             UPPER(REPLACE(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(f.Symbol)), '/', ''), '-', ''), '_', ''), ' ', '')) AS NormalizedSymbol
     ) parsed
-    LEFT JOIN [Intraday].[core].[Security] secById ON secById.SecurityId = parsed.SymbolSecurityId
-    LEFT JOIN [Intraday].[core].[Security] secBySymbol ON secById.SecurityId IS NULL
+    LEFT JOIN {IntradayCoreSecurity} secById ON secById.SecurityId = parsed.SymbolSecurityId
+    LEFT JOIN {IntradayCoreSecurity} secBySymbol ON secById.SecurityId IS NULL
         AND parsed.NormalizedSymbol IS NOT NULL
         AND UPPER(REPLACE(REPLACE(REPLACE(REPLACE(LTRIM(RTRIM(secBySymbol.Symbol)), '/', ''), '-', ''), '_', ''), ' ', '')) = parsed.NormalizedSymbol
     WHERE
@@ -82,28 +82,28 @@ FROM FillWithSecurity;
 ";
 
 
-    private const string SymbolSql = @"SELECT SecurityId, Symbol
-FROM [Intraday].[core].[Security]
+    private const string SymbolSqlTemplate = @"SELECT SecurityId, Symbol
+FROM {IntradayCoreSecurity}
 WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
-    private const string LatestPricesSql = @"SELECT SecurityId, [Close]
+    private const string LatestPricesSqlTemplate = @"SELECT SecurityId, [Close]
 FROM (
     SELECT
         pb.SecurityId,
         pb.[Close],
         ROW_NUMBER() OVER (PARTITION BY pb.SecurityId ORDER BY pb.BarTimeUtc DESC) AS rn
-    FROM [Intraday].[mkt].[PriceBar] pb
+    FROM {IntradayMarketPriceBar} pb
         WHERE pb.TimeframeMinute = 60 AND pb.SecurityId IN @SecurityIds
 ) src
 WHERE src.rn = 1;";
 
-    private const string LatestPricesForDaySql = @"SELECT SecurityId, [Close]
+    private const string LatestPricesForDaySqlTemplate = @"SELECT SecurityId, [Close]
 FROM (
     SELECT
         pb.SecurityId,
         pb.[Close],
         ROW_NUMBER() OVER (PARTITION BY pb.SecurityId ORDER BY pb.BarTimeUtc DESC) AS rn
-    FROM [Intraday].[mkt].[PriceBar] pb
+    FROM {IntradayMarketPriceBar} pb
     WHERE
         pb.TimeframeMinute = 60
         AND pb.SecurityId IN @SecurityIds
@@ -111,7 +111,7 @@ FROM (
 ) src
 WHERE src.rn = 1;";
 
-    private const string PositionsSql = @"WITH Aggregated AS (
+    private const string PositionsSqlTemplate = @"WITH Aggregated AS (
     SELECT
         f.SymbolId,
         MAX(f.Symbol) AS Symbol,
@@ -122,7 +122,7 @@ WHERE src.rn = 1;";
                 ELSE CASE WHEN f.ExecuteSize < 0 THEN -1 ELSE 1 END
             END * COALESCE(f.ExecuteSize, 0)
         ) AS NetQuantity
-    FROM [wakett].[Fill] f
+    FROM {WakettFill} f
     WHERE
         f.TradeTimestamp >= @StartUtc
         AND f.TradeTimestamp < @EndUtc
@@ -133,7 +133,7 @@ WHERE src.rn = 1;";
         f.Symbol,
         COALESCE(f.ExecutePrice, 0) AS ExecutePrice,
         ROW_NUMBER() OVER (PARTITION BY f.SymbolId ORDER BY f.TradeTimestamp DESC) AS rn
-    FROM [wakett].[Fill] f
+    FROM {WakettFill} f
     WHERE
         f.TradeTimestamp >= @StartUtc
         AND f.TradeTimestamp < @EndUtc
@@ -147,10 +147,30 @@ FROM Aggregated a
 LEFT JOIN LatestFill lf ON lf.SymbolId = a.SymbolId AND lf.rn = 1
 WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
 
-    public PnlReportService(DapperContext context, ILogger<PnlReportService> logger)
+    private readonly string _pnlFillsSql;
+    private readonly string _symbolSql;
+    private readonly string _latestPricesSql;
+    private readonly string _latestPricesForDaySql;
+    private readonly string _positionsSql;
+    private readonly string _fillTable;
+    private readonly string _securityTable;
+    private readonly string _priceBarTable;
+
+    public PnlReportService(
+        DapperContext context,
+        ILogger<PnlReportService> logger,
+        IDatabaseObjectNameProvider databaseNameProvider)
     {
         _context = context;
         _logger = logger;
+        _fillTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettFill);
+        _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
+        _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
+        _pnlFillsSql = FormatSql(PnlFillsSqlTemplate);
+        _symbolSql = FormatSql(SymbolSqlTemplate);
+        _latestPricesSql = FormatSql(LatestPricesSqlTemplate);
+        _latestPricesForDaySql = FormatSql(LatestPricesForDaySqlTemplate);
+        _positionsSql = FormatSql(PositionsSqlTemplate);
     }
 
     public async Task<PnlReport> ComputeAndStoreCurrentDayPnlAsync(DateTime? clock = null, CancellationToken cancellationToken = default)
@@ -239,7 +259,7 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
 
     private async Task<Dictionary<string, SymbolInfo>> LoadSymbolInfosAsync(IDbConnection connection, CancellationToken cancellationToken)
     {
-        var definition = new CommandDefinition(SymbolSql, cancellationToken: cancellationToken);
+        var definition = new CommandDefinition(_symbolSql, cancellationToken: cancellationToken);
         var rows = await connection.QueryAsync<SecuritySymbolRow>(definition);
 
         var result = new Dictionary<string, SymbolInfo>(StringComparer.OrdinalIgnoreCase);
@@ -283,7 +303,7 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
     private async Task<IReadOnlyCollection<PnlFillRow>> LoadPnlFillRowsAsync(IDbConnection connection, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken)
     {
         var definition = new CommandDefinition(
-            PnlFillsSql,
+            _pnlFillsSql,
             new { StartUtc = startUtc, EndUtc = endUtc },
             cancellationToken: cancellationToken);
         var rows = await connection.QueryAsync<PnlFillRow>(definition);
@@ -298,7 +318,7 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
             return new Dictionary<long, decimal?>();
         }
 
-        var definition = new CommandDefinition(LatestPricesSql, new { SecurityIds = ids }, cancellationToken: cancellationToken);
+        var definition = new CommandDefinition(_latestPricesSql, new { SecurityIds = ids }, cancellationToken: cancellationToken);
         var rows = await connection.QueryAsync<LatestPriceRow>(definition);
 
         return rows.ToDictionary(row => row.SecurityId, row => row.Close);
@@ -313,7 +333,7 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
         }
 
         var definition = new CommandDefinition(
-            LatestPricesForDaySql,
+            _latestPricesForDaySql,
             new { SecurityIds = ids, EndUtc = endUtc },
             cancellationToken: cancellationToken);
         var rows = await connection.QueryAsync<LatestPriceRow>(definition);
@@ -323,7 +343,7 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
 
     private async Task<IReadOnlyCollection<PositionRow>> LoadPositionsAsync(IDbConnection connection, DateTime startUtc, DateTime endUtc, CancellationToken cancellationToken)
     {
-        var definition = new CommandDefinition(PositionsSql, new { StartUtc = startUtc, EndUtc = endUtc }, cancellationToken: cancellationToken);
+        var definition = new CommandDefinition(_positionsSql, new { StartUtc = startUtc, EndUtc = endUtc }, cancellationToken: cancellationToken);
         var rows = await connection.QueryAsync<PositionRow>(definition);
         return rows.ToList();
     }
@@ -655,6 +675,12 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
         rate = 0m;
         return false;
     }
+
+    private string FormatSql(string template)
+        => template
+            .Replace("{WakettFill}", _fillTable)
+            .Replace("{IntradayCoreSecurity}", _securityTable)
+            .Replace("{IntradayMarketPriceBar}", _priceBarTable);
 
     private sealed record PnlFillRow(
         decimal? ExecuteSize,

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -16,12 +16,26 @@ public class PriceFetcher
     private readonly DapperContext _context;
     private readonly ILogger<PriceFetcher> _logger;
     private readonly IConfiguration _config;
+    private readonly string _stageHistCloseTable;
+    private readonly string _flatBarStagingTable;
+    private readonly string _stageInsertSql;
+    private readonly string _selectRawSql;
+    private readonly string _priceBarTable;
 
-    public PriceFetcher(DapperContext context, ILogger<PriceFetcher> logger, IConfiguration config)
+    public PriceFetcher(
+        DapperContext context,
+        ILogger<PriceFetcher> logger,
+        IConfiguration config,
+        IDatabaseObjectNameProvider databaseNameProvider)
     {
         _context = context;
         _logger = logger;
         _config = config;
+        _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
+        _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
+        _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
+        _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
+        _selectRawSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds";
     }
 
     public async Task FetchAndStoreAsync()
@@ -59,9 +73,8 @@ public class PriceFetcher
 
         using var connection = (SqlConnection)_context.CreateConnection();
         await connection.OpenAsync();
-        await connection.ExecuteAsync("DELETE FROM [Intraday].[mkt].[Stage_HistClose]");
-        const string insertSql = "INSERT INTO [Intraday].[mkt].[Stage_HistClose] (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
-        await connection.ExecuteAsync(insertSql, records);
+        await connection.ExecuteAsync($"DELETE FROM {_stageHistCloseTable}");
+        await connection.ExecuteAsync(_stageInsertSql, records);
 
         // Load newly staged raw bars into the PriceBar table so that subsequent
         // queries include the latest data.
@@ -70,8 +83,7 @@ public class PriceFetcher
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only
         // the newly provided data.
-        const string selectRaw = "SELECT SecurityId, BarTimeUtc, [Close] FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds";
-        var existing = await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityIds });
+        var existing = await connection.QueryAsync<HistClose>(_selectRawSql, new { SecurityIds = securityIds });
 
         // Combine existing database bars with the latest file data, removing duplicates
         // by timestamp so that the most recent value for a given bar is used.
@@ -80,7 +92,7 @@ public class PriceFetcher
             .Select(g => g.Last())
             .ToList();
 
-        await connection.ExecuteAsync("DELETE FROM [Intraday].[dbo].[mkt_FlatBar_Staging]");
+        await connection.ExecuteAsync($"DELETE FROM {_flatBarStagingTable}");
         var flatRecords = new List<FlatPrice>();
         foreach (var grp in allBars.GroupBy(r => r.SecurityId))
         {
@@ -111,7 +123,7 @@ public class PriceFetcher
 
             using (var bulkCopy = new SqlBulkCopy(connection))
             {
-                bulkCopy.DestinationTableName = "[Intraday].[dbo].[mkt_FlatBar_Staging]";
+                bulkCopy.DestinationTableName = _flatBarStagingTable;
                 await bulkCopy.WriteToServerAsync(table);
             }
 

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -26,6 +26,13 @@ public class WakettPriceFetcher
     private readonly ILogger<WakettPriceFetcher> _logger;
 
     private readonly WakettAutomationOptions? _automationOptions;
+    private readonly string _stageHistCloseTable;
+    private readonly string _flatBarStagingTable;
+    private readonly string _priceBarWindowQuery;
+    private readonly string _priceBarSelectWithOffsetSql;
+    private readonly string _stageDeleteSql;
+    private readonly string _stageInsertSql;
+    private readonly string _priceBarTable;
 
 
     private int PriceMinuteOffset => Math.Clamp(
@@ -39,6 +46,7 @@ public class WakettPriceFetcher
         DapperContext context,
         IConfiguration config,
         ILogger<WakettPriceFetcher> logger,
+        IDatabaseObjectNameProvider databaseNameProvider,
         IOptions<WakettAutomationOptions>? automationOptions = null)
     {
         _client = client;
@@ -46,6 +54,13 @@ public class WakettPriceFetcher
         _config = config;
         _logger = logger;
         _automationOptions = automationOptions?.Value;
+        _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
+        _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
+        _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
+        _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
+        _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+        _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
+        _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
     }
 
     public async Task<WakettPriceUploadResult?> FetchAndStoreAsync(
@@ -530,8 +545,6 @@ public class WakettPriceFetcher
         var startUtc = startHourUtc.AddMinutes(minuteOffset);
         var endUtc = endHourUtc.AddMinutes(minuteOffset);
 
-        const string sql = @"SELECT SecurityId, BarTimeUtc FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
-
         using var connection = _context.CreateConnection();
         if (connection is DbConnection dbConnection)
         {
@@ -543,7 +556,7 @@ public class WakettPriceFetcher
         }
 
         var rows = await connection.QueryAsync<(int SecurityId, DateTime BarTimeUtc)>(
-        sql,
+        _priceBarWindowQuery,
         new
         {
             SecurityIds = securityIds.ToArray(),
@@ -680,9 +693,6 @@ public class WakettPriceFetcher
             .Distinct()
             .ToArray();
 
-        const string deleteSql = "DELETE FROM [Intraday].[mkt].[Stage_HistClose] WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
-        const string insertSql = "INSERT INTO [Intraday].[mkt].[Stage_HistClose] (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
-
         using var connection = _context.CreateConnection();
         if (connection is DbConnection dbConnection)
         {
@@ -706,9 +716,9 @@ public class WakettPriceFetcher
                     SecurityIds = securityKeys
                 };
 
-                await connection.ExecuteAsync(deleteSql, parameters, transaction);
+                await connection.ExecuteAsync(_stageDeleteSql, parameters, transaction);
                 await connection.ExecuteAsync(
-                    insertSql,
+                    _stageInsertSql,
                     recordList.Select(r => new { SecurityId = r.SecurityKey, r.BarTimeUtc, Close = r.Close }),
                     transaction);
 
@@ -725,8 +735,7 @@ public class WakettPriceFetcher
             await PriceProcessingProcedures.LoadRawFromStageAsync(connection, 60, cancellationToken);
 
             var minuteOffset = PriceMinuteOffset;
-            var selectRaw =
-                "SELECT SecurityId, BarTimeUtc, [Close] FROM [Intraday].[mkt].[PriceBar] WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+            var selectRaw = _priceBarSelectWithOffsetSql;
             var existing = (await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityKeys, MinuteOffset = minuteOffset }))
                 .GroupBy(r => (r.SecurityId, r.BarTimeUtc))
                 .Select(g => g.Last())
@@ -761,7 +770,7 @@ public class WakettPriceFetcher
 
             if (flatRecords.Count > 0)
             {
-                await connection.ExecuteAsync("DELETE FROM [Intraday].[dbo].[mkt_FlatBar_Staging]");
+                await connection.ExecuteAsync($"DELETE FROM {_flatBarStagingTable}");
 
                 var table = new DataTable();
                 table.Columns.Add("SecurityId", typeof(string));
@@ -777,7 +786,7 @@ public class WakettPriceFetcher
                 if (connection is SqlConnection sqlConnection)
                 {
                     using var bulkCopy = new SqlBulkCopy(sqlConnection);
-                    bulkCopy.DestinationTableName = "[Intraday].[dbo].[mkt_FlatBar_Staging]";
+                    bulkCopy.DestinationTableName = _flatBarStagingTable;
                     await bulkCopy.WriteToServerAsync(table);
                 }
                 else

--- a/src/TradingDaemon/Services/WakettTradeFetcher.cs
+++ b/src/TradingDaemon/Services/WakettTradeFetcher.cs
@@ -28,8 +28,8 @@ public class WakettTradeFetcher
         "yyyy-MM-dd'T'HH:mm:sszzz"
     };
 
-    private const string MergeSql = @"
-MERGE [wakett].[Fill] AS target
+private const string MergeSqlTemplate = @"
+MERGE {WakettFill} AS target
 USING (VALUES (
     @ExecuteId,
     @Account,
@@ -247,11 +247,14 @@ OUTPUT $action;";
     private readonly ILogger<WakettTradeFetcher> _logger;
     private readonly TradingOptions _tradingOptions;
     private readonly TimeProvider _timeProvider;
+    private readonly string _fillTable;
+    private readonly string _mergeSql;
 
     public WakettTradeFetcher(
         WakettApiClient client,
         DapperContext context,
         ILogger<WakettTradeFetcher> logger,
+        IDatabaseObjectNameProvider databaseNameProvider,
         IOptions<TradingOptions>? tradingOptions = null,
         TimeProvider? timeProvider = null)
     {
@@ -260,6 +263,8 @@ OUTPUT $action;";
         _logger = logger;
         _tradingOptions = tradingOptions?.Value ?? new TradingOptions();
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _fillTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettFill);
+        _mergeSql = MergeSqlTemplate.Replace("{WakettFill}", _fillTable);
     }
 
     public async Task<WakettFillUploadResponse> FetchAndStoreAsync(
@@ -349,7 +354,7 @@ OUTPUT $action;";
             }
 
             var command = new CommandDefinition(
-                MergeSql,
+                _mergeSql,
                 item,
                 transaction,
                 cancellationToken: cancellationToken);

--- a/src/TradingDaemon/Utils/ConfigurationEnvironmentExtensions.cs
+++ b/src/TradingDaemon/Utils/ConfigurationEnvironmentExtensions.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+
+namespace TradingDaemon.Utils;
+
+public static class ConfigurationEnvironmentExtensions
+{
+    public static void ApplyEnvironmentOverrides(
+        ConfigurationManager configuration,
+        string sectionName,
+        string? defaultEnvironment = null)
+    {
+        if (configuration is null)
+        {
+            throw new ArgumentNullException(nameof(configuration));
+        }
+
+        var activeEnvironment = configuration[$"{sectionName}:ActiveEnvironment"]
+            ?? defaultEnvironment;
+
+        if (string.IsNullOrWhiteSpace(activeEnvironment))
+        {
+            return;
+        }
+
+        var overrides = configuration.GetSection($"{sectionName}:Environments:{activeEnvironment}");
+        if (!overrides.Exists())
+        {
+            return;
+        }
+
+        var flattened = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        FlattenSection(overrides, sectionName, flattened);
+
+        if (flattened.Count > 0)
+        {
+            configuration.AddInMemoryCollection(flattened);
+        }
+    }
+
+    private static void FlattenSection(
+        IConfiguration section,
+        string prefix,
+        IDictionary<string, string?> target)
+    {
+        foreach (var child in section.GetChildren())
+        {
+            var key = string.IsNullOrEmpty(prefix)
+                ? child.Key
+                : string.Concat(prefix, ":", child.Key);
+
+            if (!child.GetChildren().Any())
+            {
+                target[key] = child.Value;
+            }
+            else
+            {
+                FlattenSection(child, key, target);
+            }
+        }
+    }
+}

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -2,9 +2,34 @@
   "ConnectionStrings": {
     "DefaultConnection": ""
   },
+  "Database": {
+    "SecretName": "qq-intraday-credentials",
+    "ActiveEnvironment": "Test",
+    "Objects": {},
+    "Environments": {
+      "Prod": {
+        "Objects": {}
+      },
+      "Test": {
+        "Objects": {
+          "Intraday.model.NettedWeight": "[Intraday].[model_test].[NettedWeight]",
+          "Intraday.model.Model": "[Intraday].[model_test].[Model]",
+          "Intraday.core.Security": "[Intraday].[core_test].[Security]",
+          "Intraday.mkt.PriceBar": "[Intraday].[mkt_test].[PriceBar]",
+          "Intraday.mkt.Stage_HistClose": "[Intraday].[mkt_test].[Stage_HistClose]",
+          "Intraday.dbo.mkt_FlatBar_Staging": "[Intraday].[dbo_test].[mkt_FlatBar_Staging]",
+          "wakett.Fill": "[wakett_test].[Fill]",
+          "wakett.TradingLimit": "[wakett_test].[TradingLimit]",
+          "wakett.TradingLimitBreachReport": "[wakett_test].[TradingLimitBreachReport]",
+          "wakett.Order": "[wakett_test].[Order]"
+        }
+      }
+    }
+  },
   "ModelId": 0,
   "PriceCsvPath": "/home/prices/new_prices.csv",
   "ExternalApis": {
+    "ActiveEnvironment": "Test",
     "PriceApi": {
       "BaseUrl": "https://priceapi.example.com"
     },
@@ -12,8 +37,8 @@
       "BaseUrl": "https://orderapi.example.com"
     },
     "WakettApi": {
-      "BaseUrl": "https://api.qqb.wakett.com/test/trading/",
-      "TradeBaseUrl": "https://api.qqb.wakett.com/test/history/",
+      "BaseUrl": "https://api.qqb.wakett.com/prod/trading/",
+      "TradeBaseUrl": "https://api.qqb.wakett.com/prod/history/",
       "Aum": 15800000,
       "PriceMinuteOffset": 6,
       "Symbols": [
@@ -108,6 +133,34 @@
           "Symbol": "CHF/AUD"
         }
       ]
+    },
+    "Environments": {
+      "Prod": {
+        "PriceApi": {
+          "BaseUrl": "https://priceapi.example.com"
+        },
+        "OrderApi": {
+          "BaseUrl": "https://orderapi.example.com"
+        },
+        "WakettApi": {
+          "BaseUrl": "https://api.qqb.wakett.com/prod/trading/",
+          "TradeBaseUrl": "https://api.qqb.wakett.com/prod/history/"
+        }
+      },
+      "Test": {
+        "PriceApi": {
+          "BaseUrl": "https://priceapi-test.example.com"
+        },
+        "OrderApi": {
+          "BaseUrl": "https://orderapi-test.example.com"
+        },
+        "WakettApi": {
+          "BaseUrl": "https://api.qqb.wakett.com/test/trading/",
+          "TradeBaseUrl": "https://api.qqb.wakett.com/test/history/",
+          "Aum": 15800000,
+          "PriceMinuteOffset": 6
+        }
+      }
     }
   },
   "Executables": {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -16,6 +16,7 @@ using Xunit;
 
 public class OrderSenderTests
 {
+    private static readonly IDatabaseObjectNameProvider DefaultDatabaseNameProvider = new DatabaseObjectNameProvider();
     [Fact]
     public async Task SendOrdersAsync_SubmitsLatestWeightsToWakett()
     {
@@ -937,8 +938,9 @@ public class OrderSenderTests
             IReadOnlyDictionary<int, string> symbolMap,
             ModelScheduleRow? schedule,
             TradingLimitRow? tradingLimit = null,
-            IReadOnlyCollection<string>? existingOrderSymbols = null)
-            : base(client, context, logger, configuration, timeProvider)
+            IReadOnlyCollection<string>? existingOrderSymbols = null,
+            IDatabaseObjectNameProvider? databaseNameProvider = null)
+            : base(client, context, logger, configuration, databaseNameProvider ?? DefaultDatabaseNameProvider, timeProvider)
         {
             _weights = weights;
             _symbolMap = symbolMap;

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -35,7 +35,8 @@ public class PriceFetcherTests
         }).Build();
         var context = new TestDapperContext(config);
         var logger = Mock.Of<ILogger<PriceFetcher>>();
-        var fetcher = new PriceFetcher(context, logger, config);
+        var provider = new DatabaseObjectNameProvider();
+        var fetcher = new PriceFetcher(context, logger, config, provider);
 
         await fetcher.FetchAndStoreAsync();
     }


### PR DESCRIPTION
## Summary
- add a configuration helper that overlays environment-specific settings for a named section
- apply the helper during startup so the selected database environment also drives external API endpoints
- restructure appsettings to include per-environment API endpoints and make the test profile the default during development

## Testing
- dotnet test *(fails: `dotnet` command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915a313415483339d9f3e43936a7600)