### PR TITLE
Add environment-specific database configuration support

### DIFF
--- a/docs/sql-server-test-database.md
+++ b/docs/sql-server-test-database.md
@@ -1,0 +1,65 @@
+# Creating a Dedicated Test Database in SQL Server Management Studio
+
+The production schemas can be cloned into a standalone integration-test database by restoring a
+backup under a new name. The following procedure keeps the test database isolated while still
+mirroring production objects (tables, stored procedures, functions, etc.).
+
+## 1. Capture a Production Backup
+1. In SSMS connect to the production SQL Server instance.
+2. Right-click the production database (e.g., `Intraday`) and choose **Tasks → Back Up…**.
+3. Use the **Full** backup type and select a disk location that is accessible from the test
+   environment.
+4. Start the backup and wait for it to complete before moving on.
+
+> :warning: Always confirm with your DBA/security team that taking a production backup is
+> acceptable. When in doubt, request a sanitized copy prepared by the data team.
+
+## 2. Restore the Backup Under a New Name
+1. In SSMS connect to the target test SQL Server instance.
+2. Right-click **Databases** and choose **Restore Database…**.
+3. Select **Device** and browse to the `.bak` file created in the previous step.
+4. In the **Destination** section change the database name to something like
+   `IntradayTest`. This ensures you do not overwrite production accidentally.
+5. In the **Files** page adjust the **Restore As** paths if required (for example to move
+   MDF/LDF files onto test storage).
+6. Click **OK** to start the restore. When it finishes you will have a new database that is a
+   full copy of production.
+
+## 3. Recreate or Remap Logins
+1. Expand the restored database → **Security → Users** to confirm that the application login
+   exists.
+2. If the login is missing on the test server, run `CREATE LOGIN` on the instance and then
+   `CREATE USER … FOR LOGIN …` inside the restored database.
+3. Grant the same roles/permissions as production (usually `db_datareader`, `db_datawriter`,
+   and execution rights on required stored procedures).
+
+## 4. Update the Application Configuration
+1. Choose a dedicated SQL credential for the test database.
+2. Update `appsettings.json` (or environment-specific overrides) with the new connection string.
+   With the code changes in this PR you can now place a connection string under
+   `Database → Environments → Test → ConnectionString`:
+   ```json
+   "Database": {
+     "ActiveEnvironment": "Test",
+     "Environments": {
+       "Test": {
+         "ConnectionString": "Server=.;Database=IntradayTest;User Id=intraday_user;Password=ChangeMe!;TrustServerCertificate=True;"
+       }
+     }
+   }
+   ```
+3. If you store credentials in AWS Secrets Manager instead of using an inline connection string,
+   create a dedicated secret (for example `qq-intraday-test-credentials`) and place its name under
+   `Database → Environments → Test → SecretName`.
+4. Redeploy or restart the service so that the new configuration is picked up.
+
+## 5. Keep the Test Database Current
+- Schedule regular refreshes (nightly/weekly) by repeating the restore process or by running the
+  same migration scripts that are applied in production.
+- Use SQL Agent jobs or automation scripts to truncate/seed data that should differ from
+  production (e.g., anonymise sensitive fields).
+- Consider enabling `AUTO_CLOSE` = `OFF` and running `DBCC CHECKDB` periodically to detect issues
+  early.
+
+Following this workflow gives the test environment a clean, production-like schema without
+polluting the primary database.

--- a/docs/sql-server-test-database.md
+++ b/docs/sql-server-test-database.md
@@ -49,8 +49,10 @@ mirroring production objects (tables, stored procedures, functions, etc.).
    }
    ```
 3. If you store credentials in AWS Secrets Manager instead of using an inline connection string,
-   create a dedicated secret (for example `qq-intraday-test-credentials`) and place its name under
-   `Database → Environments → Test → SecretName`.
+   create a dedicated secret. By convention the application will look for
+   `qq-intraday-test-credentials` when the active environment is `Test`, so you only need to set a
+   custom value if you deviate from that pattern. Otherwise place the secret name under
+   `Database → Environments → Test → SecretName` to override the default.
 4. Redeploy or restart the service so that the new configuration is picked up.
 
 ## 5. Keep the Test Database Current

--- a/src/TradingDaemon/Data/DapperContext.cs
+++ b/src/TradingDaemon/Data/DapperContext.cs
@@ -95,7 +95,7 @@ public class DapperContext
         return string.IsNullOrWhiteSpace(connectionString) ? null : connectionString;
     }
 
-    private static string ResolveSecretName(IConfiguration configuration, string? activeEnvironment)
+    internal static string ResolveSecretName(IConfiguration configuration, string? activeEnvironment)
     {
         var secretName = configuration["Database:SecretName"];
 
@@ -106,8 +106,35 @@ public class DapperContext
             {
                 return environmentSecretName;
             }
+
+            if (string.IsNullOrWhiteSpace(secretName))
+            {
+                var inferredSecretName = InferSecretName(activeEnvironment);
+                if (!string.IsNullOrWhiteSpace(inferredSecretName))
+                {
+                    return inferredSecretName;
+                }
+            }
         }
 
         return string.IsNullOrWhiteSpace(secretName) ? "qq-intraday-credentials" : secretName;
+    }
+
+    private static string? InferSecretName(string environment)
+    {
+        if (string.IsNullOrWhiteSpace(environment))
+        {
+            return null;
+        }
+
+        var normalized = environment.Trim();
+
+        if (string.Equals(normalized, "Prod", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(normalized, "Production", StringComparison.OrdinalIgnoreCase))
+        {
+            return "qq-intraday-credentials";
+        }
+
+        return $"qq-intraday-{normalized.ToLowerInvariant()}-credentials";
     }
 }

--- a/src/TradingDaemon/Data/DapperContext.cs
+++ b/src/TradingDaemon/Data/DapperContext.cs
@@ -15,14 +15,16 @@ public class DapperContext
 
     public DapperContext(IConfiguration configuration)
     {
-        var conn = configuration.GetConnectionString("DefaultConnection");
+        var activeEnvironment = configuration["Database:ActiveEnvironment"];
+
+        var conn = ResolveConnectionString(configuration, activeEnvironment);
         if (!string.IsNullOrWhiteSpace(conn))
         {
             _connectionString = conn;
             return;
         }
 
-        var secretName = configuration["Database:SecretName"] ?? "qq-intraday-credentials";
+        var secretName = ResolveSecretName(configuration, activeEnvironment);
         var region = configuration["AWS:Region"] ?? Environment.GetEnvironmentVariable("AWS_REGION") ?? "eu-west-2";
 
         using var client = new AmazonSecretsManagerClient(RegionEndpoint.GetBySystemName(region));
@@ -69,4 +71,43 @@ public class DapperContext
 
     public virtual IDbConnection CreateConnection()
         => new SqlConnection(_connectionString);
+
+    private static string? ResolveConnectionString(IConfiguration configuration, string? activeEnvironment)
+    {
+        var connectionString = configuration.GetConnectionString("DefaultConnection");
+
+        if (string.IsNullOrWhiteSpace(connectionString))
+        {
+            connectionString = configuration["Database:ConnectionString"];
+        }
+
+        if (!string.IsNullOrWhiteSpace(connectionString))
+        {
+            return connectionString;
+        }
+
+        if (string.IsNullOrWhiteSpace(activeEnvironment))
+        {
+            return null;
+        }
+
+        connectionString = configuration[$"Database:Environments:{activeEnvironment}:ConnectionString"];
+        return string.IsNullOrWhiteSpace(connectionString) ? null : connectionString;
+    }
+
+    private static string ResolveSecretName(IConfiguration configuration, string? activeEnvironment)
+    {
+        var secretName = configuration["Database:SecretName"];
+
+        if (!string.IsNullOrWhiteSpace(activeEnvironment))
+        {
+            var environmentSecretName = configuration[$"Database:Environments:{activeEnvironment}:SecretName"];
+            if (!string.IsNullOrWhiteSpace(environmentSecretName))
+            {
+                return environmentSecretName;
+            }
+        }
+
+        return string.IsNullOrWhiteSpace(secretName) ? "qq-intraday-credentials" : secretName;
+    }
 }

--- a/src/TradingDaemon/Options/DatabaseObjectNameOptions.cs
+++ b/src/TradingDaemon/Options/DatabaseObjectNameOptions.cs
@@ -7,6 +7,12 @@ public class DatabaseObjectNameOptions
     public string? ActiveEnvironment { get; set; }
         = "Prod";
 
+    public string? ConnectionString { get; set; }
+        = null;
+
+    public string? SecretName { get; set; }
+        = null;
+
     public Dictionary<string, string> Objects { get; set; }
         = new(StringComparer.OrdinalIgnoreCase);
 
@@ -16,6 +22,12 @@ public class DatabaseObjectNameOptions
 
 public class DatabaseObjectNameEnvironment
 {
+    public string? ConnectionString { get; set; }
+        = null;
+
+    public string? SecretName { get; set; }
+        = null;
+
     public Dictionary<string, string> Objects { get; set; }
         = new(StringComparer.OrdinalIgnoreCase);
 }

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -5,12 +5,15 @@
   "Database": {
     "SecretName": "qq-intraday-credentials",
     "ActiveEnvironment": "Test",
+    "ConnectionString": "",
     "Objects": {},
     "Environments": {
       "Prod": {
         "Objects": {}
       },
       "Test": {
+        "ConnectionString": "Server=.;Database=IntradayTest;User Id=intraday_user;Password=ChangeMe!;TrustServerCertificate=True;",
+        "SecretName": "qq-intraday-test-credentials",
         "Objects": {
           "Intraday.model.NettedWeight": "[Intraday].[model_test].[NettedWeight]",
           "Intraday.model.Model": "[Intraday].[model_test].[Model]",

--- a/tests/TradingDaemon.Tests/DapperContextTests.cs
+++ b/tests/TradingDaemon.Tests/DapperContextTests.cs
@@ -1,0 +1,67 @@
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using TradingDaemon.Data;
+using Xunit;
+
+namespace TradingDaemon.Tests;
+
+public class DapperContextTests
+{
+    [Fact]
+    public void UsesEnvironmentConnectionStringWhenConfigured()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:ActiveEnvironment"] = "Test",
+                ["Database:Environments:Test:ConnectionString"] = "Server=.;Database=IntradayTest;User Id=user;Password=pass;"
+            })
+            .Build();
+
+        var context = new DapperContext(configuration);
+
+        using var connection = context.CreateConnection();
+        Assert.Equal(
+            "Server=.;Database=IntradayTest;User Id=user;Password=pass;",
+            connection.ConnectionString);
+    }
+
+    [Fact]
+    public void PrefersDefaultConnectionStringWhenProvided()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ConnectionStrings:DefaultConnection"] = "Server=.;Database=Primary;User Id=prod;Password=prod;",
+                ["Database:ActiveEnvironment"] = "Test",
+                ["Database:Environments:Test:ConnectionString"] = "Server=.;Database=IntradayTest;User Id=user;Password=pass;"
+            })
+            .Build();
+
+        var context = new DapperContext(configuration);
+
+        using var connection = context.CreateConnection();
+        Assert.Equal(
+            "Server=.;Database=Primary;User Id=prod;Password=prod;",
+            connection.ConnectionString);
+    }
+
+    [Fact]
+    public void UsesTopLevelDatabaseConnectionStringWhenNoDefaultConnectionIsConfigured()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:ConnectionString"] = "Server=.;Database=TopLevel;User Id=top;Password=top;",
+                ["Database:ActiveEnvironment"] = "Test"
+            })
+            .Build();
+
+        var context = new DapperContext(configuration);
+
+        using var connection = context.CreateConnection();
+        Assert.Equal(
+            "Server=.;Database=TopLevel;User Id=top;Password=top;",
+            connection.ConnectionString);
+    }
+}

--- a/tests/TradingDaemon.Tests/DapperContextTests.cs
+++ b/tests/TradingDaemon.Tests/DapperContextTests.cs
@@ -64,4 +64,35 @@ public class DapperContextTests
             "Server=.;Database=TopLevel;User Id=top;Password=top;",
             connection.ConnectionString);
     }
+
+    [Fact]
+    public void InfersSecretNameForTestEnvironmentWhenNotConfigured()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:ActiveEnvironment"] = "Test"
+            })
+            .Build();
+
+        var secretName = DapperContext.ResolveSecretName(configuration, "Test");
+
+        Assert.Equal("qq-intraday-test-credentials", secretName);
+    }
+
+    [Fact]
+    public void ReturnsTopLevelSecretWhenProvided()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Database:ActiveEnvironment"] = "Test",
+                ["Database:SecretName"] = "custom-secret"
+            })
+            .Build();
+
+        var secretName = DapperContext.ResolveSecretName(configuration, "Test");
+
+        Assert.Equal("custom-secret", secretName);
+    }
 }


### PR DESCRIPTION
## Summary
- allow DapperContext to honour environment-specific connection strings and secrets before falling back to AWS Secrets Manager
- extend database options so appsettings can carry per-environment connection settings and ship a sample configuration for the new test database
- document how to clone the production database in SSMS and add tests covering the new connection-string resolution logic

## Testing
- `dotnet test` *(fails: command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170464568883339596bb53a102db83)