### PR TITLE
Fix test environment home root mapping

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -31,6 +31,23 @@ SESSION_HOURS_NY = {
 }
 
 
+def resolve_home_root() -> pathlib.Path:
+    env_root = os.environ.get("HOME_ROOT")
+    if env_root:
+        return pathlib.Path(env_root)
+
+    environment = (
+        os.environ.get("ASPNETCORE_ENVIRONMENT")
+        or os.environ.get("DOTNET_ENVIRONMENT")
+        or ""
+    ).lower()
+
+    if environment == "test":
+        return pathlib.Path("/home_test")
+
+    return pathlib.Path("/home")
+
+
 def get_conn_from_secret(
     secret_name: str, region_name: str, default_driver: str
 ) -> str:
@@ -239,7 +256,7 @@ universe_id, universe_name, members_df = get_universe_info(engine, args.universe
 universe_ids = members_df["SecurityId"].unique().tolist()
 # Save exported price files to a fixed directory for downstream processes
 # that expect universes to reside under the ``HOME_ROOT`` directory.
-home_root = pathlib.Path(os.environ.get("HOME_ROOT", "/home"))
+home_root = resolve_home_root()
 output_dir = home_root / "data" / "historical_data" / f"Univ{universe_id}"
 output_dir.mkdir(parents=True, exist_ok=True)
 OUT = {k: output_dir / f"{k}.txt" for k in "ABCDEFGHI"}

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -633,6 +633,17 @@ END";
         var resolved = path;
 
         var unixRoot = Environment.GetEnvironmentVariable("HOME_ROOT");
+        if (string.IsNullOrEmpty(unixRoot))
+        {
+            var environmentName =
+                Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ??
+                Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+
+            if (string.Equals(environmentName, "Test", StringComparison.OrdinalIgnoreCase))
+            {
+                unixRoot = "/home_test";
+            }
+        }
         if (!string.IsNullOrEmpty(unixRoot))
         {
             const string unixPrefix = "/home";

--- a/tests/TradingDaemon.Tests/WeightCalculatorTests.cs
+++ b/tests/TradingDaemon.Tests/WeightCalculatorTests.cs
@@ -156,6 +156,36 @@ public class WeightCalculatorTests
         }
     }
 
+    [Fact]
+    public void ResolveHomePath_DefaultsToTestRootWhenEnvironmentIsTest()
+    {
+        var method = typeof(WeightCalculator).GetMethod(
+            "ResolveHomePath",
+            BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        var originalHomeRoot = Environment.GetEnvironmentVariable("HOME_ROOT");
+        var originalAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        var originalDotnetEnv = Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+
+        try
+        {
+            Environment.SetEnvironmentVariable("HOME_ROOT", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Test");
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", null);
+
+            var result = (string?)method!.Invoke(null, new object?[] { "/home/data/file.txt" });
+
+            Assert.Equal("/home_test/data/file.txt", result);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("HOME_ROOT", originalHomeRoot);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", originalAspNetEnv);
+            Environment.SetEnvironmentVariable("DOTNET_ENVIRONMENT", originalDotnetEnv);
+        }
+    }
+
     private static void AddRow(IList rows, Type weightRowType, DateTime barTimeUtc, decimal weight)
     {
         var ctor = weightRowType.GetConstructor(new[] { typeof(DateTime), typeof(decimal?[]) });


### PR DESCRIPTION
## Summary
- ensure the weight calculator resolves /home paths to /home_test when running in the Test environment
- share the same home root resolution logic with the export_prices_rds script
- cover the new resolution behaviour with a unit test

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69171b1be0448333ba88e6c094cf1d3e)