### PR TITLE
Configure Wakett automation account per environment

### DIFF
--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -17,6 +17,11 @@ ConfigurationEnvironmentExtensions.ApplyEnvironmentOverrides(
     "ExternalApis",
     builder.Configuration["Database:ActiveEnvironment"]);
 
+ConfigurationEnvironmentExtensions.ApplyEnvironmentOverrides(
+    builder.Configuration,
+    "Automation",
+    builder.Configuration["Database:ActiveEnvironment"]);
+
 SerilogConfig.Configure(builder.Configuration);
 builder.Host.UseSerilog();
 

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -183,11 +183,24 @@
     "TimeZone": "Eastern Standard Time"
   },
   "Automation": {
+    "ActiveEnvironment": "Test",
     "Wakett": {
       "WorkflowMinuteOffset": 59,
       "FillIntervalMinutes": 10,
       "FillAccount": "QuantumQBMasterFund",
       "FillStrategy": null
+    },
+    "Environments": {
+      "Prod": {
+        "Wakett": {
+          "FillAccount": "QuantumQBMasterFund"
+        }
+      },
+      "Test": {
+        "Wakett": {
+          "FillAccount": "subacc4"
+        }
+      }
     },
     "Email": {
       "From": "intraday_bot@quantumqb.com",


### PR DESCRIPTION
## Summary
- apply environment-specific overrides to the automation configuration
- set the Wakett fill account to use subacc4 in test while keeping QuantumQBMasterFund for prod

## Testing
- not run (dotnet not installed in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69172bef94988333a7cdc5339bf65e75)