### PR TITLE
Increase automation cadence to 15 minute intervals

### DIFF
--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -34,7 +34,7 @@ public class SchedulerService : IHostedService
 
         var schedulerOptions = _optionsMonitor.CurrentValue;
         var cron = string.IsNullOrWhiteSpace(schedulerOptions.Cron)
-            ? "0 1 9-15 ? * *"
+            ? "0 1,16,31,46 9-15 ? * *"
             : schedulerOptions.Cron;
         var timeZoneId = string.IsNullOrWhiteSpace(schedulerOptions.TimeZone)
             ? "Eastern Standard Time"

--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -18,10 +18,10 @@ public sealed class WakettAutomationService : BackgroundService
     private static readonly TimeSpan SessionEnd = new(15, 59, 0);
     private static readonly TimeSpan SessionShutdownDelay = TimeSpan.FromHours(1);
 
-    private static readonly int[] PriceFetchMinutes = { 20, 50 };
-    private static readonly int[] WeightCalculationMinutes = { 25, 55 };
+    private static readonly int[] PriceFetchMinutes = { 6, 21, 36, 51 };
+    private static readonly int[] WeightCalculationMinutes = { 10, 25, 40, 55 };
     private static readonly int[] FillCheckMinutes = { 10, 40 };
-    private static readonly int[] OrderSubmissionMinutes = { 1 };
+    private static readonly int[] OrderSubmissionMinutes = { 1, 16, 31, 46 };
     private static readonly int[] PnlReportMinutes = { 15 };
 
     private readonly WakettPriceFetcher _priceFetcher;

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -179,7 +179,7 @@
     //}
   ],
   "Quartz": {
-    "Cron": "0 1 9-15 ? * *",
+    "Cron": "0 1,16,31,46 9-15 ? * *",
     "TimeZone": "Eastern Standard Time"
   },
   "Automation": {


### PR DESCRIPTION
## Summary
- expand the price, weight calculation, and order submission schedules used by the Wakett automation service so that automation now runs on 15 minute bars
- update the default Quartz cron expression (and configuration) so the on-premises scheduler fires at :01, :16, :31, and :46 during the US session

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691aeb13cc908333ac178f8bf69ace7e)