### PR TITLE
Parameterize price bar timeframe

### DIFF
--- a/src/TradingDaemon/Options/PriceBarOptions.cs
+++ b/src/TradingDaemon/Options/PriceBarOptions.cs
@@ -1,0 +1,6 @@
+namespace TradingDaemon.Options;
+
+public sealed class PriceBarOptions
+{
+    public int TimeframeMinute { get; set; } = 15;
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -72,6 +72,7 @@ builder.Services.AddTransient<TradingJob>();
 
 builder.Services.Configure<WakettAutomationOptions>(builder.Configuration.GetSection("Automation:Wakett"));
 builder.Services.Configure<TradingOptions>(builder.Configuration.GetSection("Trading"));
+builder.Services.Configure<PriceBarOptions>(builder.Configuration.GetSection("PriceBars"));
 builder.Services.AddHostedService<WakettAutomationService>();
 
 builder.Services.AddSingleton<IEmailNotificationService, EmailNotificationService>();

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -8,8 +8,10 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Dapper;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
+using TradingDaemon.Options;
 
 namespace TradingDaemon.Services;
 
@@ -55,6 +57,7 @@ public class OrderSender
     private readonly string _tradingLimitTable;
     private readonly string _orderTable;
     private readonly string _tradingLimitBreachTable;
+    private readonly PriceBarOptions _priceBarOptions;
 
     public OrderSender(
         WakettApiClient wakettApiClient,
@@ -62,13 +65,15 @@ public class OrderSender
         ILogger<OrderSender> logger,
         IConfiguration configuration,
         IDatabaseObjectNameProvider databaseNameProvider,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        IOptions<PriceBarOptions>? priceBarOptions = null)
     {
         _wakettApiClient = wakettApiClient;
         _context = context;
         _logger = logger;
         _configuration = configuration;
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
         _nettedWeightTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayModelNettedWeight);
         _modelTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayModel);
         _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
@@ -89,15 +94,14 @@ public class OrderSender
 
         var latestBarTimeUtc = latest[0].BarTimeUtc;
         var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+        var barInterval = ResolveBarInterval(latest, latestBarTimeUtc);
 
-        if (!IsBarRecentEnough(latestBarTimeUtc, utcNow))
+        if (!IsBarRecentEnough(latestBarTimeUtc, utcNow, barInterval))
         {
             return;
         }
 
         var latestWeights = latest.Where(w => w.BarTimeUtc == latestBarTimeUtc).ToList();
-
-        var barInterval = ResolveBarInterval(latest, latestBarTimeUtc);
         var session = ResolveTradingSession(latestBarTimeUtc);
         var schedule = await LoadModelScheduleAsync(connection, cancellationToken);
         var orderTimestampUtc = CalculateOrderTimestamp(
@@ -837,7 +841,8 @@ VALUES
             return TimeSpan.FromMinutes(programmeMinutes);
         }
 
-        return TimeSpan.FromHours(1);
+        var fallbackMinutes = Math.Max(1, _priceBarOptions.TimeframeMinute);
+        return TimeSpan.FromMinutes(fallbackMinutes);
     }
 
     private string ResolveTradingSession(DateTime barTimeUtc)
@@ -983,7 +988,7 @@ ORDER BY TradingLimitId DESC;";
         return row;
     }
 
-    private bool IsBarRecentEnough(DateTime barTimeUtc, DateTime utcNow)
+    private bool IsBarRecentEnough(DateTime barTimeUtc, DateTime utcNow, TimeSpan barInterval)
     {
         var zone = CentralEuropeZone;
         var barLocal = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, zone);
@@ -997,7 +1002,11 @@ ORDER BY TradingLimitId DESC;";
             return true;
         }
 
-        if (utcNow - barTimeUtc > TimeSpan.FromMinutes(60))
+        var allowedStaleness = barInterval > TimeSpan.Zero
+            ? barInterval
+            : TimeSpan.FromMinutes(Math.Max(1, _priceBarOptions.TimeframeMinute));
+
+        if (utcNow - barTimeUtc > allowedStaleness)
         {
             _logger.LogWarning(
                 "Latest netted weights are stale. Last bar: {BarTimeUtc:O}, now: {NowUtc:O}.",

--- a/src/TradingDaemon/Services/PnlReportService.cs
+++ b/src/TradingDaemon/Services/PnlReportService.cs
@@ -7,8 +7,10 @@ using System.Threading;
 using Dapper;
 using Microsoft.Data.SqlClient;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
+using TradingDaemon.Options;
 using TradingDaemon.Utils;
 
 namespace TradingDaemon.Services;
@@ -93,7 +95,7 @@ FROM (
         pb.[Close],
         ROW_NUMBER() OVER (PARTITION BY pb.SecurityId ORDER BY pb.BarTimeUtc DESC) AS rn
     FROM {IntradayMarketPriceBar} pb
-        WHERE pb.TimeframeMinute = 60 AND pb.SecurityId IN @SecurityIds
+        WHERE pb.TimeframeMinute = {TimeframeMinute} AND pb.SecurityId IN @SecurityIds
 ) src
 WHERE src.rn = 1;";
 
@@ -105,7 +107,7 @@ FROM (
         ROW_NUMBER() OVER (PARTITION BY pb.SecurityId ORDER BY pb.BarTimeUtc DESC) AS rn
     FROM {IntradayMarketPriceBar} pb
     WHERE
-        pb.TimeframeMinute = 60
+        pb.TimeframeMinute = {TimeframeMinute}
         AND pb.SecurityId IN @SecurityIds
         AND pb.BarTimeUtc < @EndUtc
 ) src
@@ -155,14 +157,19 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
     private readonly string _fillTable;
     private readonly string _securityTable;
     private readonly string _priceBarTable;
+    private readonly PriceBarOptions _priceBarOptions;
+    private readonly string _timeframeLiteral;
 
     public PnlReportService(
         DapperContext context,
         ILogger<PnlReportService> logger,
-        IDatabaseObjectNameProvider databaseNameProvider)
+        IDatabaseObjectNameProvider databaseNameProvider,
+        IOptions<PriceBarOptions>? priceBarOptions = null)
     {
         _context = context;
         _logger = logger;
+        _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
+        _timeframeLiteral = Math.Max(1, _priceBarOptions.TimeframeMinute).ToString(CultureInfo.InvariantCulture);
         _fillTable = databaseNameProvider.GetObjectName(DatabaseObjects.WakettFill);
         _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
@@ -680,7 +687,8 @@ WHERE a.NetQuantity IS NOT NULL AND a.NetQuantity <> 0;";
         => template
             .Replace("{WakettFill}", _fillTable)
             .Replace("{IntradayCoreSecurity}", _securityTable)
-            .Replace("{IntradayMarketPriceBar}", _priceBarTable);
+            .Replace("{IntradayMarketPriceBar}", _priceBarTable)
+            .Replace("{TimeframeMinute}", _timeframeLiteral);
 
     private sealed record PnlFillRow(
         decimal? ExecuteSize,

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -5,9 +5,11 @@ using System.Linq;
 using System.IO;
 using System.Data;
 using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Options;
 using Dapper;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
+using TradingDaemon.Options;
 
 namespace TradingDaemon.Services;
 
@@ -22,23 +24,26 @@ public class PriceFetcher
     private readonly string _selectRawSql;
     private readonly string _priceBarTable;
     private readonly IPriceProcessingProcedureExecutor _priceProcedures;
+    private readonly PriceBarOptions _priceBarOptions;
 
     public PriceFetcher(
         DapperContext context,
         ILogger<PriceFetcher> logger,
         IConfiguration config,
         IDatabaseObjectNameProvider databaseNameProvider,
-        IPriceProcessingProcedureExecutor priceProcedures)
+        IPriceProcessingProcedureExecutor priceProcedures,
+        IOptions<PriceBarOptions>? priceBarOptions = null)
     {
         _context = context;
         _logger = logger;
         _config = config;
         _priceProcedures = priceProcedures;
+        _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
         _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
         _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
-        _selectRawSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds";
+        _selectRawSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds";
     }
 
     public async Task FetchAndStoreAsync()
@@ -81,7 +86,7 @@ public class PriceFetcher
 
         // Load newly staged raw bars into the PriceBar table so that subsequent
         // queries include the latest data.
-        await _priceProcedures.LoadRawFromStageAsync(connection, 60);
+        await _priceProcedures.LoadRawFromStageAsync(connection, PriceTimeframeMinute);
 
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only
@@ -100,12 +105,12 @@ public class PriceFetcher
         foreach (var grp in allBars.GroupBy(r => r.SecurityId))
         {
             var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
-            var rawEU = RawNMin(ordered, 60, "EU", 0);
+            var rawEU = RawNMin(ordered, PriceTimeframeMinute, "EU", 0);
             var flatEU = Flatten(rawEU, SessionBounds["EU"].Zone)
                 .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "EU" });
             flatRecords.AddRange(flatEU);
 
-            var rawUS = RawNMin(ordered, 60, "US", 0);
+            var rawUS = RawNMin(ordered, PriceTimeframeMinute, "US", 0);
             var flatUS = Flatten(rawUS, SessionBounds["US"].Zone)
                 .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "US" });
             flatRecords.AddRange(flatUS);
@@ -131,8 +136,8 @@ public class PriceFetcher
             }
 
             // Move staged flat bars into the main table for each session.
-            await _priceProcedures.LoadFlatFromMinimalAsync(connection, 60);
-        }
+            await _priceProcedures.LoadFlatFromMinimalAsync(connection, PriceTimeframeMinute);
+    }
     }
 
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
@@ -146,6 +151,8 @@ public class PriceFetcher
 
     private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
+
+    private int PriceTimeframeMinute => Math.Max(1, _priceBarOptions.TimeframeMinute);
 
     private static List<(DateTime TimestampUtc, decimal Close)> RawNMin(List<HistClose> series, int minutes, string session, int offset)
     {

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -15,6 +15,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
+using TradingDaemon.Options;
 
 namespace TradingDaemon.Services;
 
@@ -34,6 +35,7 @@ public class WakettPriceFetcher
     private readonly string _stageInsertSql;
     private readonly string _priceBarTable;
     private readonly IPriceProcessingProcedureExecutor _priceProcedures;
+    private readonly PriceBarOptions _priceBarOptions;
 
 
     private IReadOnlyList<int>? _priceMinuteOffsets;
@@ -47,7 +49,8 @@ public class WakettPriceFetcher
         ILogger<WakettPriceFetcher> logger,
         IDatabaseObjectNameProvider databaseNameProvider,
         IPriceProcessingProcedureExecutor priceProcedures,
-        IOptions<WakettAutomationOptions>? automationOptions = null)
+        IOptions<WakettAutomationOptions>? automationOptions = null,
+        IOptions<PriceBarOptions>? priceBarOptions = null)
     {
         _client = client;
         _context = context;
@@ -55,11 +58,12 @@ public class WakettPriceFetcher
         _logger = logger;
         _priceProcedures = priceProcedures;
         _automationOptions = automationOptions?.Value;
+        _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
         _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
         _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
-        _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
-        _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = 60 AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+        _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
+        _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
         _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
     }
@@ -778,7 +782,7 @@ public class WakettPriceFetcher
 
         if (recordList.Count > 0)
         {
-            await _priceProcedures.LoadRawFromStageAsync(connection, 60, cancellationToken);
+            await _priceProcedures.LoadRawFromStageAsync(connection, PriceTimeframeMinute, cancellationToken);
 
             var selectRaw = _priceBarSelectWithOffsetSql;
             var existing = (await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityKeys, MinuteOffset = minuteOffset }))
@@ -790,7 +794,7 @@ public class WakettPriceFetcher
             foreach (var grp in existing.GroupBy(r => r.SecurityId))
             {
                 var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
-                var rawEu = RawNMin(ordered, 60, "EU", minuteOffset);
+                var rawEu = RawNMin(ordered, PriceTimeframeMinute, "EU", minuteOffset);
                 var flatEu = Flatten(rawEu, SessionBounds["EU"].Zone)
                     .Select(r => new FlatPrice
                     {
@@ -801,7 +805,7 @@ public class WakettPriceFetcher
                     });
                 flatRecords.AddRange(flatEu);
 
-                var rawUs = RawNMin(ordered, 60, "US", minuteOffset);
+                var rawUs = RawNMin(ordered, PriceTimeframeMinute, "US", minuteOffset);
                 var flatUs = Flatten(rawUs, SessionBounds["US"].Zone)
                     .Select(r => new FlatPrice
                     {
@@ -840,8 +844,10 @@ public class WakettPriceFetcher
                 }
             }
 
-            await _priceProcedures.LoadFlatFromMinimalAsync(connection, 60, cancellationToken);
-        }
+            await _priceProcedures.LoadFlatFromMinimalAsync(connection, PriceTimeframeMinute, cancellationToken);
+    }
+
+    private int PriceTimeframeMinute => Math.Max(1, _priceBarOptions.TimeframeMinute);
     }
 
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -7,7 +7,9 @@ using System.Text;
 using System.Runtime.InteropServices;
 using System.Data;
 using Dapper;
+using Microsoft.Extensions.Options;
 using TradingDaemon.Data;
+using TradingDaemon.Options;
 
 namespace TradingDaemon.Services;
 
@@ -16,6 +18,7 @@ public class WeightCalculator
     private readonly DapperContext _context;
     private readonly IConfiguration _config;
     private readonly ILogger<WeightCalculator> _logger;
+    private readonly PriceBarOptions _priceBarOptions;
 
     private static readonly IReadOnlyDictionary<string, SessionInfo> SessionBounds =
         new Dictionary<string, SessionInfo>(StringComparer.OrdinalIgnoreCase)
@@ -26,11 +29,16 @@ public class WeightCalculator
                 TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
         };
 
-    public WeightCalculator(DapperContext context, IConfiguration config, ILogger<WeightCalculator> logger)
+    public WeightCalculator(
+        DapperContext context,
+        IConfiguration config,
+        ILogger<WeightCalculator> logger,
+        IOptions<PriceBarOptions>? priceBarOptions = null)
     {
         _context = context;
         _config = config;
         _logger = logger;
+        _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
     }
 
     public async Task CalculateAndStoreAsync()
@@ -49,10 +57,11 @@ public class WeightCalculator
             var universe = model["Universe"] ?? string.Empty;
             var universeId = model["UniverseId"] ?? string.Empty;
             var tradingSession = model["Session"] ?? string.Empty;
-            var timeFrame = model["Timeframe"] ?? "60";
+            var defaultTimeframe = Math.Max(1, _priceBarOptions.TimeframeMinute);
+            var timeFrame = model["Timeframe"] ?? defaultTimeframe.ToString(CultureInfo.InvariantCulture);
             var startDate = model["StartDate"] ?? "2022-01-01";
             var modelId = int.Parse(model["ModelId"] ?? "0");
-            var timeFrameInt = int.TryParse(timeFrame, out var tfVal) ? tfVal : 60;
+            var timeFrameInt = int.TryParse(timeFrame, out var tfVal) ? tfVal : defaultTimeframe;
 
             modelTimeframes[modelId] = timeFrameInt;
             if (!string.IsNullOrWhiteSpace(tradingSession))

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -190,6 +190,9 @@
     //  "StartDate": "2022-01-01"
     //}
   ],
+  "PriceBars": {
+    "TimeframeMinute": 15
+  },
   "Quartz": {
     "Cron": "0 1,16,31,46 9-15 ? * *",
     "TimeZone": "Eastern Standard Time"


### PR DESCRIPTION
## Summary
- add a `PriceBarOptions` configuration section (defaulting to 15 minutes) and register it for dependency injection
- update the price/pnl/weight services to consume the configured timeframe instead of hard-coded 60 minute bars
- update the Wakett order sender to derive its recency checks and fallback interval from the configurable timeframe as well

## Testing
- `dotnet test` *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b3239ce0c833382a3131b113fbcb2)