### PR TITLE
Fix price bar minute filtering for 15-minute exports

### DIFF
--- a/scripts/export_prices_rds.py
+++ b/scripts/export_prices_rds.py
@@ -157,7 +157,7 @@ def read_price_bars(
         "SELECT BarTimeUtc AS timestamp, [Close] AS [close] "
         "FROM mkt.PriceBar "
         "WHERE SecurityId = :sid AND TimeframeMinute = :tf "
-        "AND DATEPART(MINUTE, BarTimeUtc) = 6"
+        "AND DATEPART(MINUTE, BarTimeUtc) % :tf = 6"
     )
     if start:
         sql += " AND BarTimeUtc >= :start"
@@ -187,7 +187,7 @@ def read_flat_bars(
         "SELECT BarTimeUtc AS timestamp, [Close] AS [close] "
         "FROM mkt.FlatBar "
         "WHERE SecurityId = :sid AND TimeframeMinute = :tf "
-        "AND DATEPART(MINUTE, BarTimeUtc) = 6"
+        "AND DATEPART(MINUTE, BarTimeUtc) % :tf = 6"
     )
     if start:
         sql += " AND BarTimeUtc >= :start"


### PR DESCRIPTION
## Summary
- update the price and flat bar queries in `export_prices_rds.py` to filter on minutes modulo timeframe so 15-minute bars are retrieved correctly

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b4018a3d88333ba950d931710da82)