### PR TITLE
Ensure export script receives CLI arguments

### DIFF
--- a/src/TradingDaemon/Services/ProcessRunner.cs
+++ b/src/TradingDaemon/Services/ProcessRunner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
 
@@ -5,13 +6,23 @@ namespace TradingDaemon.Services;
 
 public static class ProcessRunner
 {
-    public static async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(
+    public static Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(
         string fileName,
         string arguments,
         Action<string>? onOutput = null,
-        Action<string>? onError = null)
+        Action<string>? onError = null) =>
+        RunAsync(CreateProcess(fileName, arguments), onOutput, onError);
+
+    public static Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(
+        string fileName,
+        IEnumerable<string> arguments,
+        Action<string>? onOutput = null,
+        Action<string>? onError = null) =>
+        RunAsync(CreateProcess(fileName, arguments), onOutput, onError);
+
+    private static Process CreateProcess(string fileName, string arguments)
     {
-        var process = new Process
+        return new Process
         {
             StartInfo = new ProcessStartInfo
             {
@@ -21,7 +32,36 @@ public static class ProcessRunner
                 RedirectStandardError = true
             }
         };
+    }
 
+    private static Process CreateProcess(string fileName, IEnumerable<string> arguments)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = fileName,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            }
+        };
+
+        foreach (var argument in arguments)
+        {
+            if (!string.IsNullOrWhiteSpace(argument))
+            {
+                process.StartInfo.ArgumentList.Add(argument);
+            }
+        }
+
+        return process;
+    }
+
+    private static async Task<(string StdOut, string StdErr, int ExitCode)> RunAsync(
+        Process process,
+        Action<string>? onOutput,
+        Action<string>? onError)
+    {
         var stdOut = new StringBuilder();
         var stdErr = new StringBuilder();
         var outTcs = new TaskCompletionSource<bool>();
@@ -58,7 +98,6 @@ public static class ProcessRunner
         process.BeginErrorReadLine();
 
         await Task.WhenAll(process.WaitForExitAsync(), outTcs.Task, errTcs.Task);
-
         return (stdOut.ToString(), stdErr.ToString(), process.ExitCode);
     }
 }

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -69,9 +69,34 @@ public class WeightCalculator
                 modelSessions[modelId] = tradingSession.Trim();
             }
 
-            var scriptArgs = string.IsNullOrEmpty(universe)
-                ? scriptPath
-                : $"{scriptPath} --universe {universe} --session {tradingSession} --timeframe {timeFrame} --start {startDate}";
+            if (string.IsNullOrWhiteSpace(universe))
+            {
+                _logger.LogWarning("Skipping price export: model {ModelId} does not define a universe", modelId);
+                continue;
+            }
+
+            var scriptArgs = new List<string>
+            {
+                scriptPath,
+                "--universe",
+                universe
+            };
+
+            if (!string.IsNullOrWhiteSpace(tradingSession))
+            {
+                scriptArgs.AddRange(new[] { "--session", tradingSession });
+            }
+
+            scriptArgs.AddRange(new[]
+            {
+                "--timeframe",
+                timeFrameInt.ToString(CultureInfo.InvariantCulture)
+            });
+
+            if (!string.IsNullOrWhiteSpace(startDate))
+            {
+                scriptArgs.AddRange(new[] { "--start", startDate });
+            }
 
             var sbOut = new StringBuilder();
             var sbErr = new StringBuilder();


### PR DESCRIPTION
## Summary
- add a ProcessRunner overload that accepts individual command line arguments so we can pass them without concatenating strings
- update WeightCalculator to build the export_prices_rds.py arguments explicitly and skip models with no universe configured

## Testing
- `dotnet build TradingDaemon.sln` *(fails: dotnet is not installed in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b45cc93ac8333b441877c6a3c9e96)