### PR TITLE
Fetch Wakett symbols from DB and auto build crosses

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -128,14 +128,7 @@ public class OrderSender
             return;
         }
 
-        var allowedSymbols = LoadAllowedSymbols();
-        if (allowedSymbols.Count == 0)
-        {
-            _logger.LogWarning("No allowed Wakett symbols configured. Aborting order submission.");
-            return;
-        }
-
-        var builtOrders = BuildOrders(latestWeights, symbolMap, allowedSymbols, orderTimestampUtc);
+        var builtOrders = BuildOrders(latestWeights, symbolMap, orderTimestampUtc);
         var isFlatOrderRequest = builtOrders.Count == 0
             || builtOrders.All(order => order.Order.size?.value == 0d);
         if (isFlatOrderRequest)
@@ -1050,44 +1043,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         return map;
     }
 
-    private HashSet<string> LoadAllowedSymbols()
-    {
-        var allowed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-
-        foreach (var item in EnumerateConfiguredSymbols("ExternalApis:WakettApi:Symbols"))
-        {
-            allowed.Add(item);
-        }
-
-        foreach (var item in EnumerateConfiguredSymbols("ExternalApis:WakettApi:MissingSymbols"))
-        {
-            allowed.Add(item);
-        }
-
-        return allowed;
-    }
-
-    private IEnumerable<string> EnumerateConfiguredSymbols(string section)
-    {
-        var configured = _configuration
-            .GetSection(section)
-            .Get<List<WakettSecuritySymbol>>() ?? new();
-
-        foreach (var symbol in configured)
-        {
-            var requestSymbol = WakettSymbolPatch.GetRequestSymbol(symbol.SecurityId, symbol.Symbol);
-
-            if (SymbolInfo.TryCreate(symbol.SecurityId, requestSymbol, out var info))
-            {
-                yield return info.FormattedSymbol;
-            }
-        }
-    }
-
     private static List<(int SecurityId, WakettOrderItem Order)> BuildOrders(
         IEnumerable<NettedWeightRow> weights,
         IReadOnlyDictionary<int, string> symbolMap,
-        ISet<string> allowedSymbols,
         DateTime orderTimestampUtc)
     {
         var parsedSymbols = symbolMap
@@ -1121,7 +1079,7 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
         if (exposures.Count == 0)
         {
-            return BuildFlatOrders(weights, parsedSymbols, allowedSymbols, orderTimestampUtc);
+            return BuildFlatOrders(weights, parsedSymbols, orderTimestampUtc);
         }
 
         var usdBasePairs = parsedSymbols.Values
@@ -1177,20 +1135,6 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             var side = order.Weight > 0 ? "BUY" : "SELL";
             var value = Math.Abs((double)order.Weight);
 
-            if (!allowedSymbols.Contains(formatted))
-            {
-                var reversed = order.Info.ReversedFormattedSymbol;
-                if (allowedSymbols.Contains(reversed))
-                {
-                    formatted = reversed;
-                    side = side == "BUY" ? "SELL" : "BUY";
-                }
-                else
-                {
-                    continue;
-                }
-            }
-
             var orderCode = BuildOrderCode(order.SecurityId, orderTimestampUtc);
 
             result.Add((order.SecurityId, new WakettOrderItem
@@ -1212,7 +1156,6 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private static List<(int SecurityId, WakettOrderItem Order)> BuildFlatOrders(
         IEnumerable<NettedWeightRow> weights,
         IReadOnlyDictionary<int, SymbolInfo> parsedSymbols,
-        ISet<string> allowedSymbols,
         DateTime orderTimestampUtc)
     {
         var result = new List<(int SecurityId, WakettOrderItem Order)>();
@@ -1228,17 +1171,6 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         foreach (var symbol in orderedSymbols)
         {
             var formatted = symbol.FormattedSymbol;
-
-            if (!allowedSymbols.Contains(formatted))
-            {
-                var reversed = symbol.ReversedFormattedSymbol;
-                if (!allowedSymbols.Contains(reversed))
-                {
-                    continue;
-                }
-
-                formatted = reversed;
-            }
 
             result.Add((symbol.SecurityId, new WakettOrderItem
             {

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -34,6 +34,7 @@ public class WakettPriceFetcher
     private readonly string _stageDeleteSql;
     private readonly string _stageInsertSql;
     private readonly string _priceBarTable;
+    private readonly string _securityTable;
     private readonly IPriceProcessingProcedureExecutor _priceProcedures;
     private readonly PriceBarOptions _priceBarOptions;
 
@@ -62,6 +63,7 @@ public class WakettPriceFetcher
         _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
         _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
+        _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
         _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
         _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
         _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
@@ -90,10 +92,15 @@ public class WakettPriceFetcher
     public async Task<WakettPriceUploadResult?> FetchAndStoreAsync(
         CancellationToken cancellationToken = default)
     {
-        if (!TryLoadConfiguredSymbols(out var baseSymbols, out var missingSymbols, out var allSecurityIds))
+        var symbolConfiguration = await LoadSymbolConfigurationAsync(cancellationToken);
+        if (symbolConfiguration is null)
         {
             return null;
         }
+
+        var baseSymbols = symbolConfiguration.BaseSymbols;
+        var missingSymbols = symbolConfiguration.MissingSymbols;
+        var allSecurityIds = symbolConfiguration.AllSecurityIds;
 
         var missingBars = new List<(int MinuteOffset, DateTime BarTimeUtc)>();
         foreach (var minuteOffset in PriceMinuteOffsets)
@@ -224,10 +231,13 @@ public class WakettPriceFetcher
 
     public async Task<bool> AreRecentPricesCompleteAsync(CancellationToken cancellationToken = default)
     {
-        if (!TryLoadConfiguredSymbols(out _, out _, out var securityIds))
+        var symbolConfiguration = await LoadSymbolConfigurationAsync(cancellationToken);
+        if (symbolConfiguration is null)
         {
             return false;
         }
+
+        var securityIds = symbolConfiguration.AllSecurityIds;
 
         var missingByOffset = new List<(int MinuteOffset, IReadOnlyList<DateTime> Missing)>();
         foreach (var minuteOffset in PriceMinuteOffsets)
@@ -514,34 +524,171 @@ public class WakettPriceFetcher
         inverse[pair.Base] = 1m / rate;
     }
 
-    private bool TryLoadConfiguredSymbols(
-        out IReadOnlyList<WakettSecuritySymbol> baseSymbols,
-        out IReadOnlyList<WakettSecuritySymbol> missingSymbols,
-        out int[] allSecurityIds)
+    private async Task<SymbolConfiguration?> LoadSymbolConfigurationAsync(CancellationToken cancellationToken)
     {
-        baseSymbols = _config
-            .GetSection("ExternalApis:WakettApi:Symbols")
-            .Get<List<WakettSecuritySymbol>>() ?? new();
+        var basePairs = LoadConfiguredBasePairs();
+        if (basePairs.Count == 0)
+        {
+            _logger.LogWarning("No Wakett base pairs configured. Aborting Wakett price processing.");
+            return null;
+        }
+
+        var allowedCurrencies = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var pair in basePairs)
+        {
+            allowedCurrencies.Add(pair.Base);
+            allowedCurrencies.Add(pair.Quote);
+        }
+
+        var securityDefinitions = await LoadSecurityDefinitionsAsync(allowedCurrencies, cancellationToken);
+        if (securityDefinitions.Count == 0)
+        {
+            _logger.LogWarning(
+                "No FX securities were found in {Table} for the configured Wakett currencies.",
+                _securityTable);
+            return null;
+        }
+
+        var baseSymbols = new List<WakettSecuritySymbol>();
+        var baseSecurityIds = new HashSet<int>();
+
+        foreach (var pair in basePairs)
+        {
+            var match = securityDefinitions.FirstOrDefault(def => PairMatches(def.Pair, pair));
+            if (match is null)
+            {
+                _logger.LogWarning(
+                    "Unable to locate security for Wakett base pair {Base}/{Quote}.",
+                    pair.Base,
+                    pair.Quote);
+                continue;
+            }
+
+            baseSecurityIds.Add(match.SecurityId);
+            baseSymbols.Add(new WakettSecuritySymbol
+            {
+                SecurityId = match.SecurityId,
+                Symbol = FormatCurrencyPair(pair)
+            });
+        }
 
         if (baseSymbols.Count == 0)
         {
-            _logger.LogWarning("No Wakett symbols configured. Aborting Wakett price processing.");
-            missingSymbols = Array.Empty<WakettSecuritySymbol>();
-            allSecurityIds = Array.Empty<int>();
-            return false;
+            _logger.LogWarning("None of the configured Wakett base pairs are present in the security table.");
+            return null;
         }
 
-        missingSymbols = _config
-            .GetSection("ExternalApis:WakettApi:MissingSymbols")
-            .Get<List<WakettSecuritySymbol>>() ?? new();
+        var missingSymbols = securityDefinitions
+            .Where(def => !baseSecurityIds.Contains(def.SecurityId))
+            .Select(def => new WakettSecuritySymbol
+            {
+                SecurityId = def.SecurityId,
+                Symbol = FormatCurrencyPair(def.Pair)
+            })
+            .ToList();
 
-        allSecurityIds = baseSymbols
-            .Concat(missingSymbols)
-            .Select(s => s.SecurityId)
+        var allSecurityIds = baseSecurityIds
+            .Concat(missingSymbols.Select(symbol => symbol.SecurityId))
             .Distinct()
             .ToArray();
 
-        return true;
+        return new SymbolConfiguration(baseSymbols, missingSymbols, allSecurityIds);
+    }
+
+    private IReadOnlyList<CurrencyPair> LoadConfiguredBasePairs()
+    {
+        var configured = _config
+            .GetSection("ExternalApis:WakettApi:BasePairs")
+            .Get<string[]>() ?? Array.Empty<string>();
+
+        var pairs = new List<CurrencyPair>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entry in configured)
+        {
+            if (!TryParsePair(entry, out var pair))
+            {
+                _logger.LogWarning(
+                    "Skipping invalid Wakett base pair configuration value '{Value}'.",
+                    entry);
+                continue;
+            }
+
+            var key = FormatCurrencyPair(pair);
+            if (!seen.Add(key))
+            {
+                continue;
+            }
+
+            pairs.Add(pair);
+        }
+
+        return pairs;
+    }
+
+    private async Task<List<SecuritySymbolDefinition>> LoadSecurityDefinitionsAsync(
+        ISet<string> allowedCurrencies,
+        CancellationToken cancellationToken)
+    {
+        if (allowedCurrencies.Count == 0)
+        {
+            return new List<SecuritySymbolDefinition>();
+        }
+
+        var sql = $@"SELECT SecurityId, Symbol
+FROM {_securityTable}
+WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
+
+        using var connection = _context.CreateConnection();
+        if (connection is DbConnection dbConnection)
+        {
+            await dbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            connection.Open();
+        }
+
+        var definition = new CommandDefinition(sql, cancellationToken: cancellationToken);
+        var rows = await connection.QueryAsync<SecuritySymbolRow>(definition);
+        var definitions = new List<SecuritySymbolDefinition>();
+
+        foreach (var row in rows)
+        {
+            if (string.IsNullOrWhiteSpace(row.Symbol))
+            {
+                continue;
+            }
+
+            var normalized = NormalizeSymbol(row.Symbol);
+            if (normalized.Length != 6)
+            {
+                continue;
+            }
+
+            var pair = new CurrencyPair(normalized[..3], normalized.Substring(3, 3));
+            if (!allowedCurrencies.Contains(pair.Base) || !allowedCurrencies.Contains(pair.Quote))
+            {
+                continue;
+            }
+
+            definitions.Add(new SecuritySymbolDefinition(row.SecurityId, pair));
+        }
+
+        return definitions;
+    }
+
+    private static string FormatCurrencyPair(CurrencyPair pair) => $"{pair.Base}/{pair.Quote}";
+
+    private static bool PairMatches(CurrencyPair candidate, CurrencyPair target)
+    {
+        if (candidate.Equals(target))
+        {
+            return true;
+        }
+
+        return candidate.Base.Equals(target.Quote, StringComparison.OrdinalIgnoreCase)
+            && candidate.Quote.Equals(target.Base, StringComparison.OrdinalIgnoreCase);
     }
 
     private static IReadOnlyList<WakettSecuritySymbol> BuildWakettRequestSymbols(
@@ -707,7 +854,7 @@ public class WakettPriceFetcher
         if (ids.Length == 0)
             return new Dictionary<int, CurrencyPair>();
 
-        const string sql = "SELECT SecurityId, BloombergTicker FROM core.Security WHERE SecurityId IN @Ids";
+        var sql = $"SELECT SecurityId, BloombergTicker FROM {_securityTable} WHERE SecurityId IN @Ids";
         using var connection = _context.CreateConnection();
         if (connection is DbConnection dbConnection)
         {
@@ -946,6 +1093,15 @@ public class WakettPriceFetcher
             result.Add((times[i], flat[i]));
         return result;
     }
+
+    private sealed record SymbolConfiguration(
+        IReadOnlyList<WakettSecuritySymbol> BaseSymbols,
+        IReadOnlyList<WakettSecuritySymbol> MissingSymbols,
+        int[] AllSecurityIds);
+
+    private sealed record SecuritySymbolDefinition(int SecurityId, CurrencyPair Pair);
+
+    private sealed record SecuritySymbolRow(int SecurityId, string? Symbol);
 
     internal readonly record struct CurrencyPair(string Base, string Quote);
 

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -38,97 +38,22 @@
         51
       ],
       "PriceMinuteOffset": 6,
-      "Symbols": [
-        {
-          "SecurityId": 58,
-          "Symbol": "NZD/USD"
-        },
-        {
-          "SecurityId": 61,
-          "Symbol": "EUR/CHF"
-        },
-        {
-          "SecurityId": 62,
-          "Symbol": "CAD/JPY"
-        },
-        {
-          "SecurityId": 63,
-          "Symbol": "EUR/JPY"
-        },
-        {
-          "SecurityId": 64,
-          "Symbol": "USD/CAD"
-        },
-        {
-          "SecurityId": 65,
-          "Symbol": "USD/JPY"
-        },
-        {
-          "SecurityId": 66,
-          "Symbol": "EUR/USD"
-        },
-        {
-          "SecurityId": 68,
-          "Symbol": "GBP/USD"
-        },
-        {
-          "SecurityId": 127,
-          "Symbol": "USD/AUD"
-        },
-        {
-          "SecurityId": 134,
-          "Symbol": "GBP/EUR"
-        },
-        {
-          "SecurityId": 136,
-          "Symbol": "CHF/USD"
-        }
-      ],
-      "MissingSymbols": [
-        {
-          "SecurityId": 123,
-          "Symbol": "JPY/CHF"
-        },
-        {
-          "SecurityId": 124,
-          "Symbol": "NZD/EUR"
-        },
-        {
-          "SecurityId": 125,
-          "Symbol": "AUD/EUR"
-        },
-        {
-          "SecurityId": 126,
-          "Symbol": "NZD/CAD"
-        },
-        {
-          "SecurityId": 135,
-          "Symbol": "AUD/CAD"
-        },
-        {
-          "SecurityId": 128,
-          "Symbol": "GBP/CHF"
-        },
-        {
-          "SecurityId": 129,
-          "Symbol": "CAD/CHF"
-        },
-        {
-          "SecurityId": 130,
-          "Symbol": "NZD/CHF"
-        },
-        {
-          "SecurityId": 131,
-          "Symbol": "CAD/EUR"
-        },
-        {
-          "SecurityId": 132,
-          "Symbol": "GBP/CAD"
-        },
-        {
-          "SecurityId": 133,
-          "Symbol": "CHF/AUD"
-        }
+      "BasePairs": [
+        "AUDUSD",
+        "CADUSD",
+        "CHFUSD",
+        "USDCNH",
+        "EURUSD",
+        "GBPUSD",
+        "USDJPY",
+        "USDKRW",
+        "USDMXN",
+        "USDNOK",
+        "NZDUSD",
+        "USDSEK",
+        "USDSGD",
+        "USDTWD",
+        "USDZAR"
       ]
     },
     "Environments": {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -900,21 +900,7 @@ public class OrderSenderTests
         {
             ["Programmes:0:ModelId"] = "1",
             ["Programmes:0:Session"] = "EUUS",
-            ["Programmes:0:Timeframe"] = "60",
-            ["ExternalApis:WakettApi:Symbols:0:SecurityId"] = "58",
-            ["ExternalApis:WakettApi:Symbols:0:Symbol"] = "EUR/USD",
-            ["ExternalApis:WakettApi:Symbols:1:SecurityId"] = "61",
-            ["ExternalApis:WakettApi:Symbols:1:Symbol"] = "EUR/CHF",
-            ["ExternalApis:WakettApi:Symbols:2:SecurityId"] = "62",
-            ["ExternalApis:WakettApi:Symbols:2:Symbol"] = "CAD/JPY",
-            ["ExternalApis:WakettApi:Symbols:3:SecurityId"] = "64",
-            ["ExternalApis:WakettApi:Symbols:3:Symbol"] = "USD/CAD",
-            ["ExternalApis:WakettApi:Symbols:4:SecurityId"] = "65",
-            ["ExternalApis:WakettApi:Symbols:4:Symbol"] = "USD/JPY",
-            ["ExternalApis:WakettApi:Symbols:5:SecurityId"] = "66",
-            ["ExternalApis:WakettApi:Symbols:5:Symbol"] = "EUR/USD",
-            ["ExternalApis:WakettApi:Symbols:6:SecurityId"] = "136",
-            ["ExternalApis:WakettApi:Symbols:6:Symbol"] = "USD/CHF"
+            ["Programmes:0:Timeframe"] = "60"
         };
 
         foreach (var kvp in values)


### PR DESCRIPTION
## Summary
- load the Wakett base pairs from configuration, resolve their security identifiers from the core.Security table, and derive every cross symbol directly from the database so computed rates can be generated automatically
- simplify the configuration by replacing the old symbol/missing symbol arrays with a BasePairs list and update the order sender so it no longer depends on those sections
- refresh the order sender tests to reflect the new configuration shape

## Testing
- not run (dotnet CLI is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c3ede4d488333b4d1c83d76923c5b)