### PR TITLE
Use environment-specific Intraday database

### DIFF
--- a/scripts/sql/CreateTestStoredProcs.sql
+++ b/scripts/sql/CreateTestStoredProcs.sql
@@ -1,4 +1,4 @@
-USE [Intraday]
+USE [Intraday_Test]
 GO
 
 SET ANSI_NULLS ON
@@ -124,7 +124,7 @@ BEGIN
 END;
 GO
 
-USE [Intraday]
+USE [Intraday_Test]
 GO
 
 SET ANSI_NULLS ON

--- a/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
+++ b/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using TradingDaemon.Options;
@@ -11,6 +12,10 @@ public interface IDatabaseObjectNameProvider
 
 public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
 {
+    private const string ProdIntradayDatabaseName = "Intraday";
+    private const string TestIntradayDatabaseName = "Intraday_Test";
+    private const string IntradayDatabaseToken = "[Intraday]";
+
     private static readonly IReadOnlyDictionary<string, string> DefaultNames = new Dictionary<string, string>(
         StringComparer.OrdinalIgnoreCase)
     {
@@ -35,17 +40,21 @@ public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
     {
         var names = new Dictionary<string, string>(DefaultNames, StringComparer.OrdinalIgnoreCase);
         var options = optionsAccessor?.Value;
+        DatabaseObjectNameEnvironment? environment = null;
 
         if (options is not null)
         {
+            environment = ResolveEnvironment(options);
             Merge(names, options.Objects);
 
-            var environment = ResolveEnvironment(options);
             if (environment?.Objects is not null)
             {
                 Merge(names, environment.Objects);
             }
         }
+
+        var intradayDatabaseName = ResolveIntradayDatabaseName(options);
+        ApplyIntradayDatabaseName(names, intradayDatabaseName);
 
         _names = names;
     }
@@ -75,6 +84,29 @@ public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
             }
 
             target[pair.Key] = pair.Value;
+        }
+    }
+
+    private static string ResolveIntradayDatabaseName(DatabaseObjectNameOptions? options)
+    {
+        return string.Equals(options?.ActiveEnvironment, "Test", StringComparison.OrdinalIgnoreCase)
+            ? TestIntradayDatabaseName
+            : ProdIntradayDatabaseName;
+    }
+
+    private static void ApplyIntradayDatabaseName(Dictionary<string, string> names, string databaseName)
+    {
+        if (string.Equals(databaseName, ProdIntradayDatabaseName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var replacement = $"[{databaseName}]";
+        var keys = new List<string>(names.Keys);
+
+        foreach (var key in keys)
+        {
+            names[key] = names[key].Replace(IntradayDatabaseToken, replacement, StringComparison.OrdinalIgnoreCase);
         }
     }
 


### PR DESCRIPTION
## Summary
- update the database object name provider so test environments point to the Intraday_Test database while prod keeps Intraday
- update the SQL helper script so the test stored procedures are created in Intraday_Test

## Testing
- dotnet test TradingDaemon.sln *(fails: dotnet command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4807c40c833390d77db9f34fe2eb)