### PR TITLE
Ensure default intraday object names respect environment

### DIFF
--- a/scripts/sql/CreateTestStoredProcs.sql
+++ b/scripts/sql/CreateTestStoredProcs.sql
@@ -1,4 +1,4 @@
-USE [Intraday]
+USE [Intraday_Test]
 GO
 
 SET ANSI_NULLS ON
@@ -124,7 +124,7 @@ BEGIN
 END;
 GO
 
-USE [Intraday]
+USE [Intraday_Test]
 GO
 
 SET ANSI_NULLS ON

--- a/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
+++ b/src/TradingDaemon/Data/DatabaseObjectNameProvider.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Options;
 using TradingDaemon.Options;
@@ -11,41 +12,31 @@ public interface IDatabaseObjectNameProvider
 
 public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
 {
-    private static readonly IReadOnlyDictionary<string, string> DefaultNames = new Dictionary<string, string>(
-        StringComparer.OrdinalIgnoreCase)
-    {
-        [DatabaseObjects.IntradayModelNettedWeight.Key] = "[Intraday].[model].[NettedWeight]",
-        [DatabaseObjects.IntradayModel.Key] = "[Intraday].[model].[Model]",
-        [DatabaseObjects.IntradayCoreSecurity.Key] = "[Intraday].[core].[Security]",
-        [DatabaseObjects.IntradayMarketPriceBar.Key] = "[Intraday].[mkt].[PriceBar]",
-        [DatabaseObjects.IntradayMarketFlatBar.Key] = "[Intraday].[mkt].[FlatBar]",
-        [DatabaseObjects.IntradayMarketStageHistClose.Key] = "[Intraday].[mkt].[Stage_HistClose]",
-        [DatabaseObjects.IntradayStagingFlatBar.Key] = "[Intraday].[dbo].[mkt_FlatBar_Staging]",
-        [DatabaseObjects.IntradayMarketLoadRawFromStageProc.Key] = "[Intraday].[mkt].[LoadRawFromStage]",
-        [DatabaseObjects.IntradayMarketLoadFlatFromMinimalProc.Key] = "[Intraday].[mkt].[LoadFlatFromMinimal]",
-        [DatabaseObjects.WakettFill.Key] = "[wakett].[Fill]",
-        [DatabaseObjects.WakettTradingLimit.Key] = "[wakett].[TradingLimit]",
-        [DatabaseObjects.WakettTradingLimitBreachReport.Key] = "[wakett].[TradingLimitBreachReport]",
-        [DatabaseObjects.WakettOrder.Key] = "[wakett].[Order]"
-    };
+    private const string ProdIntradayDatabaseName = "Intraday";
+    private const string TestIntradayDatabaseName = "Intraday_Test";
+    private const string IntradayDatabaseToken = "[Intraday]";
 
     private readonly IReadOnlyDictionary<string, string> _names;
 
     public DatabaseObjectNameProvider(IOptions<DatabaseObjectNameOptions>? optionsAccessor = null)
     {
-        var names = new Dictionary<string, string>(DefaultNames, StringComparer.OrdinalIgnoreCase);
         var options = optionsAccessor?.Value;
+        var intradayDatabaseName = ResolveIntradayDatabaseName(options);
+        var names = CreateDefaultNames(intradayDatabaseName);
+        DatabaseObjectNameEnvironment? environment = null;
 
         if (options is not null)
         {
+            environment = ResolveEnvironment(options);
             Merge(names, options.Objects);
 
-            var environment = ResolveEnvironment(options);
             if (environment?.Objects is not null)
             {
                 Merge(names, environment.Objects);
             }
         }
+
+        ApplyIntradayDatabaseName(names, intradayDatabaseName);
 
         _names = names;
     }
@@ -76,6 +67,56 @@ public sealed class DatabaseObjectNameProvider : IDatabaseObjectNameProvider
 
             target[pair.Key] = pair.Value;
         }
+    }
+
+    private static Dictionary<string, string> CreateDefaultNames(string intradayDatabaseName)
+    {
+        var names = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            [DatabaseObjects.IntradayModelNettedWeight.Key] = BuildIntradayObjectName(intradayDatabaseName, "model", "NettedWeight"),
+            [DatabaseObjects.IntradayModel.Key] = BuildIntradayObjectName(intradayDatabaseName, "model", "Model"),
+            [DatabaseObjects.IntradayCoreSecurity.Key] = BuildIntradayObjectName(intradayDatabaseName, "core", "Security"),
+            [DatabaseObjects.IntradayMarketPriceBar.Key] = BuildIntradayObjectName(intradayDatabaseName, "mkt", "PriceBar"),
+            [DatabaseObjects.IntradayMarketFlatBar.Key] = BuildIntradayObjectName(intradayDatabaseName, "mkt", "FlatBar"),
+            [DatabaseObjects.IntradayMarketStageHistClose.Key] = BuildIntradayObjectName(intradayDatabaseName, "mkt", "Stage_HistClose"),
+            [DatabaseObjects.IntradayStagingFlatBar.Key] = BuildIntradayObjectName(intradayDatabaseName, "dbo", "mkt_FlatBar_Staging"),
+            [DatabaseObjects.IntradayMarketLoadRawFromStageProc.Key] = BuildIntradayObjectName(intradayDatabaseName, "mkt", "LoadRawFromStage"),
+            [DatabaseObjects.IntradayMarketLoadFlatFromMinimalProc.Key] = BuildIntradayObjectName(intradayDatabaseName, "mkt", "LoadFlatFromMinimal"),
+            [DatabaseObjects.WakettFill.Key] = "[wakett].[Fill]",
+            [DatabaseObjects.WakettTradingLimit.Key] = "[wakett].[TradingLimit]",
+            [DatabaseObjects.WakettTradingLimitBreachReport.Key] = "[wakett].[TradingLimitBreachReport]",
+            [DatabaseObjects.WakettOrder.Key] = "[wakett].[Order]"
+        };
+
+        return names;
+    }
+
+    private static string ResolveIntradayDatabaseName(DatabaseObjectNameOptions? options)
+    {
+        return string.Equals(options?.ActiveEnvironment, "Test", StringComparison.OrdinalIgnoreCase)
+            ? TestIntradayDatabaseName
+            : ProdIntradayDatabaseName;
+    }
+
+    private static void ApplyIntradayDatabaseName(Dictionary<string, string> names, string databaseName)
+    {
+        if (string.Equals(databaseName, ProdIntradayDatabaseName, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var replacement = $"[{databaseName}]";
+        var keys = new List<string>(names.Keys);
+
+        foreach (var key in keys)
+        {
+            names[key] = names[key].Replace(IntradayDatabaseToken, replacement, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+
+    private static string BuildIntradayObjectName(string databaseName, string schema, string objectName)
+    {
+        return $"[{databaseName}].[{schema}].[{objectName}]";
     }
 
     private static DatabaseObjectNameEnvironment? ResolveEnvironment(DatabaseObjectNameOptions options)


### PR DESCRIPTION
## Summary
- build the default intraday object names from the resolved environment-specific database name so the dictionary itself reflects Intraday vs Intraday_Test
- keep the replacement pass so overrides that still reference [Intraday] are rewritten automatically in test environments

## Testing
- dotnet test TradingDaemon.sln *(fails: dotnet command not found in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c4807c40c833390d77db9f34fe2eb)