### PR TITLE
Add 30 and 60 minute flat bar builds

### DIFF
--- a/src/TradingDaemon/Services/FlatBarBuildSpecificationFactory.cs
+++ b/src/TradingDaemon/Services/FlatBarBuildSpecificationFactory.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+
+namespace TradingDaemon.Services;
+
+public readonly record struct FlatBarBuildSpecification(int TimeframeMinute, int OffsetMinute);
+
+public static class FlatBarBuildSpecificationFactory
+{
+    private static readonly IReadOnlyList<FlatBarBuildSpecification> AdditionalSpecifications = new[]
+    {
+        new FlatBarBuildSpecification(30, 6),
+        new FlatBarBuildSpecification(60, 6)
+    };
+
+    public static IReadOnlyList<FlatBarBuildSpecification> CreateDefault(int baseTimeframeMinute, int baseOffsetMinute)
+        => Create(baseTimeframeMinute, baseOffsetMinute, AdditionalSpecifications);
+
+    private static IReadOnlyList<FlatBarBuildSpecification> Create(
+        int baseTimeframeMinute,
+        int baseOffsetMinute,
+        IReadOnlyList<FlatBarBuildSpecification> additionalSpecifications)
+    {
+        var builds = new List<FlatBarBuildSpecification>();
+        var seen = new HashSet<(int TimeframeMinute, int OffsetMinute)>();
+
+        void TryAdd(int timeframeMinute, int offsetMinute)
+        {
+            if (timeframeMinute <= 0)
+            {
+                return;
+            }
+
+            var normalized = NormalizeOffset(offsetMinute);
+            var sanitizedTimeframe = Math.Max(1, timeframeMinute);
+            if (seen.Add((sanitizedTimeframe, normalized)))
+            {
+                builds.Add(new FlatBarBuildSpecification(sanitizedTimeframe, normalized));
+            }
+        }
+
+        TryAdd(baseTimeframeMinute, baseOffsetMinute);
+
+        foreach (var spec in additionalSpecifications)
+        {
+            TryAdd(spec.TimeframeMinute, spec.OffsetMinute);
+        }
+
+        return builds;
+    }
+
+    private static int NormalizeOffset(int offsetMinute)
+    {
+        var normalized = offsetMinute % 60;
+        if (normalized < 0)
+        {
+            normalized += 60;
+        }
+
+        return normalized;
+    }
+}

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -100,24 +100,48 @@ public class PriceFetcher
             .Select(g => g.Last())
             .ToList();
 
-        await connection.ExecuteAsync($"DELETE FROM {_flatBarStagingTable}");
-        var flatRecords = new List<FlatPrice>();
-        foreach (var grp in allBars.GroupBy(r => r.SecurityId))
-        {
-            var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
-            var rawEU = RawNMin(ordered, PriceTimeframeMinute, "EU", 0);
-            var flatEU = Flatten(rawEU, SessionBounds["EU"].Zone)
-                .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "EU" });
-            flatRecords.AddRange(flatEU);
+        var seriesBySecurity = allBars
+            .GroupBy(r => r.SecurityId)
+            .Select(g => new { SecurityId = g.Key, Series = g.OrderBy(r => r.BarTimeUtc).ToList() })
+            .ToList();
 
-            var rawUS = RawNMin(ordered, PriceTimeframeMinute, "US", 0);
-            var flatUS = Flatten(rawUS, SessionBounds["US"].Zone)
-                .Select(r => new FlatPrice { SecurityId = grp.Key, BarTimeUtc = r.TimestampUtc, Close = r.Close, Session = "US" });
-            flatRecords.AddRange(flatUS);
-        }
+        var flatBarBuilds = FlatBarBuildSpecificationFactory.CreateDefault(PriceTimeframeMinute, 0);
 
-        if (flatRecords.Count > 0)
+        foreach (var build in flatBarBuilds)
         {
+            var flatRecords = new List<FlatPrice>();
+            foreach (var grp in seriesBySecurity)
+            {
+                var rawEU = RawNMin(grp.Series, build.TimeframeMinute, "EU", build.OffsetMinute);
+                var flatEU = Flatten(rawEU, SessionBounds["EU"].Zone)
+                    .Select(r => new FlatPrice
+                    {
+                        SecurityId = grp.SecurityId,
+                        BarTimeUtc = r.TimestampUtc,
+                        Close = r.Close,
+                        Session = "EU"
+                    });
+                flatRecords.AddRange(flatEU);
+
+                var rawUS = RawNMin(grp.Series, build.TimeframeMinute, "US", build.OffsetMinute);
+                var flatUS = Flatten(rawUS, SessionBounds["US"].Zone)
+                    .Select(r => new FlatPrice
+                    {
+                        SecurityId = grp.SecurityId,
+                        BarTimeUtc = r.TimestampUtc,
+                        Close = r.Close,
+                        Session = "US"
+                    });
+                flatRecords.AddRange(flatUS);
+            }
+
+            if (flatRecords.Count == 0)
+            {
+                continue;
+            }
+
+            await connection.ExecuteAsync($"DELETE FROM {_flatBarStagingTable}");
+
             var table = new DataTable();
             table.Columns.Add("SecurityId", typeof(string));
             table.Columns.Add("BarTimeUtc", typeof(DateTime));
@@ -136,7 +160,8 @@ public class PriceFetcher
             }
 
             // Move staged flat bars into the main table for each session.
-            await _priceProcedures.LoadFlatFromMinimalAsync(connection, PriceTimeframeMinute);
+            await _priceProcedures.LoadFlatFromMinimalAsync(connection, build.TimeframeMinute);
+        }
     }
     }
 

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -946,35 +946,46 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
                 .Select(g => g.Last())
                 .ToList();
 
-            var flatRecords = new List<FlatPrice>();
-            foreach (var grp in existing.GroupBy(r => r.SecurityId))
-            {
-                var ordered = grp.OrderBy(r => r.BarTimeUtc).ToList();
-                var rawEu = RawNMin(ordered, PriceTimeframeMinute, "EU", minuteOffset);
-                var flatEu = Flatten(rawEu, SessionBounds["EU"].Zone)
-                    .Select(r => new FlatPrice
-                    {
-                        SecurityId = grp.Key,
-                        BarTimeUtc = r.TimestampUtc,
-                        Close = r.Close,
-                        Session = "EU"
-                    });
-                flatRecords.AddRange(flatEu);
+            var seriesBySecurity = existing
+                .GroupBy(r => r.SecurityId)
+                .Select(g => new { SecurityId = g.Key, Series = g.OrderBy(r => r.BarTimeUtc).ToList() })
+                .ToList();
 
-                var rawUs = RawNMin(ordered, PriceTimeframeMinute, "US", minuteOffset);
-                var flatUs = Flatten(rawUs, SessionBounds["US"].Zone)
-                    .Select(r => new FlatPrice
-                    {
-                        SecurityId = grp.Key,
-                        BarTimeUtc = r.TimestampUtc,
-                        Close = r.Close,
-                        Session = "US"
-                    });
-                flatRecords.AddRange(flatUs);
-            }
+            var flatBarBuilds = FlatBarBuildSpecificationFactory.CreateDefault(PriceTimeframeMinute, minuteOffset);
 
-            if (flatRecords.Count > 0)
+            foreach (var build in flatBarBuilds)
             {
+                var flatRecords = new List<FlatPrice>();
+                foreach (var grp in seriesBySecurity)
+                {
+                    var rawEu = RawNMin(grp.Series, build.TimeframeMinute, "EU", build.OffsetMinute);
+                    var flatEu = Flatten(rawEu, SessionBounds["EU"].Zone)
+                        .Select(r => new FlatPrice
+                        {
+                            SecurityId = grp.SecurityId,
+                            BarTimeUtc = r.TimestampUtc,
+                            Close = r.Close,
+                            Session = "EU"
+                        });
+                    flatRecords.AddRange(flatEu);
+
+                    var rawUs = RawNMin(grp.Series, build.TimeframeMinute, "US", build.OffsetMinute);
+                    var flatUs = Flatten(rawUs, SessionBounds["US"].Zone)
+                        .Select(r => new FlatPrice
+                        {
+                            SecurityId = grp.SecurityId,
+                            BarTimeUtc = r.TimestampUtc,
+                            Close = r.Close,
+                            Session = "US"
+                        });
+                    flatRecords.AddRange(flatUs);
+                }
+
+                if (flatRecords.Count == 0)
+                {
+                    continue;
+                }
+
                 await connection.ExecuteAsync($"DELETE FROM {_flatBarStagingTable}");
 
                 var table = new DataTable();
@@ -998,9 +1009,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
                 {
                     throw new InvalidOperationException("Expected SqlConnection for bulk copy operations.");
                 }
-            }
 
-            await _priceProcedures.LoadFlatFromMinimalAsync(connection, PriceTimeframeMinute, cancellationToken);
+                await _priceProcedures.LoadFlatFromMinimalAsync(connection, build.TimeframeMinute, cancellationToken);
+            }
         }
     }
 

--- a/tests/TradingDaemon.Tests/FlatBarBuildSpecificationFactoryTests.cs
+++ b/tests/TradingDaemon.Tests/FlatBarBuildSpecificationFactoryTests.cs
@@ -1,0 +1,27 @@
+using System.Linq;
+using TradingDaemon.Services;
+using Xunit;
+
+public class FlatBarBuildSpecificationFactoryTests
+{
+    [Fact]
+    public void CreateDefault_IncludesBaseAndAdditionalSchedules()
+    {
+        var builds = FlatBarBuildSpecificationFactory.CreateDefault(15, 0);
+
+        Assert.Equal(3, builds.Count);
+        Assert.Contains(builds, b => b.TimeframeMinute == 15 && b.OffsetMinute == 0);
+        Assert.Contains(builds, b => b.TimeframeMinute == 30 && b.OffsetMinute == 6);
+        Assert.Contains(builds, b => b.TimeframeMinute == 60 && b.OffsetMinute == 6);
+    }
+
+    [Fact]
+    public void CreateDefault_DeduplicatesEquivalentBuilds()
+    {
+        var builds = FlatBarBuildSpecificationFactory.CreateDefault(30, 66);
+
+        Assert.Equal(2, builds.Count);
+        Assert.Single(builds.Where(b => b.TimeframeMinute == 30 && b.OffsetMinute == 6));
+        Assert.Single(builds.Where(b => b.TimeframeMinute == 60 && b.OffsetMinute == 6));
+    }
+}


### PR DESCRIPTION
## Summary
- build flat bar schedules for the configured timeframe as well as new 30-minute (:06/:36) and 60-minute (:06) bars via a shared factory
- update both the CSV and Wakett price fetchers to iterate over the new build set when recreating flattened bars
- add unit coverage for the build factory to ensure the expected schedules are emitted

## Testing
- `dotnet test` *(fails: `dotnet` command is not available in the execution environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c630c0b7c8333a7b9fcb4b480f6dd)