### PR TITLE
Skip redundant Wakett price fetches

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -31,6 +31,7 @@ public class WakettPriceFetcher
     private readonly string _flatBarStagingTable;
     private readonly string _priceBarWindowQuery;
     private readonly string _priceBarSelectWithOffsetSql;
+    private readonly string _priceBarTimestampPresenceSql;
     private readonly string _stageDeleteSql;
     private readonly string _stageInsertSql;
     private readonly string _priceBarTable;
@@ -40,6 +41,8 @@ public class WakettPriceFetcher
 
 
     private IReadOnlyList<int>? _priceMinuteOffsets;
+
+    private static readonly TimeSpan HistoricalWindow = TimeSpan.FromHours(6);
 
     private IReadOnlyList<int> PriceMinuteOffsets => _priceMinuteOffsets ??= LoadMinuteOffsets();
 
@@ -66,6 +69,7 @@ public class WakettPriceFetcher
         _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
         _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
         _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+        _priceBarTimestampPresenceSql = $"SELECT SecurityId FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND BarTimeUtc = @BarTimeUtc";
         _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
     }
@@ -112,9 +116,18 @@ public class WakettPriceFetcher
             missingBars.AddRange(missingForOffset.Select(bar => (minuteOffset, bar)));
         }
 
-        if (missingBars.Count == 0)
+        var nowUtc = DateTimeOffset.UtcNow;
+        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow);
+
+        var fetchableMissingBars = missingBars
+            .Where(entry => entry.BarTimeUtc.AddMinutes(entry.MinuteOffset) >= historicalWindowStart.UtcDateTime)
+            .ToList();
+
+        if (fetchableMissingBars.Count == 0)
         {
-            _logger.LogInformation("No missing Wakett price bars detected in the last 24 hours for configured minute offsets.");
+            _logger.LogInformation(
+                "No missing Wakett price bars detected within the last {Hours} hours for configured minute offsets.",
+                HistoricalWindow.TotalHours);
             return null;
         }
 
@@ -122,16 +135,14 @@ public class WakettPriceFetcher
         var wakettSymbols = BuildWakettRequestSymbols(baseSymbols);
         WakettPriceUploadResult? lastResult = null;
 
-        var nowUtc = DateTimeOffset.UtcNow;
-        var historicalWindowStart = nowUtc.AddHours(-6);
-
-        foreach (var (minuteOffset, barTimeUtc) in missingBars
+        foreach (var (minuteOffset, barTimeUtc) in fetchableMissingBars
             .OrderBy(entry => entry.BarTimeUtc.AddMinutes(entry.MinuteOffset)))
         {
 
             var baseTimestamp = new DateTimeOffset(barTimeUtc, TimeSpan.Zero);
             var requestTimestamp = baseTimestamp.AddMinutes(minuteOffset);
             var expectedBarTimestamp = baseTimestamp.AddMinutes(minuteOffset);
+            var expectedBarTimestampUtc = DateTime.SpecifyKind(expectedBarTimestamp.UtcDateTime, DateTimeKind.Utc);
 
             if (requestTimestamp > nowUtc)
             {
@@ -146,6 +157,14 @@ public class WakettPriceFetcher
                 _logger.LogInformation(
                     "Skipping Wakett price request for timestamp {TimestampUtc} because it is outside the 6-hour history window.",
                     requestTimestamp.UtcDateTime);
+                continue;
+            }
+
+            if (!await ArePricesMissingForTimestampAsync(allSecurityIds, expectedBarTimestampUtc, cancellationToken))
+            {
+                _logger.LogInformation(
+                    "Skipping Wakett price request for timestamp {TimestampUtc} because all price bars already exist.",
+                    expectedBarTimestampUtc);
                 continue;
             }
 
@@ -248,13 +267,20 @@ public class WakettPriceFetcher
 
         var securityIds = symbolConfiguration.AllSecurityIds;
 
+        var nowUtc = DateTimeOffset.UtcNow;
+        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow).UtcDateTime;
+
         var missingByOffset = new List<(int MinuteOffset, IReadOnlyList<DateTime> Missing)>();
         foreach (var minuteOffset in PriceMinuteOffsets)
         {
             var missingBars = await FindMissingBarTimestampsAsync(securityIds, minuteOffset, cancellationToken);
-            if (missingBars.Count > 0)
+            var relevantMissing = missingBars
+                .Where(bar => bar.AddMinutes(minuteOffset) >= historicalWindowStart)
+                .ToList();
+
+            if (relevantMissing.Count > 0)
             {
-                missingByOffset.Add((minuteOffset, missingBars));
+                missingByOffset.Add((minuteOffset, relevantMissing));
             }
         }
 
@@ -802,6 +828,48 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         }
 
         return missing;
+    }
+
+    private async Task<bool> ArePricesMissingForTimestampAsync(
+        IReadOnlyCollection<int> securityIds,
+        DateTime expectedBarTimestampUtc,
+        CancellationToken cancellationToken)
+    {
+        if (securityIds.Count == 0)
+        {
+            return false;
+        }
+
+        var ids = securityIds.ToArray();
+        using var connection = _context.CreateConnection();
+        if (connection is DbConnection dbConnection)
+        {
+            await dbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            connection.Open();
+        }
+
+        var rows = await connection.QueryAsync<int>(
+            _priceBarTimestampPresenceSql,
+            new
+            {
+                SecurityIds = ids,
+                BarTimeUtc = expectedBarTimestampUtc
+            });
+
+        var present = new HashSet<int>();
+        foreach (var securityId in rows)
+        {
+            present.Add(securityId);
+            if (present.Count == ids.Length)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     internal static IReadOnlyList<DateTime> BuildExpectedBarHours(DateTime endHourUtc, int count)


### PR DESCRIPTION
## Summary
- add an explicit presence check before each Wakett fetch so requests are only issued when the bar is still missing in the database
- reuse a new timestamp-specific query to ensure the checker runs quickly without re-enumerating the whole 24-hour window

## Testing
- `dotnet build` *(fails: `dotnet` command is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb016d33c83339932635b8640ca36)