### PR TITLE
Exclude base securities from Wakett price validation

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -31,6 +31,7 @@ public class WakettPriceFetcher
     private readonly string _flatBarStagingTable;
     private readonly string _priceBarWindowQuery;
     private readonly string _priceBarSelectWithOffsetSql;
+    private readonly string _priceBarTimestampPresenceSql;
     private readonly string _stageDeleteSql;
     private readonly string _stageInsertSql;
     private readonly string _priceBarTable;
@@ -40,6 +41,8 @@ public class WakettPriceFetcher
 
 
     private IReadOnlyList<int>? _priceMinuteOffsets;
+
+    private static readonly TimeSpan HistoricalWindow = TimeSpan.FromHours(6);
 
     private IReadOnlyList<int> PriceMinuteOffsets => _priceMinuteOffsets ??= LoadMinuteOffsets();
 
@@ -66,6 +69,7 @@ public class WakettPriceFetcher
         _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
         _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
         _priceBarSelectWithOffsetSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset";
+        _priceBarTimestampPresenceSql = $"SELECT SecurityId FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND BarTimeUtc = @BarTimeUtc";
         _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
     }
@@ -101,20 +105,37 @@ public class WakettPriceFetcher
         var baseSymbols = symbolConfiguration.BaseSymbols;
         var missingSymbols = symbolConfiguration.MissingSymbols;
         var allSecurityIds = symbolConfiguration.AllSecurityIds;
+        var uploadSecurityIds = symbolConfiguration.NonBaseSecurityIds;
+        var uploadSecurityIdSet = new HashSet<int>(uploadSecurityIds);
+
+        if (uploadSecurityIds.Length == 0)
+        {
+            _logger.LogInformation("No non-base Wakett securities require database uploads.");
+            return null;
+        }
 
         var missingBars = new List<(int MinuteOffset, DateTime BarTimeUtc)>();
         foreach (var minuteOffset in PriceMinuteOffsets)
         {
             var missingForOffset = await FindMissingBarTimestampsAsync(
-                allSecurityIds,
+                uploadSecurityIds,
                 minuteOffset,
                 cancellationToken);
             missingBars.AddRange(missingForOffset.Select(bar => (minuteOffset, bar)));
         }
 
-        if (missingBars.Count == 0)
+        var nowUtc = DateTimeOffset.UtcNow;
+        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow);
+
+        var fetchableMissingBars = missingBars
+            .Where(entry => entry.BarTimeUtc.AddMinutes(entry.MinuteOffset) >= historicalWindowStart.UtcDateTime)
+            .ToList();
+
+        if (fetchableMissingBars.Count == 0)
         {
-            _logger.LogInformation("No missing Wakett price bars detected in the last 24 hours for configured minute offsets.");
+            _logger.LogInformation(
+                "No missing Wakett price bars detected within the last {Hours} hours for configured minute offsets.",
+                HistoricalWindow.TotalHours);
             return null;
         }
 
@@ -122,16 +143,14 @@ public class WakettPriceFetcher
         var wakettSymbols = BuildWakettRequestSymbols(baseSymbols);
         WakettPriceUploadResult? lastResult = null;
 
-        var nowUtc = DateTimeOffset.UtcNow;
-        var historicalWindowStart = nowUtc.AddHours(-6);
-
-        foreach (var (minuteOffset, barTimeUtc) in missingBars
+        foreach (var (minuteOffset, barTimeUtc) in fetchableMissingBars
             .OrderBy(entry => entry.BarTimeUtc.AddMinutes(entry.MinuteOffset)))
         {
 
             var baseTimestamp = new DateTimeOffset(barTimeUtc, TimeSpan.Zero);
             var requestTimestamp = baseTimestamp.AddMinutes(minuteOffset);
             var expectedBarTimestamp = baseTimestamp.AddMinutes(minuteOffset);
+            var expectedBarTimestampUtc = DateTime.SpecifyKind(expectedBarTimestamp.UtcDateTime, DateTimeKind.Utc);
 
             if (requestTimestamp > nowUtc)
             {
@@ -146,6 +165,14 @@ public class WakettPriceFetcher
                 _logger.LogInformation(
                     "Skipping Wakett price request for timestamp {TimestampUtc} because it is outside the 6-hour history window.",
                     requestTimestamp.UtcDateTime);
+                continue;
+            }
+
+            if (!await ArePricesMissingForTimestampAsync(uploadSecurityIds, expectedBarTimestampUtc, cancellationToken))
+            {
+                _logger.LogInformation(
+                    "Skipping Wakett price request for timestamp {TimestampUtc} because all price bars already exist.",
+                    expectedBarTimestampUtc);
                 continue;
             }
 
@@ -174,6 +201,11 @@ public class WakettPriceFetcher
 
             foreach (var rate in computedRates)
             {
+                if (!uploadSecurityIdSet.Contains(rate.Definition.SecurityId))
+                {
+                    continue;
+                }
+
                 if (!TryParsePair(rate.Definition.Symbol, out var configPair))
                 {
                     _logger.LogWarning(
@@ -247,14 +279,28 @@ public class WakettPriceFetcher
         }
 
         var securityIds = symbolConfiguration.AllSecurityIds;
+        var uploadSecurityIds = symbolConfiguration.NonBaseSecurityIds;
+
+        if (uploadSecurityIds.Length == 0)
+        {
+            _logger.LogInformation("No non-base Wakett securities require database uploads.");
+            return true;
+        }
+
+        var nowUtc = DateTimeOffset.UtcNow;
+        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow).UtcDateTime;
 
         var missingByOffset = new List<(int MinuteOffset, IReadOnlyList<DateTime> Missing)>();
         foreach (var minuteOffset in PriceMinuteOffsets)
         {
-            var missingBars = await FindMissingBarTimestampsAsync(securityIds, minuteOffset, cancellationToken);
-            if (missingBars.Count > 0)
+            var missingBars = await FindMissingBarTimestampsAsync(uploadSecurityIds, minuteOffset, cancellationToken);
+            var relevantMissing = missingBars
+                .Where(bar => bar.AddMinutes(minuteOffset) >= historicalWindowStart)
+                .ToList();
+
+            if (relevantMissing.Count > 0)
             {
-                missingByOffset.Add((minuteOffset, missingBars));
+                missingByOffset.Add((minuteOffset, relevantMissing));
             }
         }
 
@@ -601,7 +647,12 @@ public class WakettPriceFetcher
             .Distinct()
             .ToArray();
 
-        return new SymbolConfiguration(baseSymbols, missingSymbols, allSecurityIds);
+        var nonBaseSecurityIds = missingSymbols
+            .Select(symbol => symbol.SecurityId)
+            .Distinct()
+            .ToArray();
+
+        return new SymbolConfiguration(baseSymbols, missingSymbols, allSecurityIds, nonBaseSecurityIds);
     }
 
     private IReadOnlyList<CurrencyPair> LoadConfiguredBasePairs()
@@ -802,6 +853,48 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         }
 
         return missing;
+    }
+
+    private async Task<bool> ArePricesMissingForTimestampAsync(
+        IReadOnlyCollection<int> securityIds,
+        DateTime expectedBarTimestampUtc,
+        CancellationToken cancellationToken)
+    {
+        if (securityIds.Count == 0)
+        {
+            return false;
+        }
+
+        var ids = securityIds.ToArray();
+        using var connection = _context.CreateConnection();
+        if (connection is DbConnection dbConnection)
+        {
+            await dbConnection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            connection.Open();
+        }
+
+        var rows = await connection.QueryAsync<int>(
+            _priceBarTimestampPresenceSql,
+            new
+            {
+                SecurityIds = ids,
+                BarTimeUtc = expectedBarTimestampUtc
+            });
+
+        var present = new HashSet<int>();
+        foreach (var securityId in rows)
+        {
+            present.Add(securityId);
+            if (present.Count == ids.Length)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     internal static IReadOnlyList<DateTime> BuildExpectedBarHours(DateTime endHourUtc, int count)
@@ -1117,7 +1210,8 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private sealed record SymbolConfiguration(
         IReadOnlyList<WakettSecuritySymbol> BaseSymbols,
         IReadOnlyList<WakettSecuritySymbol> MissingSymbols,
-        int[] AllSecurityIds);
+        int[] AllSecurityIds,
+        int[] NonBaseSecurityIds);
 
     private sealed record SecuritySymbolDefinition(int SecurityId, CurrencyPair Pair);
 


### PR DESCRIPTION
## Summary
- add a `NonBaseSecurityIds` list to the Wakett symbol configuration so only uploadable securities participate in missing-bar detection and timestamp presence checks
- skip computed rates for base securities and exit early when no non-base instruments are configured, keeping the base pairs out of the database

## Testing
- `dotnet build` *(fails: `dotnet` command is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691cb016d33c83339932635b8640ca36)