### PR TITLE
Align flat bar load proc with schema

### DIFF
--- a/scripts/sql/CreateTestStoredProcs.sql
+++ b/scripts/sql/CreateTestStoredProcs.sql
@@ -192,18 +192,22 @@ BEGIN
       l.SecurityId,
       l.BarTimeUtc,
       @TimeframeMinute                AS TimeframeMinute,
-      l.CloseVal                      AS [Open],
-      l.CloseVal                      AS High,
-      l.CloseVal                      AS [Low],
-      l.CloseVal                      AS [Close],
-      CAST(NULL AS bigint)            AS Volume,
-      @Source                         AS Source,
-      CASE WHEN l.prev_ts IS NULL
-                OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
-           THEN 1 ELSE 0 END         AS IsSessionOpen,
-      CASE WHEN l.prev_ts IS NULL
-                OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
-           THEN NULL ELSE l.prev_close END AS PrevCloseInSess,
+      CAST(l.CloseVal AS decimal(18,8))      AS [Open],
+      CAST(l.CloseVal AS decimal(18,8))      AS High,
+      CAST(l.CloseVal AS decimal(18,8))      AS [Low],
+      CAST(l.CloseVal AS decimal(18,8))      AS [Close],
+      CAST(NULL AS bigint)                  AS Volume,
+      CAST(@Source AS nvarchar(32))         AS Source,
+      CAST(
+           CASE WHEN l.prev_ts IS NULL
+                     OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
+                THEN 1 ELSE 0 END
+           AS bit)                         AS IsSessionOpen,
+      CAST(
+           CASE WHEN l.prev_ts IS NULL
+                     OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
+                THEN NULL ELSE l.prev_close END
+           AS decimal(18,8))              AS PrevCloseInSess,
       @FlattenVersion                 AS FlattenVersion,
       SUSER_SNAME()                   AS CreatedBy,
       l.SessionCode                   AS SessionCode


### PR DESCRIPTION
## Summary
- ensure the LoadFlatFromMinimal procedure writes decimals, bigint volume, nvarchar source, and bit session flags that match the optimized FlatBar schema
- cast PrevCloseInSess to decimal(18,8) so it aligns with the table definition while still letting CreatedUtc use its default value

## Testing
- Not run (SQL script change only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d99d8478c833389fa90d47fd794b6)