### PR TITLE
Require explicit source id for price bar loading

### DIFF
--- a/scripts/sql/CreateTestStoredProcs.sql
+++ b/scripts/sql/CreateTestStoredProcs.sql
@@ -14,12 +14,17 @@ GO
 ----------------------------------------------*/
 CREATE OR ALTER PROCEDURE [mkt_test].[LoadRawFromStage]
   @TimeframeMinute  SMALLINT,                   -- e.g. 60
-  @Source           NVARCHAR(32) = N'HistImport',
+  @Source           TINYINT = NULL,
   @FromUtc          DATETIME2(3) = NULL,        -- optional filter on BarTimeUtc (>=)
   @ToUtc            DATETIME2(3) = NULL         -- optional filter on BarTimeUtc (<)
 AS
 BEGIN
   SET NOCOUNT ON;
+
+  IF @Source IS NULL
+  BEGIN
+      THROW 50021, 'Source identifier is required.', 1;
+  END;
 
   -- Buffer rows to upsert into the duplicated price bar table
   DECLARE @Rows TABLE (
@@ -31,7 +36,7 @@ BEGIN
       [Low]           DECIMAL(18, 8) NOT NULL,
       [Close]         DECIMAL(18, 8) NOT NULL,
       Volume          BIGINT         NULL,
-      Source          NVARCHAR(32)   NOT NULL
+      Source          TINYINT        NOT NULL
   );
 
   ;WITH ImportDeDup AS (
@@ -192,18 +197,22 @@ BEGIN
       l.SecurityId,
       l.BarTimeUtc,
       @TimeframeMinute                AS TimeframeMinute,
-      l.CloseVal                      AS [Open],
-      l.CloseVal                      AS High,
-      l.CloseVal                      AS [Low],
-      l.CloseVal                      AS [Close],
-      CAST(NULL AS bigint)            AS Volume,
-      @Source                         AS Source,
-      CASE WHEN l.prev_ts IS NULL
-                OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
-           THEN 1 ELSE 0 END         AS IsSessionOpen,
-      CASE WHEN l.prev_ts IS NULL
-                OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
-           THEN NULL ELSE l.prev_close END AS PrevCloseInSess,
+      CAST(l.CloseVal AS decimal(18,8))      AS [Open],
+      CAST(l.CloseVal AS decimal(18,8))      AS High,
+      CAST(l.CloseVal AS decimal(18,8))      AS [Low],
+      CAST(l.CloseVal AS decimal(18,8))      AS [Close],
+      CAST(NULL AS bigint)                  AS Volume,
+      CAST(@Source AS nvarchar(32))         AS Source,
+      CAST(
+           CASE WHEN l.prev_ts IS NULL
+                     OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
+                THEN 1 ELSE 0 END
+           AS bit)                         AS IsSessionOpen,
+      CAST(
+           CASE WHEN l.prev_ts IS NULL
+                     OR DATEADD(MINUTE, @TimeframeMinute, l.prev_ts) <> l.BarTimeUtc
+                THEN NULL ELSE l.prev_close END
+           AS decimal(18,8))              AS PrevCloseInSess,
       @FlattenVersion                 AS FlattenVersion,
       SUSER_SNAME()                   AS CreatedBy,
       l.SessionCode                   AS SessionCode

--- a/src/TradingDaemon/Options/PriceBarOptions.cs
+++ b/src/TradingDaemon/Options/PriceBarOptions.cs
@@ -3,4 +3,5 @@ namespace TradingDaemon.Options;
 public sealed class PriceBarOptions
 {
     public int TimeframeMinute { get; set; } = 15;
+    public int SourceId { get; set; } = 1;
 }

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -86,7 +86,10 @@ public class PriceFetcher
 
         // Load newly staged raw bars into the PriceBar table so that subsequent
         // queries include the latest data.
-        await _priceProcedures.LoadRawFromStageAsync(connection, PriceTimeframeMinute);
+        await _priceProcedures.LoadRawFromStageAsync(
+            connection,
+            PriceTimeframeMinute,
+            _priceBarOptions.SourceId);
 
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only

--- a/src/TradingDaemon/Services/PriceProcessingProcedureExecutor.cs
+++ b/src/TradingDaemon/Services/PriceProcessingProcedureExecutor.cs
@@ -11,6 +11,7 @@ public interface IPriceProcessingProcedureExecutor
     Task LoadRawFromStageAsync(
         IDbConnection connection,
         int timeframeMinute,
+        int sourceId,
         CancellationToken cancellationToken = default);
 
     Task LoadFlatFromMinimalAsync(
@@ -33,11 +34,12 @@ internal sealed class PriceProcessingProcedureExecutor : IPriceProcessingProcedu
     public Task LoadRawFromStageAsync(
         IDbConnection connection,
         int timeframeMinute,
+        int sourceId,
         CancellationToken cancellationToken = default)
     {
         var command = new CommandDefinition(
             _loadRawFromStageProc,
-            new { TimeframeMinute = timeframeMinute },
+            new { TimeframeMinute = timeframeMinute, Source = sourceId },
             commandType: CommandType.StoredProcedure,
             cancellationToken: cancellationToken);
 

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1031,7 +1031,11 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
         if (recordList.Count > 0)
         {
-            await _priceProcedures.LoadRawFromStageAsync(connection, PriceTimeframeMinute, cancellationToken);
+            await _priceProcedures.LoadRawFromStageAsync(
+                connection,
+                PriceTimeframeMinute,
+                _priceBarOptions.SourceId,
+                cancellationToken);
 
             var selectRaw = _priceBarSelectWithOffsetSql;
             var existing = (await connection.QueryAsync<HistClose>(selectRaw, new { SecurityIds = securityKeys, MinuteOffset = minuteOffset }))

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -114,7 +114,8 @@
     //}
   ],
   "PriceBars": {
-    "TimeframeMinute": 15
+    "TimeframeMinute": 15,
+    "SourceId": 1
   },
   "Quartz": {
     "Cron": "0 1,16,31,46 2-15 ? * *",


### PR DESCRIPTION
## Summary
- require the LoadRawFromStage stored procedure to accept a tinyint source id and throw when it is omitted so it stays aligned with the PriceBar schema
- plumb the configured `PriceBars:SourceId` option through `PriceProcessingProcedureExecutor`, `PriceFetcher`, and `WakettPriceFetcher` so the stored procedure always receives a valid source id
- expose the new `SourceId` option in `PriceBarOptions` and `appsettings.json`

## Testing
- Not run (dotnet CLI is unavailable in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d99d8478c833389fa90d47fd794b6)