### PR TITLE
Add SQL timeout logging middleware

### DIFF
--- a/src/TradingDaemon/Middleware/SqlTimeoutLoggingMiddleware.cs
+++ b/src/TradingDaemon/Middleware/SqlTimeoutLoggingMiddleware.cs
@@ -1,0 +1,59 @@
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace TradingDaemon.Middleware;
+
+/// <summary>
+/// Captures SQL timeout exceptions and logs the HTTP request information so that
+/// the failing endpoint can be identified from the logs.
+/// </summary>
+public sealed class SqlTimeoutLoggingMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly ILogger<SqlTimeoutLoggingMiddleware> _logger;
+
+    public SqlTimeoutLoggingMiddleware(RequestDelegate next, ILogger<SqlTimeoutLoggingMiddleware> logger)
+    {
+        _next = next;
+        _logger = logger;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        try
+        {
+            await _next(context);
+        }
+        catch (SqlException ex) when (IsTimeout(ex))
+        {
+            var queryString = context.Request.QueryString.HasValue
+                ? context.Request.QueryString.Value
+                : string.Empty;
+
+            _logger.LogError(
+                ex,
+                "SQL timeout while handling {Method} {Path}{QueryString}. TraceIdentifier: {TraceIdentifier}",
+                context.Request.Method,
+                context.Request.Path,
+                queryString,
+                context.TraceIdentifier);
+
+            throw;
+        }
+    }
+
+    private static bool IsTimeout(SqlException exception)
+    {
+        if (exception.Number == -2)
+        {
+            return true;
+        }
+
+        // SqlException may contain multiple errors, so fall back to inspecting them as well.
+        return exception.Errors
+            .Cast<SqlError>()
+            .Any(error => error.Number == -2);
+    }
+}

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -5,6 +5,7 @@ using Serilog;
 using TradingDaemon.Controllers;
 using TradingDaemon.Data;
 using TradingDaemon.Logging;
+using TradingDaemon.Middleware;
 using TradingDaemon.Services;
 using TradingDaemon.Models;
 using TradingDaemon.Utils;
@@ -97,6 +98,8 @@ var app = builder.Build();
         c.RoutePrefix = string.Empty;  // Swagger accessible à la racine
     });
 }
+
+app.UseMiddleware<SqlTimeoutLoggingMiddleware>();
 
 app.MapFillEndpoints();
 app.MapPriceEndpoints();


### PR DESCRIPTION
## Summary
- add a middleware that logs the HTTP request information whenever a SQL timeout exception bubbles up
- register the middleware in the ASP.NET Core pipeline so that timeouts can be tied back to the originating endpoint

## Testing
- Not run (dotnet CLI is not available in the execution environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d9eabbdac8333a26e0fc12cf5a816)