### PR TITLE
Add script to ensure stage tables exist

### DIFF
--- a/scripts/sql/EnsureStageTables.sql
+++ b/scripts/sql/EnsureStageTables.sql
@@ -1,0 +1,56 @@
+/*
+    Script: EnsureStageTables.sql
+    Purpose: Create the Wakett staging tables inside the currently
+             selected database when they have not yet been provisioned.
+
+    Usage:
+        1. Connect to the intraday database (e.g., Intraday_Test) in
+           SQL Server Management Studio or sqlcmd.
+        2. Execute this script. Existing tables are left untouched; any
+           missing table is created with the expected schema.
+*/
+
+SET NOCOUNT ON;
+
+IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'mkt')
+BEGIN
+    PRINT 'Schema [mkt] does not exist. Creating it...';
+    EXEC('CREATE SCHEMA [mkt];');
+END;
+
+IF OBJECT_ID(N'[mkt].[Stage_HistClose]', N'U') IS NULL
+BEGIN
+    PRINT 'Creating [mkt].[Stage_HistClose]...';
+
+    CREATE TABLE [mkt].[Stage_HistClose]
+    (
+        [SecurityId] INT NOT NULL,
+        [BarTimeUtc] DATETIME2(3) NOT NULL,
+        [Close] DECIMAL(18, 8) NOT NULL,
+        CONSTRAINT [PK_Stage_HistClose]
+            PRIMARY KEY CLUSTERED ([SecurityId], [BarTimeUtc])
+    );
+END;
+ELSE
+BEGIN
+    PRINT '[mkt].[Stage_HistClose] already exists. Skipping creation.';
+END;
+
+IF OBJECT_ID(N'[mkt].[Stage_HistClose_Flat]', N'U') IS NULL
+BEGIN
+    PRINT 'Creating [mkt].[Stage_HistClose_Flat]...';
+
+    CREATE TABLE [mkt].[Stage_HistClose_Flat]
+    (
+        [SecurityId] INT NOT NULL,
+        [Session] NVARCHAR(16) NOT NULL,
+        [BarTimeUtc] DATETIME2(3) NOT NULL,
+        [Close] DECIMAL(18, 8) NOT NULL,
+        CONSTRAINT [PK_Stage_HistClose_Flat]
+            PRIMARY KEY CLUSTERED ([SecurityId], [Session], [BarTimeUtc])
+    );
+END;
+ELSE
+BEGIN
+    PRINT '[mkt].[Stage_HistClose_Flat] already exists. Skipping creation.';
+END;

--- a/scripts/sql/README.md
+++ b/scripts/sql/README.md
@@ -2,6 +2,15 @@
 
 This folder contains utility scripts for managing the Wakett and intraday database schema.
 
+## Creating staging tables on demand
+
+Use [`EnsureStageTables.sql`](./EnsureStageTables.sql) when provisioning a
+fresh environment. It checks for the `mkt.Stage_HistClose` and
+`mkt.Stage_HistClose_Flat` tables inside the currently selected database and
+creates them if they are missing. Run the script while connected to either the
+production or duplicated test database so the stage tables always exist before
+running the data loaders.
+
 ## Refreshing test tables from production
 
 The [`RefreshTestTables.sql`](./RefreshTestTables.sql) script truncates each test table and reloads it from the production equivalent so that the duplicated environment stays in sync. It:


### PR DESCRIPTION
## Summary
- add an EnsureStageTables.sql helper that creates mkt.Stage_HistClose and mkt.Stage_HistClose_Flat when they are missing
- document the new helper script in scripts/sql/README.md so it is easy to discover when provisioning environments

## Testing
- not run (SQL-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dba5cc50083339f0b57d18fd5116e)