### PR TITLE
Fix flattening algorithm for flat bars

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -243,28 +243,49 @@ public class PriceFetcher
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)
     {
-        if (raw.Count == 0) return new();
-        var times = raw.Select(r => r.TimestampUtc).ToList();
-        var px = raw.Select(r => r.Close).ToList();
-        var localTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, zone)).ToList();
-        var ret = new decimal[px.Count];
-        for (int i = 1; i < px.Count; i++)
+        if (raw.Count == 0)
         {
-            var prev = px[i - 1];
-            ret[i] = prev != 0 ? (px[i] - prev) / prev : 0m;
-            if (localTimes[i].Date != localTimes[i - 1].Date)
-                ret[i] = 0m;
+            return new();
         }
-        var flat = new decimal[px.Count];
-        flat[px.Count - 1] = px[px.Count - 1];
-        for (int i = px.Count - 2; i >= 0; i--)
+
+        var ordered = raw
+            .OrderBy(r => r.TimestampUtc)
+            .ToList();
+        var count = ordered.Count;
+
+        var localDates = ordered
+            .Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).Date)
+            .ToArray();
+
+        var returns = new decimal[count];
+        for (var i = 1; i < count; i++)
         {
-            var inc = ret[i + 1];
-            flat[i] = flat[i + 1] / (1 + inc);
+            var prevClose = ordered[i - 1].Close;
+            returns[i] = prevClose != 0 ? (ordered[i].Close / prevClose) - 1m : 0m;
         }
-        var result = new List<(DateTime, decimal)>();
-        for (int i = 0; i < px.Count; i++)
-            result.Add((times[i], flat[i]));
+
+        for (var i = 1; i < count; i++)
+        {
+            if (localDates[i] != localDates[i - 1])
+            {
+                returns[i] = 0m;
+            }
+        }
+
+        var flattenedCloses = new decimal[count];
+        flattenedCloses[count - 1] = ordered[count - 1].Close;
+        for (var i = count - 2; i >= 0; i--)
+        {
+            var inc = returns[i + 1];
+            flattenedCloses[i] = flattenedCloses[i + 1] / (1 + inc);
+        }
+
+        var result = new List<(DateTime TimestampUtc, decimal Close)>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add((ordered[i].TimestampUtc, flattenedCloses[i]));
+        }
+
         return result;
     }
 }

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1181,28 +1181,49 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)
     {
-        if (raw.Count == 0) return new();
-        var times = raw.Select(r => r.TimestampUtc).ToList();
-        var px = raw.Select(r => r.Close).ToList();
-        var localTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, zone)).ToList();
-        var ret = new decimal[px.Count];
-        for (int i = 1; i < px.Count; i++)
+        if (raw.Count == 0)
         {
-            var prev = px[i - 1];
-            ret[i] = prev != 0 ? (px[i] - prev) / prev : 0m;
-            if (localTimes[i].Date != localTimes[i - 1].Date)
-                ret[i] = 0m;
+            return new();
         }
-        var flat = new decimal[px.Count];
-        flat[px.Count - 1] = px[px.Count - 1];
-        for (int i = px.Count - 2; i >= 0; i--)
+
+        var ordered = raw
+            .OrderBy(r => r.TimestampUtc)
+            .ToList();
+        var count = ordered.Count;
+
+        var localDates = ordered
+            .Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).Date)
+            .ToArray();
+
+        var returns = new decimal[count];
+        for (var i = 1; i < count; i++)
         {
-            var inc = ret[i + 1];
-            flat[i] = flat[i + 1] / (1 + inc);
+            var prevClose = ordered[i - 1].Close;
+            returns[i] = prevClose != 0 ? (ordered[i].Close / prevClose) - 1m : 0m;
         }
-        var result = new List<(DateTime, decimal)>();
-        for (int i = 0; i < px.Count; i++)
-            result.Add((times[i], flat[i]));
+
+        for (var i = 1; i < count; i++)
+        {
+            if (localDates[i] != localDates[i - 1])
+            {
+                returns[i] = 0m;
+            }
+        }
+
+        var flattenedCloses = new decimal[count];
+        flattenedCloses[count - 1] = ordered[count - 1].Close;
+        for (var i = count - 2; i >= 0; i--)
+        {
+            var inc = returns[i + 1];
+            flattenedCloses[i] = flattenedCloses[i + 1] / (1 + inc);
+        }
+
+        var result = new List<(DateTime TimestampUtc, decimal Close)>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add((ordered[i].TimestampUtc, flattenedCloses[i]));
+        }
+
         return result;
     }
 

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -175,4 +175,36 @@ public class PriceFetcherTests
         Assert.Contains(new TimeSpan(10, 0, 0), times);
         Assert.Contains(new TimeSpan(15, 0, 0), times);
     }
+
+    [Fact]
+    public void Flatten_ZeroesOvernightReturnsAndPreservesIntraday()
+    {
+        var raw = new List<(DateTime TimestampUtc, decimal Close)>
+        {
+            (new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc), 100m),
+            (new DateTime(2024, 1, 1, 11, 0, 0, DateTimeKind.Utc), 105m),
+            (new DateTime(2024, 1, 2, 10, 0, 0, DateTimeKind.Utc), 110m),
+            (new DateTime(2024, 1, 2, 11, 0, 0, DateTimeKind.Utc), 121m)
+        };
+
+        var zone = TimeZoneInfo.Utc;
+
+        var flat = (List<(DateTime TimestampUtc, decimal Close)>)typeof(PriceFetcher)
+            .GetMethod("Flatten", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, new object[] { raw, zone })!;
+
+        static decimal ReturnBetween((DateTime TimestampUtc, decimal Close) prev, (DateTime TimestampUtc, decimal Close) next)
+            => prev.Close != 0 ? (next.Close - prev.Close) / prev.Close : 0m;
+
+        var expectedIntradayFirst = ReturnBetween(raw[0], raw[1]);
+        var expectedIntradaySecond = ReturnBetween(raw[2], raw[3]);
+
+        var flattenedFirst = ReturnBetween(flat[0], flat[1]);
+        var flattenedOvernight = ReturnBetween(flat[1], flat[2]);
+        var flattenedSecond = ReturnBetween(flat[2], flat[3]);
+
+        Assert.Equal(expectedIntradayFirst, flattenedFirst);
+        Assert.Equal(0m, flattenedOvernight);
+        Assert.Equal(expectedIntradaySecond, flattenedSecond);
+    }
 }


### PR DESCRIPTION
## Summary
- rewrite the shared flattening routine to explicitly compute returns, zero out overnight transitions, and rebuild prices from the most recent bar for both the legacy and Wakett price fetchers
- add a regression test to ensure overnight returns are zeroed while intraday returns remain unchanged

## Testing
- Not Run (dotnet CLI is not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc67d3ec483339eabd4b27442348f)