### PR TITLE
Adjust EU session flattening window

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -170,7 +170,7 @@ public class PriceFetcher
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+        ["EU"] = (CentralEuropeZone, TimeSpan.Parse("07:06"), TimeSpan.Parse("13:51"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
@@ -232,39 +232,59 @@ public class PriceFetcher
             throw new ArgumentOutOfRangeException(nameof(minutes), "Aggregation interval must be positive.");
         }
 
-        if (sessionStart == TimeSpan.Zero)
+        if (sessionStart < TimeSpan.Zero)
         {
-            return TimeSpan.Zero;
+            throw new ArgumentOutOfRangeException(nameof(sessionStart), "Session start cannot be negative.");
         }
 
-        var totalMinutes = (int)Math.Ceiling(sessionStart.TotalMinutes / minutes) * minutes;
-        return TimeSpan.FromMinutes(totalMinutes);
+        return sessionStart;
     }
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)
     {
-        if (raw.Count == 0) return new();
-        var times = raw.Select(r => r.TimestampUtc).ToList();
-        var px = raw.Select(r => r.Close).ToList();
-        var localTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, zone)).ToList();
-        var ret = new decimal[px.Count];
-        for (int i = 1; i < px.Count; i++)
+        if (raw.Count == 0)
         {
-            var prev = px[i - 1];
-            ret[i] = prev != 0 ? (px[i] - prev) / prev : 0m;
-            if (localTimes[i].Date != localTimes[i - 1].Date)
-                ret[i] = 0m;
+            return new();
         }
-        var flat = new decimal[px.Count];
-        flat[px.Count - 1] = px[px.Count - 1];
-        for (int i = px.Count - 2; i >= 0; i--)
+
+        var ordered = raw
+            .OrderBy(r => r.TimestampUtc)
+            .ToList();
+        var count = ordered.Count;
+
+        var localDates = ordered
+            .Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).Date)
+            .ToArray();
+
+        var returns = new decimal[count];
+        for (var i = 1; i < count; i++)
         {
-            var inc = ret[i + 1];
-            flat[i] = flat[i + 1] / (1 + inc);
+            var prevClose = ordered[i - 1].Close;
+            returns[i] = prevClose != 0 ? (ordered[i].Close / prevClose) - 1m : 0m;
         }
-        var result = new List<(DateTime, decimal)>();
-        for (int i = 0; i < px.Count; i++)
-            result.Add((times[i], flat[i]));
+
+        for (var i = 1; i < count; i++)
+        {
+            if (localDates[i] != localDates[i - 1])
+            {
+                returns[i] = 0m;
+            }
+        }
+
+        var flattenedCloses = new decimal[count];
+        flattenedCloses[count - 1] = ordered[count - 1].Close;
+        for (var i = count - 2; i >= 0; i--)
+        {
+            var inc = returns[i + 1];
+            flattenedCloses[i] = flattenedCloses[i + 1] / (1 + inc);
+        }
+
+        var result = new List<(DateTime TimestampUtc, decimal Close)>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add((ordered[i].TimestampUtc, flattenedCloses[i]));
+        }
+
         return result;
     }
 }

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1113,11 +1113,14 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+        ["EU"] = (CentralEuropeZone, TimeSpan.Parse("07:06"), TimeSpan.Parse("13:51"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York");
+
+    private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
+        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
 
     private static List<(DateTime TimestampUtc, decimal Close)> RawNMin(List<HistClose> series, int minutes, string session, int offset)
     {
@@ -1170,39 +1173,59 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             throw new ArgumentOutOfRangeException(nameof(minutes), "Aggregation interval must be positive.");
         }
 
-        if (sessionStart == TimeSpan.Zero)
+        if (sessionStart < TimeSpan.Zero)
         {
-            return TimeSpan.Zero;
+            throw new ArgumentOutOfRangeException(nameof(sessionStart), "Session start cannot be negative.");
         }
 
-        var totalMinutes = (int)Math.Ceiling(sessionStart.TotalMinutes / minutes) * minutes;
-        return TimeSpan.FromMinutes(totalMinutes);
+        return sessionStart;
     }
 
     private static List<(DateTime TimestampUtc, decimal Close)> Flatten(List<(DateTime TimestampUtc, decimal Close)> raw, TimeZoneInfo zone)
     {
-        if (raw.Count == 0) return new();
-        var times = raw.Select(r => r.TimestampUtc).ToList();
-        var px = raw.Select(r => r.Close).ToList();
-        var localTimes = times.Select(t => TimeZoneInfo.ConvertTimeFromUtc(t, zone)).ToList();
-        var ret = new decimal[px.Count];
-        for (int i = 1; i < px.Count; i++)
+        if (raw.Count == 0)
         {
-            var prev = px[i - 1];
-            ret[i] = prev != 0 ? (px[i] - prev) / prev : 0m;
-            if (localTimes[i].Date != localTimes[i - 1].Date)
-                ret[i] = 0m;
+            return new();
         }
-        var flat = new decimal[px.Count];
-        flat[px.Count - 1] = px[px.Count - 1];
-        for (int i = px.Count - 2; i >= 0; i--)
+
+        var ordered = raw
+            .OrderBy(r => r.TimestampUtc)
+            .ToList();
+        var count = ordered.Count;
+
+        var localDates = ordered
+            .Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).Date)
+            .ToArray();
+
+        var returns = new decimal[count];
+        for (var i = 1; i < count; i++)
         {
-            var inc = ret[i + 1];
-            flat[i] = flat[i + 1] / (1 + inc);
+            var prevClose = ordered[i - 1].Close;
+            returns[i] = prevClose != 0 ? (ordered[i].Close / prevClose) - 1m : 0m;
         }
-        var result = new List<(DateTime, decimal)>();
-        for (int i = 0; i < px.Count; i++)
-            result.Add((times[i], flat[i]));
+
+        for (var i = 1; i < count; i++)
+        {
+            if (localDates[i] != localDates[i - 1])
+            {
+                returns[i] = 0m;
+            }
+        }
+
+        var flattenedCloses = new decimal[count];
+        flattenedCloses[count - 1] = ordered[count - 1].Close;
+        for (var i = count - 2; i >= 0; i--)
+        {
+            var inc = returns[i + 1];
+            flattenedCloses[i] = flattenedCloses[i + 1] / (1 + inc);
+        }
+
+        var result = new List<(DateTime TimestampUtc, decimal Close)>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add((ordered[i].TimestampUtc, flattenedCloses[i]));
+        }
+
         return result;
     }
 

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -92,23 +92,24 @@ public class PriceFetcherTests
     {
         var series = new List<HistClose>
         {
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), Close = 1m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 1, 0, 0, DateTimeKind.Utc), Close = 2m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 7, 0, 0, DateTimeKind.Utc), Close = 3m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 8, 0, 0, DateTimeKind.Utc), Close = 4m }
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 6, 0, DateTimeKind.Utc), Close = 1m }, // 07:06 CET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 21, 0, DateTimeKind.Utc), Close = 2m }, // 07:21 CET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 36, 0, DateTimeKind.Utc), Close = 3m }, // 13:36 CET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 51, 0, DateTimeKind.Utc), Close = 4m }, // 13:51 CET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 6, 0, DateTimeKind.Utc), Close = 5m } // 14:06 CET (outside)
         };
 
         var method = typeof(PriceFetcher).GetMethod("RawNMin", BindingFlags.NonPublic | BindingFlags.Static)!;
-        var result = (List<(DateTime TimestampUtc, decimal Close)>)method.Invoke(null, new object[] { series, 60, "EU", 0 })!;
+        var result = (List<(DateTime TimestampUtc, decimal Close)>)method.Invoke(null, new object[] { series, 15, "EU", 0 })!;
 
         var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin";
         var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
         var times = result.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
 
-        Assert.Contains(new TimeSpan(2, 0, 0), times);
-        Assert.Contains(new TimeSpan(8, 0, 0), times);
-        Assert.DoesNotContain(new TimeSpan(1, 0, 0), times);
-        Assert.DoesNotContain(new TimeSpan(9, 0, 0), times);
+        Assert.Contains(new TimeSpan(7, 6, 0), times);
+        Assert.Contains(new TimeSpan(13, 51, 0), times);
+        Assert.DoesNotContain(new TimeSpan(6, 51, 0), times);
+        Assert.DoesNotContain(new TimeSpan(14, 6, 0), times);
     }
 
     [Fact]
@@ -116,16 +117,17 @@ public class PriceFetcherTests
     {
         var series = new List<HistClose>
         {
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 0, 0, 0, DateTimeKind.Utc), Close = 1m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 1, 0, 0, DateTimeKind.Utc), Close = 2m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 2, 0, 0, DateTimeKind.Utc), Close = 3m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 8, 0, 0, DateTimeKind.Utc), Close = 4m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 9, 0, 0, DateTimeKind.Utc), Close = 5m }
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 5, 51, 0, DateTimeKind.Utc), Close = 1m }, // 06:51 CET (pre session)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 6, 0, DateTimeKind.Utc), Close = 2m }, // 07:06 CET (start)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 21, 0, DateTimeKind.Utc), Close = 3m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 36, 0, DateTimeKind.Utc), Close = 4m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 51, 0, DateTimeKind.Utc), Close = 5m }, // 13:51 CET (end)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 6, 0, DateTimeKind.Utc), Close = 6m } // 14:06 CET (post session)
         };
 
         var raw = (List<(DateTime TimestampUtc, decimal Close)>)typeof(PriceFetcher)
             .GetMethod("RawNMin", BindingFlags.NonPublic | BindingFlags.Static)!
-            .Invoke(null, new object[] { series, 60, "EU", 0 })!;
+            .Invoke(null, new object[] { series, 15, "EU", 0 })!;
 
         var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
             ? "Central European Standard Time"
@@ -138,10 +140,10 @@ public class PriceFetcherTests
 
         var times = flat.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
 
-        Assert.DoesNotContain(new TimeSpan(1, 0, 0), times);
-        Assert.DoesNotContain(new TimeSpan(9, 0, 0), times);
-        Assert.Contains(new TimeSpan(2, 0, 0), times);
-        Assert.Contains(new TimeSpan(8, 0, 0), times);
+        Assert.DoesNotContain(new TimeSpan(6, 51, 0), times);
+        Assert.DoesNotContain(new TimeSpan(14, 6, 0), times);
+        Assert.Contains(new TimeSpan(7, 6, 0), times);
+        Assert.Contains(new TimeSpan(13, 51, 0), times);
     }
 
     [Fact]
@@ -174,5 +176,37 @@ public class PriceFetcherTests
         Assert.DoesNotContain(new TimeSpan(16, 0, 0), times);
         Assert.Contains(new TimeSpan(10, 0, 0), times);
         Assert.Contains(new TimeSpan(15, 0, 0), times);
+    }
+
+    [Fact]
+    public void Flatten_ZeroesOvernightReturnsAndPreservesIntraday()
+    {
+        var raw = new List<(DateTime TimestampUtc, decimal Close)>
+        {
+            (new DateTime(2024, 1, 1, 10, 0, 0, DateTimeKind.Utc), 100m),
+            (new DateTime(2024, 1, 1, 11, 0, 0, DateTimeKind.Utc), 105m),
+            (new DateTime(2024, 1, 2, 10, 0, 0, DateTimeKind.Utc), 110m),
+            (new DateTime(2024, 1, 2, 11, 0, 0, DateTimeKind.Utc), 121m)
+        };
+
+        var zone = TimeZoneInfo.Utc;
+
+        var flat = (List<(DateTime TimestampUtc, decimal Close)>)typeof(PriceFetcher)
+            .GetMethod("Flatten", BindingFlags.NonPublic | BindingFlags.Static)!
+            .Invoke(null, new object[] { raw, zone })!;
+
+        static decimal ReturnBetween((DateTime TimestampUtc, decimal Close) prev, (DateTime TimestampUtc, decimal Close) next)
+            => prev.Close != 0 ? (next.Close - prev.Close) / prev.Close : 0m;
+
+        var expectedIntradayFirst = ReturnBetween(raw[0], raw[1]);
+        var expectedIntradaySecond = ReturnBetween(raw[2], raw[3]);
+
+        var flattenedFirst = ReturnBetween(flat[0], flat[1]);
+        var flattenedOvernight = ReturnBetween(flat[1], flat[2]);
+        var flattenedSecond = ReturnBetween(flat[2], flat[3]);
+
+        Assert.Equal(expectedIntradayFirst, flattenedFirst);
+        Assert.Equal(0m, flattenedOvernight);
+        Assert.Equal(expectedIntradaySecond, flattenedSecond);
     }
 }


### PR DESCRIPTION
## Summary
- use the Central European time zone and the actual 07:06–13:51 trading window for the EU session so the flattening logic lines up with the next 15 minute bar instead of skipping an hour
- stop rounding session starts to the next timeframe boundary so buckets preserve the real session offsets, and mirror the same behavior in the Wakett price fetcher
- update the EU session unit tests to cover the revised window and verify the new timestamps

## Testing
- Not Run (dotnet CLI is not available in the container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691dc67d3ec483339eabd4b27442348f)