### PR TITLE
Align EU session windows to Eastern time

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -170,7 +170,7 @@ public class PriceFetcher
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (CentralEuropeZone, TimeSpan.Parse("07:06"), TimeSpan.Parse("13:51"))
+        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1113,14 +1113,11 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (CentralEuropeZone, TimeSpan.Parse("07:06"), TimeSpan.Parse("13:51"))
+        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York");
-
-    private static TimeZoneInfo CentralEuropeZone => TimeZoneInfo.FindSystemTimeZoneById(
-        RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin");
 
     private static List<(DateTime TimestampUtc, decimal Close)> RawNMin(List<HistClose> series, int minutes, string session, int offset)
     {

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -88,28 +88,29 @@ public class PriceFetcherTests
     }
 
     [Fact]
-    public void RawNMin_UsesCETForEUSession()
+    public void RawNMin_UsesEasternTimeForEUSession()
     {
         var series = new List<HistClose>
         {
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 6, 0, DateTimeKind.Utc), Close = 1m }, // 07:06 CET
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 21, 0, DateTimeKind.Utc), Close = 2m }, // 07:21 CET
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 36, 0, DateTimeKind.Utc), Close = 3m }, // 13:36 CET
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 51, 0, DateTimeKind.Utc), Close = 4m }, // 13:51 CET
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 6, 0, DateTimeKind.Utc), Close = 5m } // 14:06 CET (outside)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 45, 0, DateTimeKind.Utc), Close = 0.5m }, // 01:45 ET (pre session)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 7, 0, 0, DateTimeKind.Utc), Close = 1m }, // 02:00 ET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 7, 15, 0, DateTimeKind.Utc), Close = 2m }, // 02:15 ET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 45, 0, DateTimeKind.Utc), Close = 3m }, // 08:45 ET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 59, 0, DateTimeKind.Utc), Close = 4m }, // 08:59 ET
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 14, 5, 0, DateTimeKind.Utc), Close = 5m } // 09:05 ET (outside)
         };
 
         var method = typeof(PriceFetcher).GetMethod("RawNMin", BindingFlags.NonPublic | BindingFlags.Static)!;
         var result = (List<(DateTime TimestampUtc, decimal Close)>)method.Invoke(null, new object[] { series, 15, "EU", 0 })!;
 
-        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Central European Standard Time" : "Europe/Berlin";
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
         var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
         var times = result.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
 
-        Assert.Contains(new TimeSpan(7, 6, 0), times);
-        Assert.Contains(new TimeSpan(13, 51, 0), times);
-        Assert.DoesNotContain(new TimeSpan(6, 51, 0), times);
-        Assert.DoesNotContain(new TimeSpan(14, 6, 0), times);
+        Assert.Contains(new TimeSpan(2, 0, 0), times);
+        Assert.Contains(new TimeSpan(8, 45, 0), times);
+        Assert.DoesNotContain(new TimeSpan(1, 45, 0), times);
+        Assert.DoesNotContain(new TimeSpan(9, 0, 0), times);
     }
 
     [Fact]
@@ -117,12 +118,12 @@ public class PriceFetcherTests
     {
         var series = new List<HistClose>
         {
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 5, 51, 0, DateTimeKind.Utc), Close = 1m }, // 06:51 CET (pre session)
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 6, 0, DateTimeKind.Utc), Close = 2m }, // 07:06 CET (start)
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 21, 0, DateTimeKind.Utc), Close = 3m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 36, 0, DateTimeKind.Utc), Close = 4m },
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 12, 51, 0, DateTimeKind.Utc), Close = 5m }, // 13:51 CET (end)
-            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 6, 0, DateTimeKind.Utc), Close = 6m } // 14:06 CET (post session)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 6, 45, 0, DateTimeKind.Utc), Close = 1m }, // 01:45 ET (pre session)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 7, 0, 0, DateTimeKind.Utc), Close = 2m }, // 02:00 ET (start)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 7, 15, 0, DateTimeKind.Utc), Close = 3m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 13, 45, 0, DateTimeKind.Utc), Close = 4m },
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 14, 5, 0, DateTimeKind.Utc), Close = 5m }, // 09:05 ET (post session)
+            new HistClose { BarTimeUtc = new DateTime(2024, 1, 2, 14, 15, 0, DateTimeKind.Utc), Close = 6m } // 09:15 ET (post session)
         };
 
         var raw = (List<(DateTime TimestampUtc, decimal Close)>)typeof(PriceFetcher)
@@ -130,8 +131,8 @@ public class PriceFetcherTests
             .Invoke(null, new object[] { series, 15, "EU", 0 })!;
 
         var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
-            ? "Central European Standard Time"
-            : "Europe/Berlin";
+            ? "Eastern Standard Time"
+            : "America/New_York";
         var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
 
         var flat = (List<(DateTime TimestampUtc, decimal Close)>)typeof(PriceFetcher)
@@ -140,10 +141,10 @@ public class PriceFetcherTests
 
         var times = flat.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
 
-        Assert.DoesNotContain(new TimeSpan(6, 51, 0), times);
-        Assert.DoesNotContain(new TimeSpan(14, 6, 0), times);
-        Assert.Contains(new TimeSpan(7, 6, 0), times);
-        Assert.Contains(new TimeSpan(13, 51, 0), times);
+        Assert.DoesNotContain(new TimeSpan(1, 45, 0), times);
+        Assert.DoesNotContain(new TimeSpan(9, 0, 0), times);
+        Assert.Contains(new TimeSpan(2, 0, 0), times);
+        Assert.Contains(new TimeSpan(8, 45, 0), times);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- align the EU session definition with the New York trading hours across the price fetchers
- update the associated unit tests to assert the new 02:00–08:59 ET window

## Testing
- `dotnet test tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj` *(fails: `dotnet` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ddc50af2c8333bb4e4d6e3b593c38)