### PR TITLE
Add EUUS trading session to NY-based session bounds

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -170,7 +170,8 @@ public class PriceFetcher
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59")),
+        ["EUUS"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("11:59"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1113,7 +1113,8 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     private static readonly Dictionary<string, (TimeZoneInfo Zone, TimeSpan Start, TimeSpan End)> SessionBounds = new()
     {
         ["US"] = (NewYorkZone, TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
-        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+        ["EU"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59")),
+        ["EUUS"] = (NewYorkZone, TimeSpan.Parse("02:00"), TimeSpan.Parse("11:59"))
     };
 
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(

--- a/src/TradingDaemon/Services/WeightCalculator.cs
+++ b/src/TradingDaemon/Services/WeightCalculator.cs
@@ -26,7 +26,9 @@ public class WeightCalculator
             ["US"] = new SessionInfo(ResolveTimeZone("Eastern Standard Time", "America/New_York"),
                 TimeSpan.Parse("09:00"), TimeSpan.Parse("15:59")),
             ["EU"] = new SessionInfo(ResolveTimeZone("Eastern Standard Time", "America/New_York"),
-                TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59"))
+                TimeSpan.Parse("02:00"), TimeSpan.Parse("08:59")),
+            ["EUUS"] = new SessionInfo(ResolveTimeZone("Eastern Standard Time", "America/New_York"),
+                TimeSpan.Parse("02:00"), TimeSpan.Parse("11:59"))
         };
 
     public WeightCalculator(


### PR DESCRIPTION
## Summary
- add EUUS session bounds using New York timezone to align with 02:00-11:59 window
- extend price fetchers and weight calculator to recognize the new session

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ef39c269c8333bff922c10dbea521)