### PR TITLE
Handle EUUS session for flat price generation

### DIFF
--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -115,27 +115,19 @@ public class PriceFetcher
             var flatRecords = new List<FlatPrice>();
             foreach (var grp in seriesBySecurity)
             {
-                var rawEU = RawNMin(grp.Series, build.TimeframeMinute, "EU", build.OffsetMinute);
-                var flatEU = Flatten(rawEU, SessionBounds["EU"].Zone)
-                    .Select(r => new FlatPrice
-                    {
-                        SecurityId = grp.SecurityId,
-                        BarTimeUtc = r.TimestampUtc,
-                        Close = r.Close,
-                        Session = "EU"
-                    });
-                flatRecords.AddRange(flatEU);
-
-                var rawUS = RawNMin(grp.Series, build.TimeframeMinute, "US", build.OffsetMinute);
-                var flatUS = Flatten(rawUS, SessionBounds["US"].Zone)
-                    .Select(r => new FlatPrice
-                    {
-                        SecurityId = grp.SecurityId,
-                        BarTimeUtc = r.TimestampUtc,
-                        Close = r.Close,
-                        Session = "US"
-                    });
-                flatRecords.AddRange(flatUS);
+                foreach (var session in new[] { "EU", "US", "EUUS" })
+                {
+                    var raw = RawNMin(grp.Series, build.TimeframeMinute, session, build.OffsetMinute);
+                    var flat = Flatten(raw, SessionBounds[session].Zone)
+                        .Select(r => new FlatPrice
+                        {
+                            SecurityId = grp.SecurityId,
+                            BarTimeUtc = r.TimestampUtc,
+                            Close = r.Close,
+                            Session = session
+                        });
+                    flatRecords.AddRange(flat);
+                }
             }
 
             if (flatRecords.Count == 0)

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -1050,27 +1050,19 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
                 var flatRecords = new List<FlatPrice>();
                 foreach (var grp in seriesBySecurity)
                 {
-                    var rawEu = RawNMin(grp.Series, build.TimeframeMinute, "EU", build.OffsetMinute);
-                    var flatEu = Flatten(rawEu, SessionBounds["EU"].Zone)
-                        .Select(r => new FlatPrice
-                        {
-                            SecurityId = grp.SecurityId,
-                            BarTimeUtc = r.TimestampUtc,
-                            Close = r.Close,
-                            Session = "EU"
-                        });
-                    flatRecords.AddRange(flatEu);
-
-                    var rawUs = RawNMin(grp.Series, build.TimeframeMinute, "US", build.OffsetMinute);
-                    var flatUs = Flatten(rawUs, SessionBounds["US"].Zone)
-                        .Select(r => new FlatPrice
-                        {
-                            SecurityId = grp.SecurityId,
-                            BarTimeUtc = r.TimestampUtc,
-                            Close = r.Close,
-                            Session = "US"
-                        });
-                    flatRecords.AddRange(flatUs);
+                    foreach (var session in new[] { "EU", "US", "EUUS" })
+                    {
+                        var raw = RawNMin(grp.Series, build.TimeframeMinute, session, build.OffsetMinute);
+                        var flat = Flatten(raw, SessionBounds[session].Zone)
+                            .Select(r => new FlatPrice
+                            {
+                                SecurityId = grp.SecurityId,
+                                BarTimeUtc = r.TimestampUtc,
+                                Close = r.Close,
+                                Session = session
+                            });
+                        flatRecords.AddRange(flat);
+                    }
                 }
 
                 if (flatRecords.Count == 0)

--- a/tests/TradingDaemon.Tests/PriceFetcherTests.cs
+++ b/tests/TradingDaemon.Tests/PriceFetcherTests.cs
@@ -114,6 +114,37 @@ public class PriceFetcherTests
     }
 
     [Fact]
+    public void RawNMin_UsesEasternTimeForEUUSSession()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+            ? "Eastern Standard Time"
+            : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+
+        DateTime EtLocal(int hour, int minute) => new DateTime(2024, 1, 2, hour, minute, 0, DateTimeKind.Unspecified);
+        DateTime ToUtc(int hour, int minute) => TimeZoneInfo.ConvertTimeToUtc(EtLocal(hour, minute), zone);
+
+        var series = new List<HistClose>
+        {
+            new HistClose { BarTimeUtc = ToUtc(1, 0), Close = 0.5m }, // 01:00 ET (pre session)
+            new HistClose { BarTimeUtc = ToUtc(2, 0), Close = 1m },   // 02:00 ET (session start)
+            new HistClose { BarTimeUtc = ToUtc(5, 0), Close = 2m },   // 05:00 ET (mid-session)
+            new HistClose { BarTimeUtc = ToUtc(11, 0), Close = 3m },  // 11:00 ET (session end bucket)
+            new HistClose { BarTimeUtc = ToUtc(12, 0), Close = 4m }   // 12:00 ET (post session)
+        };
+
+        var method = typeof(PriceFetcher).GetMethod("RawNMin", BindingFlags.NonPublic | BindingFlags.Static)!;
+        var result = (List<(DateTime TimestampUtc, decimal Close)>)method.Invoke(null, new object[] { series, 60, "EUUS", 0 })!;
+
+        var times = result.Select(r => TimeZoneInfo.ConvertTimeFromUtc(r.TimestampUtc, zone).TimeOfDay).ToList();
+
+        Assert.Contains(new TimeSpan(2, 0, 0), times);
+        Assert.Contains(new TimeSpan(11, 0, 0), times);
+        Assert.DoesNotContain(new TimeSpan(1, 0, 0), times);
+        Assert.DoesNotContain(new TimeSpan(12, 0, 0), times);
+    }
+
+    [Fact]
     public void Flatten_FiltersBarsToEUSession()
     {
         var series = new List<HistClose>


### PR DESCRIPTION
## Summary
- generate flat prices for the EUUS session alongside EU and US in both price fetchers
- add coverage to ensure EUUS raw bar aggregation respects session bounds

## Testing
- dotnet test tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691f35764de483339a88dd01a9723742)