### PR TITLE
Allow trading across EU, US, and EUUS sessions

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -28,15 +28,18 @@ public class OrderSender
         ["ALL"] = (TimeSpan.Parse("02:00", CultureInfo.InvariantCulture), TimeSpan.Parse("15:59", CultureInfo.InvariantCulture)),
     };
 
-    private static readonly IReadOnlyList<string> SessionPreference = new[]
+    private static readonly IReadOnlyCollection<string> AllowedTradingSessions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
     {
+        "EU",
         "US",
-        "US2",
+        "EUUS"
+    };
+
+    private static readonly IReadOnlyList<string> TradingSessionPreference = new[]
+    {
         "EU",
         "EUUS",
-        "AS",
-        "ASEU",
-        "ALL"
+        "US"
     };
 
     private const int TargetModelId = 1;
@@ -958,7 +961,7 @@ VALUES
         return TimeSpan.FromMinutes(fallbackMinutes);
     }
 
-    private string ResolveTradingSession(DateTime barTimeUtc)
+    protected virtual string ResolveTradingSession(DateTime barTimeUtc)
     {
         var configured = Environment.GetEnvironmentVariable("WAKETT_SESSION")
             ?? _configuration["ExternalApis:WakettApi:Session"];
@@ -966,9 +969,16 @@ VALUES
         if (!string.IsNullOrWhiteSpace(configured))
         {
             var normalized = configured.Trim().ToUpperInvariant();
-            if (SessionBounds.ContainsKey(normalized))
+            if (AllowedTradingSessions.Contains(normalized))
             {
                 return normalized;
+            }
+
+            if (SessionBounds.ContainsKey(normalized))
+            {
+                _logger.LogWarning(
+                    "Configured trading session {ConfiguredSession} is not enabled. Falling back to allowed sessions EU/US/EUUS.",
+                    configured);
             }
         }
 
@@ -981,7 +991,7 @@ VALUES
             if (!string.IsNullOrWhiteSpace(programmeSession))
             {
                 var normalized = programmeSession.Trim().ToUpperInvariant();
-                if (SessionBounds.ContainsKey(normalized))
+                if (AllowedTradingSessions.Contains(normalized))
                 {
                     return normalized;
                 }
@@ -989,7 +999,7 @@ VALUES
         }
 
         var local = TimeZoneInfo.ConvertTimeFromUtc(barTimeUtc, NewYorkZone);
-        foreach (var session in SessionPreference)
+        foreach (var session in TradingSessionPreference)
         {
             if (SessionBounds.TryGetValue(session, out var bounds) && IsWithinSession(local, bounds))
             {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -894,6 +894,42 @@ public class OrderSenderTests
         Assert.Equal(expected, formatted);
     }
 
+    [Theory]
+    [InlineData("EU", "EU")]
+    [InlineData("US", "US")]
+    [InlineData("EUUS", "EUUS")]
+    public void ResolveTradingSession_RespectsAllowedConfiguration(string configuredSession, string expected)
+    {
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Session"] = configuredSession
+        });
+
+        var sender = CreateSessionResolvingSender(configuration);
+        var result = sender.InvokeResolveTradingSession(new DateTime(2024, 1, 2, 12, 0, 0, DateTimeKind.Utc));
+
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void ResolveTradingSession_PrefersAllowedSessionsWhenConfiguredSessionDisabled()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var localBar = new DateTime(2024, 1, 2, 10, 0, 0, DateTimeKind.Unspecified);
+        var barTimeUtc = TimeZoneInfo.ConvertTimeToUtc(localBar, zone);
+
+        var configuration = BuildConfiguration(new Dictionary<string, string?>
+        {
+            ["ExternalApis:WakettApi:Session"] = "AS"
+        });
+
+        var sender = CreateSessionResolvingSender(configuration);
+        var result = sender.InvokeResolveTradingSession(barTimeUtc);
+
+        Assert.Equal("EUUS", result);
+    }
+
     private static IConfigurationRoot BuildConfiguration(IDictionary<string, string?> values)
     {
         var defaults = new Dictionary<string, string?>
@@ -909,6 +945,26 @@ public class OrderSenderTests
         }
 
         return new ConfigurationBuilder().AddInMemoryCollection(defaults).Build();
+    }
+
+    private static TestOrderSender CreateSessionResolvingSender(IConfiguration configuration)
+    {
+        var httpClient = new HttpClient();
+        var factory = Mock.Of<IHttpClientFactory>(f => f.CreateClient(It.IsAny<string>()) == httpClient);
+        var apiClient = new WakettApiClient(factory);
+        var context = new Mock<DapperContext>(configuration);
+        context.Setup(c => c.CreateConnection()).Returns(Mock.Of<IDbConnection>());
+        var logger = Mock.Of<ILogger<OrderSender>>();
+
+        return new TestOrderSender(
+            apiClient,
+            context.Object,
+            logger,
+            configuration,
+            new TestTimeProvider(DateTimeOffset.UtcNow),
+            Array.Empty<OrderSender.NettedWeightRow>(),
+            new Dictionary<int, string>(),
+            null);
     }
 
     private sealed class TestOrderSender : OrderSender
@@ -996,6 +1052,9 @@ public class OrderSenderTests
             IEnumerable<(int SecurityId, WakettOrderItem Order)> builtOrders,
             CancellationToken cancellationToken)
             => Task.FromResult(_existingOrderSymbols);
+
+        public string InvokeResolveTradingSession(DateTime barTimeUtc)
+            => ResolveTradingSession(barTimeUtc);
     }
 
     private sealed class TestTimeProvider : TimeProvider


### PR DESCRIPTION
## Summary
- restrict Wakett order submission to the EU, US, and EUUS trading sessions and warn when a disabled session is configured
- prioritize EUUS/EU sessions when selecting a session fallback and expose the resolver for verification
- add unit coverage to confirm allowed configuration values and fallback behavior

## Testing
- Not run (dotnet SDK unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920439c62e88333a2076e1a8412e716)