### PR TITLE
Support multiple price bar timeframes

### DIFF
--- a/src/TradingDaemon/Options/PriceBarOptions.cs
+++ b/src/TradingDaemon/Options/PriceBarOptions.cs
@@ -1,7 +1,28 @@
+using System;
+using System.Linq;
+
 namespace TradingDaemon.Options;
 
 public sealed class PriceBarOptions
 {
     public int TimeframeMinute { get; set; } = 15;
+    public int[] TimeframeMinutes { get; set; } = Array.Empty<int>();
     public int SourceId { get; set; } = 1;
+
+    public IReadOnlyList<int> GetOrderedTimeframeMinutes()
+    {
+        var candidates = (TimeframeMinutes?.Length > 0 ? TimeframeMinutes : Array.Empty<int>())
+            .Append(TimeframeMinute)
+            .Select(min => Math.Max(1, min))
+            .Distinct()
+            .OrderBy(min => min)
+            .ToArray();
+
+        if (candidates.Length > 0)
+        {
+            return candidates;
+        }
+
+        return new[] { Math.Max(1, TimeframeMinute) };
+    }
 }

--- a/src/TradingDaemon/Services/PriceFetcher.cs
+++ b/src/TradingDaemon/Services/PriceFetcher.cs
@@ -25,6 +25,7 @@ public class PriceFetcher
     private readonly string _priceBarTable;
     private readonly IPriceProcessingProcedureExecutor _priceProcedures;
     private readonly PriceBarOptions _priceBarOptions;
+    private readonly IReadOnlyList<int> _priceTimeframeMinutes;
 
     public PriceFetcher(
         DapperContext context,
@@ -39,11 +40,12 @@ public class PriceFetcher
         _config = config;
         _priceProcedures = priceProcedures;
         _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
+        _priceTimeframeMinutes = _priceBarOptions.GetOrderedTimeframeMinutes();
         _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
         _flatBarStagingTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayStagingFlatBar);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
-        _selectRawSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds";
+        _selectRawSql = $"SELECT SecurityId, BarTimeUtc, [Close] FROM {_priceBarTable} WHERE TimeframeMinute = {BasePriceTimeframeMinute} AND SecurityId IN @SecurityIds";
     }
 
     public async Task FetchAndStoreAsync()
@@ -86,10 +88,13 @@ public class PriceFetcher
 
         // Load newly staged raw bars into the PriceBar table so that subsequent
         // queries include the latest data.
-        await _priceProcedures.LoadRawFromStageAsync(
-            connection,
-            PriceTimeframeMinute,
-            _priceBarOptions.SourceId);
+        foreach (var timeframe in PriceTimeframeMinutes)
+        {
+            await _priceProcedures.LoadRawFromStageAsync(
+                connection,
+                timeframe,
+                _priceBarOptions.SourceId);
+        }
 
         // Retrieve all existing raw bars for the affected securities so that
         // flat bars can be recomputed over the full history instead of only
@@ -108,7 +113,7 @@ public class PriceFetcher
             .Select(g => new { SecurityId = g.Key, Series = g.OrderBy(r => r.BarTimeUtc).ToList() })
             .ToList();
 
-        var flatBarBuilds = FlatBarBuildSpecificationFactory.CreateDefault(PriceTimeframeMinute, 0);
+        var flatBarBuilds = FlatBarBuildSpecificationFactory.CreateDefault(BasePriceTimeframeMinute, 0);
 
         foreach (var build in flatBarBuilds)
         {
@@ -169,7 +174,9 @@ public class PriceFetcher
     private static TimeZoneInfo NewYorkZone => TimeZoneInfo.FindSystemTimeZoneById(
         RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York");
 
-    private int PriceTimeframeMinute => Math.Max(1, _priceBarOptions.TimeframeMinute);
+    private IReadOnlyList<int> PriceTimeframeMinutes => _priceTimeframeMinutes;
+
+    private int BasePriceTimeframeMinute => PriceTimeframeMinutes.First();
 
     private static List<(DateTime TimestampUtc, decimal Close)> RawNMin(List<HistClose> series, int minutes, string session, int offset)
     {

--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -36,6 +36,7 @@ public class WakettPriceFetcher
     private readonly string _securityTable;
     private readonly IPriceProcessingProcedureExecutor _priceProcedures;
     private readonly PriceBarOptions _priceBarOptions;
+    private readonly IReadOnlyList<int> _priceTimeframeMinutes;
 
 
     private IReadOnlyList<int>? _priceMinuteOffsets;
@@ -61,11 +62,12 @@ public class WakettPriceFetcher
         _priceProcedures = priceProcedures;
         _automationOptions = automationOptions?.Value;
         _priceBarOptions = priceBarOptions?.Value ?? new PriceBarOptions();
+        _priceTimeframeMinutes = _priceBarOptions.GetOrderedTimeframeMinutes();
         _stageHistCloseTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketStageHistClose);
         _priceBarTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBar);
         _securityTable = databaseNameProvider.GetObjectName(DatabaseObjects.IntradayCoreSecurity);
-        _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
-        _priceBarTimestampPresenceSql = $"SELECT SecurityId FROM {_priceBarTable} WHERE TimeframeMinute = {PriceTimeframeMinute} AND SecurityId IN @SecurityIds AND BarTimeUtc = @BarTimeUtc";
+        _priceBarWindowQuery = $"SELECT SecurityId, BarTimeUtc FROM {_priceBarTable} WHERE TimeframeMinute = {BasePriceTimeframeMinute} AND SecurityId IN @SecurityIds AND DATEPART(MINUTE, BarTimeUtc) = @MinuteOffset AND BarTimeUtc BETWEEN @StartUtc AND @EndUtc";
+        _priceBarTimestampPresenceSql = $"SELECT SecurityId FROM {_priceBarTable} WHERE TimeframeMinute = {BasePriceTimeframeMinute} AND SecurityId IN @SecurityIds AND BarTimeUtc = @BarTimeUtc";
         _stageClearSql = $"DELETE FROM {_stageHistCloseTable}";
         _stageDeleteSql = $"DELETE FROM {_stageHistCloseTable} WHERE BarTimeUtc = @BarTimeUtc AND SecurityId IN @SecurityIds";
         _stageInsertSql = $"INSERT INTO {_stageHistCloseTable} (SecurityId, BarTimeUtc, [Close]) VALUES (@SecurityId, @BarTimeUtc, @Close)";
@@ -1097,11 +1099,14 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         if (recordList.Count > 0)
         {
             var loadRawTimer = Stopwatch.StartNew();
-            await _priceProcedures.LoadRawFromStageAsync(
-                connection,
-                PriceTimeframeMinute,
-                _priceBarOptions.SourceId,
-                cancellationToken);
+            foreach (var timeframe in PriceTimeframeMinutes)
+            {
+                await _priceProcedures.LoadRawFromStageAsync(
+                    connection,
+                    timeframe,
+                    _priceBarOptions.SourceId,
+                    cancellationToken);
+            }
 
             loadRawTimer.Stop();
             _logger.LogInformation(
@@ -1131,7 +1136,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         await connection.ExecuteAsync(_stageClearSql);
     }
 
-    private int PriceTimeframeMinute => Math.Max(1, _priceBarOptions.TimeframeMinute);
+    private IReadOnlyList<int> PriceTimeframeMinutes => _priceTimeframeMinutes;
+
+    private int BasePriceTimeframeMinute => PriceTimeframeMinutes.First();
 
     private sealed record SymbolConfiguration(
         IReadOnlyList<WakettSecuritySymbol> BaseSymbols,

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -130,6 +130,11 @@
     //}
   ],
   "PriceBars": {
+    "TimeframeMinutes": [
+      15,
+      30,
+      60
+    ],
     "TimeframeMinute": 15,
     "SourceId": 1
   },


### PR DESCRIPTION
## Summary
- add a configurable list of price bar timeframes with defaults for 15, 30, and 60 minutes
- update price ingestion to load raw price bars for each configured timeframe
- expose the new timeframe configuration values in appsettings

## Testing
- dotnet build TradingDaemon.sln *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692080c38dd4833391091b003a3f592b)