### PR TITLE
Schedule orders at :01, :16, :31, and :46 ET

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -139,7 +139,7 @@
     "SourceId": 1
   },
   "Quartz": {
-    "Cron": "0 1,16,31,46 2-15 ? * *",
+    "Cron": "0 1,16,31,46 9-15 ? * *",
     "TimeZone": "Eastern Standard Time"
   },
   "Automation": {


### PR DESCRIPTION
## Summary
- align the Quartz cron schedule so automated order submissions trigger at :01, :16, :31, and :46 during trading hours

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69209222644883339b799691483561d6)