### PR TITLE
Advance order timestamp formatting to next quarter hour

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -749,17 +749,8 @@ VALUES
 
         if (local.Minute == 0 && local.Second == 0 && local.Millisecond == 0)
         {
-            local = local.AddHours(1);
+            local = local.AddMinutes(15);
         }
-
-        local = new DateTime(
-            local.Year,
-            local.Month,
-            local.Day,
-            local.Hour,
-            6,
-            0,
-            local.Kind);
 
         var offset = NewYorkZone.GetUtcOffset(local);
         var sign = offset < TimeSpan.Zero ? "-" : "+";

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -876,7 +876,7 @@ public class OrderSenderTests
     }
 
     [Fact]
-    public void FormatTimestamp_TopOfHourBarsAdvanceToNextHour()
+    public void FormatTimestamp_TopOfHourBarsAdvanceToNextQuarterHour()
     {
         var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
         var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
@@ -885,11 +885,29 @@ public class OrderSenderTests
 
         var formatted = OrderSender.FormatTimestamp(barTimeUtc);
 
-        var expectedLocal = localBar.AddHours(1).AddMinutes(6);
+        var expectedLocal = localBar.AddMinutes(15);
         var offset = zone.GetUtcOffset(expectedLocal);
         var sign = offset < TimeSpan.Zero ? "-" : "+";
         var abs = offset.Duration();
         var expected = $"{expectedLocal:yyyy-MM-dd HH:mm:ss.fff}{sign}{abs.Hours:00}{abs.Minutes:00}";
+
+        Assert.Equal(expected, formatted);
+    }
+
+    [Fact]
+    public void FormatTimestamp_PreservesMinuteWhenProvided()
+    {
+        var zoneId = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "Eastern Standard Time" : "America/New_York";
+        var zone = TimeZoneInfo.FindSystemTimeZoneById(zoneId);
+        var localBar = new DateTime(2024, 2, 5, 9, 21, 0, DateTimeKind.Unspecified);
+        var barTimeUtc = TimeZoneInfo.ConvertTimeToUtc(localBar, zone);
+
+        var formatted = OrderSender.FormatTimestamp(barTimeUtc);
+
+        var offset = zone.GetUtcOffset(localBar);
+        var sign = offset < TimeSpan.Zero ? "-" : "+";
+        var abs = offset.Duration();
+        var expected = $"{localBar:yyyy-MM-dd HH:mm:ss.fff}{sign}{abs.Hours:00}{abs.Minutes:00}";
 
         Assert.Equal(expected, formatted);
     }


### PR DESCRIPTION
## Summary
- change `FormatTimestamp` to advance top-of-hour order timestamps to the next quarter hour rather than the next hour
- update formatting test expectations to cover the quarter-hour adjustment and preserve provided minutes

## Testing
- not run (dotnet tooling unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920a2c60e888333a47f699bb36f64f6)