### PR TITLE
Remove Quartz scheduler to prevent duplicate orders

### DIFF
--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -1,6 +1,3 @@
-using Quartz;
-using Quartz.Impl;
-using Quartz.Spi;
 using Serilog;
 using TradingDaemon.Controllers;
 using TradingDaemon.Data;
@@ -68,19 +65,12 @@ builder.Services.AddTransient<ReportRunner>();
 builder.Services.AddTransient<WakettApiClient>();
 builder.Services.AddTransient<WakettPriceFetcher>();
 builder.Services.AddTransient<WakettTradeFetcher>();
-builder.Services.AddTransient<TradingJob>();
-
-
 builder.Services.Configure<WakettAutomationOptions>(builder.Configuration.GetSection("Automation:Wakett"));
 builder.Services.Configure<TradingOptions>(builder.Configuration.GetSection("Trading"));
 builder.Services.Configure<PriceBarOptions>(builder.Configuration.GetSection("PriceBars"));
 builder.Services.AddHostedService<WakettAutomationService>();
 
 builder.Services.AddSingleton<IEmailNotificationService, EmailNotificationService>();
-builder.Services.Configure<SchedulerOptions>(builder.Configuration.GetSection("Quartz"));
-builder.Services.AddSingleton<ISchedulerFactory>(_ => new StdSchedulerFactory());
-builder.Services.AddSingleton<IJobFactory, DependencyInjectionJobFactory>();
-builder.Services.AddHostedService<SchedulerService>();
 
 
 


### PR DESCRIPTION
## Summary
- stop registering the legacy Quartz scheduler so only the Wakett automation drives order submissions
- remove unused Quartz dependency registrations from the application startup

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69243be7eca4833396f4a3e1c3ebbc8a)