### PR TITLE
Adjust Wakett automation quarter timings

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -18,10 +18,10 @@ public sealed class WakettAutomationService : BackgroundService
     private static readonly TimeSpan SessionEnd = new(15, 59, 0);
     private static readonly TimeSpan SessionShutdownDelay = TimeSpan.FromHours(1);
 
-    private static readonly IReadOnlyList<TimeSpan> PriceFetchOffsets = BuildQuarterOffsets(TimeSpan.FromMinutes(2));
-    private static readonly IReadOnlyList<TimeSpan> WeightCalculationOffsets = BuildQuarterOffsets(TimeSpan.FromMinutes(2.5));
+    private static readonly IReadOnlyList<TimeSpan> PriceFetchOffsets = BuildQuarterOffsets(TimeSpan.FromSeconds(7));
+    private static readonly IReadOnlyList<TimeSpan> WeightCalculationOffsets = BuildQuarterOffsets(TimeSpan.FromSeconds(7.5));
     private static readonly IReadOnlyList<TimeSpan> FillCheckOffsets = new[] { TimeSpan.FromMinutes(10), TimeSpan.FromMinutes(40) };
-    private static readonly IReadOnlyList<TimeSpan> OrderSubmissionOffsets = BuildQuarterOffsets(TimeSpan.FromMinutes(1));
+    private static readonly IReadOnlyList<TimeSpan> OrderSubmissionOffsets = BuildQuarterOffsets(TimeSpan.FromSeconds(1));
     private static readonly IReadOnlyList<TimeSpan> PnlReportOffsets = new[] { TimeSpan.FromMinutes(15) };
 
     private readonly WakettPriceFetcher _priceFetcher;


### PR DESCRIPTION
## Summary
- update Wakett automation offsets to run price fetch at quarter plus seven seconds
- schedule weight calculations at quarter plus seven-and-a-half seconds and order submissions at quarter plus one second

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6924424926c88333ba9d4d16ab81b3d8)