### PR TITLE
Adjust NZDUSD cutoff to 7am NZ time

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -43,7 +43,7 @@ public class OrderSender
         "US"
     };
 
-    private static readonly TimeSpan NzWeightOverrideTime = new(6, 30, 0);
+    private static readonly TimeSpan NzWeightOverrideTime = new(7, 0, 0);
 
     private const int TargetModelId = 1;
 

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -196,8 +196,8 @@ public class OrderSenderTests
     [Theory]
     [InlineData(2024, 1, 1, 17, 0, 0, false)] // 06:00 NZDT
     [InlineData(2024, 1, 1, 18, 0, 0, true)]  // 07:00 NZDT
-    [InlineData(2024, 6, 30, 18, 25, 0, false)] // 06:25 NZST
-    [InlineData(2024, 6, 30, 18, 30, 0, true)]  // 06:30 NZST
+    [InlineData(2024, 6, 30, 18, 55, 0, false)] // 06:55 NZST
+    [InlineData(2024, 6, 30, 19, 0, 0, true)]  // 07:00 NZST
     public void ApplyWeightOverrides_UsesNewZealandLocalTime(
         int year,
         int month,


### PR DESCRIPTION
## Summary
- move the NZDUSD weight override cutoff to 7:00am New Zealand time
- update tests to reflect the new cutoff and timezone expectations

## Testing
- dotnet test *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692567dcd9548333a4256621142afd4c)