### PR TITLE
Update NZDUSD cutoff to 12:30pm NY

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -43,7 +43,7 @@ public class OrderSender
         "US"
     };
 
-    private static readonly TimeSpan NzWeightOverrideTime = new(7, 0, 0);
+    private static readonly TimeSpan NyWeightOverrideTime = new(12, 30, 0);
 
     private const int TargetModelId = 1;
 
@@ -1312,9 +1312,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             return weightList;
         }
 
-        var localTime = TimeZoneInfo.ConvertTimeFromUtc(orderTimestampUtc, NewZealandZone);
+        var localTime = TimeZoneInfo.ConvertTimeFromUtc(orderTimestampUtc, NewYorkZone);
 
-        if (localTime.TimeOfDay < NzWeightOverrideTime)
+        if (localTime.TimeOfDay < NyWeightOverrideTime)
         {
             return weightList;
         }
@@ -1335,9 +1335,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         }
 
         _logger.LogInformation(
-            "Zeroing NZDUSD weights for order timestamp {OrderTimestampUtc:O} after {CutoffLocal} NZ.",
+            "Zeroing NZDUSD weights for order timestamp {OrderTimestampUtc:O} after {CutoffLocal} NY.",
             orderTimestampUtc,
-            NzWeightOverrideTime);
+            NyWeightOverrideTime);
 
         return weightList
             .Select(weight => nzdusdIds.Contains(weight.SecurityId) ? weight with { Weight = 0m } : weight)


### PR DESCRIPTION
## Summary
- adjust NZDUSD weight override to use New York time
- set NZDUSD weights to zero when NY time is 12:30pm or later

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6925fa6105208333ab7e9aec2c935d35)