### PR TITLE
Set production configuration as active environment

### DIFF
--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -4,7 +4,7 @@
   },
   "Database": {
     "SecretName": "qq-intraday-credentials",
-    "ActiveEnvironment": "Test",
+    "ActiveEnvironment": "Prod",
     "ConnectionString": "",
     "Objects": {},
     "Environments": {
@@ -20,7 +20,7 @@
   "ModelId": 0,
   "PriceCsvPath": "/home/prices/new_prices.csv",
   "ExternalApis": {
-    "ActiveEnvironment": "Test",
+    "ActiveEnvironment": "Prod",
     "PriceApi": {
       "BaseUrl": "https://priceapi.example.com"
     },
@@ -159,7 +159,7 @@
     "TimeZone": "Eastern Standard Time"
   },
   "Automation": {
-    "ActiveEnvironment": "Test",
+    "ActiveEnvironment": "Prod",
     "Wakett": {
       "WorkflowMinuteOffset": 59,
       "FillIntervalMinutes": 10,


### PR DESCRIPTION
## Summary
- switch active environment settings to production for database, external APIs, and automation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926a1a980bc83339bf194c3d60a70b7)