### PR TITLE
Use base pairs for flat Wakett orders

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1286,7 +1286,26 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
 
         if (exposures.Count == 0)
         {
-            return BuildFlatOrders(adjustedWeights, parsedSymbols, orderTimestampUtc);
+            var flatSymbols = configuredPairLookup.Keys
+                .Select(key => symbolPairLookup.TryGetValue(key, out var info) ? info : null)
+                .Where(info => info is not null)
+                .Cast<SymbolInfo>()
+                .OrderBy(info => info.SecurityId)
+                .ToList();
+
+            if (flatSymbols.Count == 0)
+            {
+                flatSymbols = adjustedWeights
+                    .Select(weight => weight.SecurityId)
+                    .Distinct()
+                    .Select(id => parsedSymbols.TryGetValue(id, out var info) ? info : null)
+                    .Where(info => info is not null)
+                    .Cast<SymbolInfo>()
+                    .OrderBy(info => info.SecurityId)
+                    .ToList();
+            }
+
+            return BuildFlatOrders(flatSymbols, orderTimestampUtc);
         }
 
         var orderDescriptors = new List<(int SecurityId, SymbolInfo Info, decimal Weight)>();
@@ -1479,19 +1498,10 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
     }
 
     private static List<(int SecurityId, WakettOrderItem Order)> BuildFlatOrders(
-        IEnumerable<NettedWeightRow> weights,
-        IReadOnlyDictionary<int, SymbolInfo> parsedSymbols,
+        IEnumerable<SymbolInfo> orderedSymbols,
         DateTime orderTimestampUtc)
     {
         var result = new List<(int SecurityId, WakettOrderItem Order)>();
-
-        var orderedSymbols = weights
-            .Select(weight => weight.SecurityId)
-            .Distinct()
-            .Select(id => parsedSymbols.TryGetValue(id, out var info) ? info : null)
-            .Where(info => info is not null)
-            .Cast<SymbolInfo>()
-            .OrderBy(info => info.SecurityId);
 
         foreach (var symbol in orderedSymbols)
         {

--- a/tests/TradingDaemon.Tests/OrderSenderTests.cs
+++ b/tests/TradingDaemon.Tests/OrderSenderTests.cs
@@ -186,9 +186,9 @@ public class OrderSenderTests
         Assert.Equal(0d, first.GetProperty("size").GetProperty("value").GetDouble());
 
         var second = orders[1];
-        Assert.Equal("EUR/CHF", second.GetProperty("symbol").GetString());
+        Assert.Equal("USD/CHF", second.GetProperty("symbol").GetString());
         Assert.Equal("BUY", second.GetProperty("side").GetString());
-        Assert.Equal(OrderSender.BuildOrderCode(61, expectedOrderTimestampUtc), second.GetProperty("code").GetString());
+        Assert.Equal(OrderSender.BuildOrderCode(136, expectedOrderTimestampUtc), second.GetProperty("code").GetString());
         Assert.Equal("percentage", second.GetProperty("size").GetProperty("type").GetString());
         Assert.Equal(0d, second.GetProperty("size").GetProperty("value").GetDouble());
     }
@@ -874,7 +874,20 @@ public class OrderSenderTests
         {
             ["Programmes:0:ModelId"] = "1",
             ["Programmes:0:Session"] = "EUUS",
-            ["Programmes:0:Timeframe"] = "60"
+            ["Programmes:0:Timeframe"] = "60",
+            ["ExternalApis:WakettApi:BasePairs:0"] = "AUDUSD",
+            ["ExternalApis:WakettApi:BasePairs:1"] = "USDCAD",
+            ["ExternalApis:WakettApi:BasePairs:2"] = "USDCHF",
+            ["ExternalApis:WakettApi:BasePairs:3"] = "USDCNH",
+            ["ExternalApis:WakettApi:BasePairs:4"] = "EURUSD",
+            ["ExternalApis:WakettApi:BasePairs:5"] = "GBPUSD",
+            ["ExternalApis:WakettApi:BasePairs:6"] = "USDJPY",
+            ["ExternalApis:WakettApi:BasePairs:7"] = "USDMXN",
+            ["ExternalApis:WakettApi:BasePairs:8"] = "USDNOK",
+            ["ExternalApis:WakettApi:BasePairs:9"] = "NZDUSD",
+            ["ExternalApis:WakettApi:BasePairs:10"] = "USDSEK",
+            ["ExternalApis:WakettApi:BasePairs:11"] = "USDSGD",
+            ["ExternalApis:WakettApi:BasePairs:12"] = "USDZAR"
         };
 
         foreach (var kvp in values)


### PR DESCRIPTION
## Summary
- generate flat Wakett orders from configured base pairs when all weights net to zero
- fall back to prior weight-driven symbols if no base pairs are available and keep flat order formatting unchanged
- update test configuration defaults and flat-order expectations to reflect base pair usage

## Testing
- dotnet test *(fails: `dotnet` command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69276c07fe5c8333a2de084705fe2071)