### PR TITLE
Allow CNH trading weights

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1440,31 +1440,6 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             return weightList;
         }
 
-        var cnhIds = symbolMap
-            .Where(pair => !string.IsNullOrWhiteSpace(pair.Value))
-            .Select(pair => new
-            {
-                pair.Key,
-                Sanitized = pair.Value.Trim().Replace("/", string.Empty).ToUpperInvariant()
-            })
-            .Where(pair =>
-                pair.Sanitized.Length == 6 &&
-                (pair.Sanitized.StartsWith("CNH", StringComparison.OrdinalIgnoreCase) ||
-                 pair.Sanitized.EndsWith("CNH", StringComparison.OrdinalIgnoreCase)))
-            .Select(pair => pair.Key)
-            .ToHashSet();
-
-        if (cnhIds.Count > 0)
-        {
-            _logger.LogInformation(
-                "Zeroing CNH weights for order timestamp {OrderTimestampUtc:O}.",
-                orderTimestampUtc);
-
-            weightList = weightList
-                .Select(weight => cnhIds.Contains(weight.SecurityId) ? weight with { Weight = 0m } : weight)
-                .ToList();
-        }
-
         var localTime = TimeZoneInfo.ConvertTimeFromUtc(orderTimestampUtc, NewYorkZone);
 
         if (localTime.TimeOfDay < NyWeightOverrideTime)


### PR DESCRIPTION
## Summary
- remove the special-case override that zeroed CNH weights during order creation
- allow CNH currency pairs to retain their calculated weights

## Testing
- dotnet test tests/TradingDaemon.Tests/TradingDaemon.Tests.csproj *(fails: dotnet not installed in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69280496b8388333a534f92d630f0611)