### PR TITLE
Adjust EU session start to 6am UTC

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -13,7 +13,10 @@ namespace TradingDaemon.Services;
 
 public sealed class WakettAutomationService : BackgroundService
 {
-    private static readonly TimeSpan SessionStart = new(2, 0, 0);
+    // EU session should begin at 06:00 UTC; using 01:00 New York time aligns
+    // the automated schedule with that UTC start during the winter trading
+    // calendar.
+    private static readonly TimeSpan SessionStart = new(1, 0, 0);
     private static readonly TimeSpan AutomationLeadTime = TimeSpan.Zero;
     private static readonly TimeSpan SessionEnd = new(15, 59, 0);
     private static readonly TimeSpan SessionShutdownDelay = TimeSpan.FromHours(1);


### PR DESCRIPTION
## Summary
- align EU session start time with 06:00 UTC by moving the start hour earlier
- document the rationale for mapping the automation schedule to the earlier start

## Testing
- dotnet test (fails: dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69328fc8af4883339071250e2b152cee)