### PR TITLE
Fix Wakett automation window scheduling

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -463,6 +463,11 @@ public sealed class WakettAutomationService : BackgroundService
             return TimeZoneInfo.ConvertTimeToUtc(candidate.Add(-AutomationLeadTime), NewYorkTimeZone);
         }
 
+        if (local >= candidate)
+        {
+            candidate = candidate.AddDays(1);
+        }
+
         do
         {
             candidate = candidate.AddDays(1);


### PR DESCRIPTION
## Summary
- advance the automation window start to the next day when the current time is already past today's session start
- prevent the scheduler from repeatedly re-entering a finished session and idling without running workflows

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932a18e4dc08333988cb8ad2e5c7b6f)