### PR TITLE
Fix session window calculation to prevent infinite loop

### DIFF
--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -1028,18 +1028,23 @@ VALUES
             duration += TimeSpan.FromDays(1);
         }
 
-        var start = local.Date + bounds.Start;
-
-        while (true)
+        var todayStart = local.Date + bounds.Start;
+        var todayEnd = todayStart + duration;
+        if (local >= todayStart && local <= todayEnd)
         {
-            var end = start + duration;
-            if (local >= start && local <= end)
-            {
-                return (start, end);
-            }
-
-            start = local < start ? start.AddDays(-1) : start.AddDays(1);
+            return (todayStart, todayEnd);
         }
+
+        var yesterdayStart = todayStart.AddDays(-1);
+        var yesterdayEnd = yesterdayStart + duration;
+        if (local >= yesterdayStart && local <= yesterdayEnd)
+        {
+            return (yesterdayStart, yesterdayEnd);
+        }
+
+        var tomorrowStart = todayStart.AddDays(1);
+        var tomorrowEnd = tomorrowStart + duration;
+        return (tomorrowStart, tomorrowEnd);
     }
 
     private static bool IsWithinSession(DateTime local, (TimeSpan Start, TimeSpan End) bounds)

--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -463,6 +463,11 @@ public sealed class WakettAutomationService : BackgroundService
             return TimeZoneInfo.ConvertTimeToUtc(candidate.Add(-AutomationLeadTime), NewYorkTimeZone);
         }
 
+        if (local >= candidate)
+        {
+            candidate = candidate.AddDays(1);
+        }
+
         do
         {
             candidate = candidate.AddDays(1);


### PR DESCRIPTION
## Summary
- resolve the session window by checking today, yesterday, and tomorrow instead of looping
- prevent the session window lookup from toggling days indefinitely and stalling automation

## Testing
- not run (dotnet CLI unavailable in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6932a18e4dc08333988cb8ad2e5c7b6f)