### PR TITLE
Prevent Wakett automation from starting on weekends

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -69,13 +69,23 @@ public sealed class WakettAutomationService : BackgroundService
     {
         _logger.LogInformation("Starting Wakett automation service.");
 
+        var initialNowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var initialLocal = TimeZoneInfo.ConvertTimeFromUtc(initialNowUtc, NewYorkTimeZone);
+
+        if (IsWeekend(initialLocal))
+        {
+            _logger.LogInformation(
+                "Wakett automation will not start because today is {DayOfWeek} in New York time.",
+                initialLocal.DayOfWeek);
+            _applicationLifetime.StopApplication();
+            return;
+        }
+
         var sessionActive = false;
         var sessionShutdownDeadlineUtc = (DateTime?)null;
         var currentAutomationWindowStartUtc = DateTime.MinValue;
         var currentSessionStartUtc = DateTime.MinValue;
         var currentSessionEndUtc = DateTime.MinValue;
-
-        var initialNowUtc = _timeProvider.GetUtcNow().UtcDateTime;
         var nextAutomationWindowStartUtc = GetNextAutomationWindowStartUtc(initialNowUtc);
 
         var nextPriceFetchUtc = DateTime.MaxValue;


### PR DESCRIPTION
## Summary
- add an early guard in the automation service to halt startup when the New York day is Saturday or Sunday
- log the reason and stop the application instead of waiting for the next window

## Testing
- dotnet build TradingDaemon.sln *(fails: dotnet not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934447b4ce08333971d5d260576f1c4)