### PR TITLE
Avoid stopping host when Wakett automation skips weekends

### DIFF
--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -69,13 +69,22 @@ public sealed class WakettAutomationService : BackgroundService
     {
         _logger.LogInformation("Starting Wakett automation service.");
 
+        var initialNowUtc = _timeProvider.GetUtcNow().UtcDateTime;
+        var initialLocal = TimeZoneInfo.ConvertTimeFromUtc(initialNowUtc, NewYorkTimeZone);
+
+        if (IsWeekend(initialLocal))
+        {
+            _logger.LogInformation(
+                "Wakett automation will not start because today is {DayOfWeek} in New York time.",
+                initialLocal.DayOfWeek);
+            return;
+        }
+
         var sessionActive = false;
         var sessionShutdownDeadlineUtc = (DateTime?)null;
         var currentAutomationWindowStartUtc = DateTime.MinValue;
         var currentSessionStartUtc = DateTime.MinValue;
         var currentSessionEndUtc = DateTime.MinValue;
-
-        var initialNowUtc = _timeProvider.GetUtcNow().UtcDateTime;
         var nextAutomationWindowStartUtc = GetNextAutomationWindowStartUtc(initialNowUtc);
 
         var nextPriceFetchUtc = DateTime.MaxValue;


### PR DESCRIPTION
## Summary
- keep the application running when the New York weekend guard is hit
- exit the automation service early without requesting host shutdown

## Testing
- not run (not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934447b4ce08333971d5d260576f1c4)