### PR TITLE
Fix slippage order mapping to use DateTimeOffset

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -135,7 +135,7 @@ ORDER BY Symbol, BarTimeUtc";
                 continue;
             }
 
-            var barIndex = bars.FindIndex(b => b.BarTimeUtc == order.ScheduledTimestamp);
+            var barIndex = bars.FindIndex(b => b.BarTimeUtc == order.ScheduledTimestamp.UtcDateTime);
             if (barIndex < 0 || barIndex >= bars.Count - 1)
             {
                 _logger.LogDebug("No matching bar for order at {Timestamp} ({Symbol})", order.ScheduledTimestamp, pair.FormattedSymbol);
@@ -294,7 +294,7 @@ ORDER BY Symbol, BarTimeUtc";
         string? Side,
         decimal? SizeValue,
         decimal? Aum,
-        DateTime ScheduledTimestamp);
+        DateTimeOffset ScheduledTimestamp);
 
     private sealed record FillRow(
         long WakettFillId,


### PR DESCRIPTION
## Summary
- update slippage order mapping to use DateTimeOffset for scheduled timestamps
- compare scheduled timestamps using UTC DateTime to align with price bar timestamps

## Testing
- dotnet test TradingDaemon.sln *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693578afb9788333a512faace7964dd1)