### PR TITLE
Fix fill timestamp mapping in slippage service

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -195,7 +195,9 @@ ORDER BY Symbol, BarTimeUtc";
             for (var i = 0; i < bars.Count - 1; i++)
             {
                 var currentBar = bars[i];
-                while (symbolFills is not null && fillIndex < symbolFills.Count && symbolFills[fillIndex].TradeTimestamp < currentBar.BarTimeUtc)
+                while (symbolFills is not null
+                    && fillIndex < symbolFills.Count
+                    && symbolFills[fillIndex].TradeTimestamp.UtcDateTime < currentBar.BarTimeUtc)
                 {
                     var fill = symbolFills[fillIndex];
                     var sideMultiplier = GetSideMultiplier(fill.Side);
@@ -301,7 +303,7 @@ ORDER BY Symbol, BarTimeUtc";
         string Symbol,
         string? Side,
         decimal? ExecuteSize,
-        DateTime TradeTimestamp);
+        DateTimeOffset TradeTimestamp);
 
     private sealed record PriceBarRow(string Symbol, DateTime BarTimeUtc, decimal Close);
 }


### PR DESCRIPTION
## Summary
- align `FillRow` trade timestamp type with database mapping to avoid Dapper materialization errors
- compare fill timestamps using UTC to match price bar times

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69357aa36e4483339677892592ed9458)