### PR TITLE
Fix theoretical PnL currency handling

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -162,9 +162,9 @@ ORDER BY Symbol, BarTimeUtc";
         var realPnlResult = CalculateRealPnlByCurrency(fills, lastClosePrices, conversionGraph);
         var realPnlByCurrency = realPnlResult.Totals;
 
-        var theoreticalUsd = hasConversionPrices
-            ? AggregateToUsd(theoreticalPnlByCurrency, conversionGraph)
-            : null;
+        var theoreticalUsd = theoreticalPnlByCurrency.TryGetValue("USD", out var theoreticalUsdTotal)
+            ? theoreticalUsdTotal
+            : (decimal?)null;
         var realUsd = hasConversionPrices
             ? AggregateToUsd(realPnlByCurrency, conversionGraph)
             : null;
@@ -273,7 +273,11 @@ ORDER BY Symbol, BarTimeUtc";
 
             if (pnlQuote != 0m)
             {
-                totals[pair.QuoteCurrency] = totals.TryGetValue(pair.QuoteCurrency, out var existing)
+                var currency = string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                    ? pair.QuoteCurrency
+                    : "USD";
+
+                totals[currency] = totals.TryGetValue(currency, out var existing)
                     ? existing + pnlQuote
                     : pnlQuote;
             }


### PR DESCRIPTION
## Summary
- treat theoretical PnL as USD even when orders reference non-USD quote currencies
- compute theoretical USD totals directly without requiring conversion rates

## Testing
- dotnet test *(fails: dotnet command not available in container)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936bb9b24e8833386f1828da050c57e)