### PR TITLE
Restore theoretical PnL currency breakdown

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -311,11 +311,7 @@ ORDER BY Symbol, BarTimeUtc";
 
             if (pnlQuote != 0m)
             {
-                var currency = string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
-                    ? pair.QuoteCurrency
-                    : "USD";
-
-                totals[currency] = totals.TryGetValue(currency, out var existing)
+                totals[pair.QuoteCurrency] = totals.TryGetValue(pair.QuoteCurrency, out var existing)
                     ? existing + pnlQuote
                     : pnlQuote;
             }


### PR DESCRIPTION
## Summary
- keep theoretical PnL grouped by each quote currency instead of aggregating everything into USD

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e45bb4488333958905cb4bf53bb1)