### PR TITLE
Align real PnL aggregate with USD conversion sum

### DIFF
--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -110,11 +110,11 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
             sb.AppendLine("  - Theoretical PnL by currency (USD basis):");
             AppendPnlByCurrency(sb, slippageResult.TheoreticalPnlByCurrency);
 
-            sb.AppendLine("  - Real PnL by currency (quote currency):");
+            sb.AppendLine("  - Real PnL by currency (USD using last available close):");
             AppendPnlByCurrency(sb, slippageResult.RealPnlByCurrency);
 
             sb.AppendLine(
-                "  Note: Theoretical PnL values are presented in USD (even when the pair is not quoted in USD); real PnL values are presented in the quote currency.");
+                "  Note: Theoretical and real PnL values are presented in USD using the last available close prices (currency list retained for clarity).");
         }
 
         return sb.ToString();
@@ -161,7 +161,7 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
                 WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.TheoreticalPnlUsd)));
             sb.AppendFormat(
                 CultureInfo.InvariantCulture,
-                "<li>Real PnL (USD aggregate after trading costs): {0}</li>",
+                "<li>Real PnL (USD aggregate): {0}</li>",
                 WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.RealPnlUsd)));
             sb.AppendFormat(
                 CultureInfo.InvariantCulture,
@@ -172,11 +172,11 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
             sb.Append("<h3>Theoretical PnL by currency (USD basis)</h3>");
             AppendPnlTable(sb, slippageResult.TheoreticalPnlByCurrency);
 
-            sb.Append("<h3>Real PnL by currency (quote currency)</h3>");
+            sb.Append("<h3>Real PnL by currency (USD using last available close)</h3>");
             AppendPnlTable(sb, slippageResult.RealPnlByCurrency);
 
             sb.Append(
-                "<p><em>Note: Theoretical PnL values are presented in USD (even when the pair is not quoted in USD); real PnL values are presented in the quote currency.</em></p>");
+                "<p><em>Note: Theoretical and real PnL values are presented in USD using the last available close prices (currency list retained for clarity).</em></p>");
         }
 
         sb.Append("</body></html>");

--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -181,22 +181,22 @@ ORDER BY Symbol, BarTimeUtc";
 
         var realPnlFills = AddVirtualStartingFills(fills, startingPositions, previousClosePrices, startUtc);
         var realPnlResult = CalculateRealPnlByCurrency(realPnlFills, lastClosePrices, conversionGraph);
-        var realPnlByCurrency = realPnlResult.Totals;
+        var realPnlByCurrencyUsd = hasConversionPrices
+            ? ConvertPnlsToUsdByCurrency(realPnlResult.Totals, conversionGraph)
+            : new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
 
         var theoreticalUsd = theoreticalPnlByCurrency.TryGetValue("USD", out var theoreticalUsdTotal)
             ? theoreticalUsdTotal
             : (decimal?)null;
-        var realUsd = hasConversionPrices
-            ? AggregateToUsd(realPnlByCurrency, conversionGraph)
-            : null;
+        var realUsd = realPnlByCurrencyUsd.Count > 0
+            ? realPnlByCurrencyUsd.Values.Sum()
+            : (decimal?)null;
+        var realUsdAfterTradingCost = realUsd.HasValue
+            ? realUsd.Value - realPnlResult.TotalTradingCostUsd
+            : (decimal?)null;
 
-        if (realUsd.HasValue)
-        {
-            realUsd -= realPnlResult.TotalTradingCostUsd;
-        }
-
-        var slippageCost = theoreticalUsd.HasValue && realUsd.HasValue
-            ? realUsd.Value - theoreticalUsd.Value
+        var slippageCost = theoreticalUsd.HasValue && realUsdAfterTradingCost.HasValue
+            ? realUsdAfterTradingCost.Value - theoreticalUsd.Value
             : (decimal?)null;
 
         Console.WriteLine($"Slippage computation for {tradingDate:yyyy-MM-dd}");
@@ -206,8 +206,8 @@ ORDER BY Symbol, BarTimeUtc";
             Console.WriteLine($" - {entry.Key}: {entry.Value}");
         }
 
-        Console.WriteLine("Real PnL by currency:");
-        foreach (var entry in realPnlByCurrency.OrderBy(e => e.Key, StringComparer.OrdinalIgnoreCase))
+        Console.WriteLine("Real PnL by currency (USD using last available close):");
+        foreach (var entry in realPnlByCurrencyUsd.OrderBy(e => e.Key, StringComparer.OrdinalIgnoreCase))
         {
             Console.WriteLine($" - {entry.Key}: {entry.Value}");
         }
@@ -219,9 +219,12 @@ ORDER BY Symbol, BarTimeUtc";
                 ? $" - Theoretical PnL (USD): {theoreticalUsd.Value}"
                 : " - Theoretical PnL could not be fully converted to USD.");
             Console.WriteLine(realUsd.HasValue
-                ? $" - Real PnL (USD, after trading costs): {realUsd.Value}"
+                ? $" - Real PnL (USD aggregate): {realUsd.Value}"
                 : " - Real PnL could not be fully converted to USD.");
             Console.WriteLine($" - Total trading cost (USD): {realPnlResult.TotalTradingCostUsd}");
+            Console.WriteLine(realUsdAfterTradingCost.HasValue
+                ? $" - Real PnL after trading costs (USD): {realUsdAfterTradingCost.Value}"
+                : " - Real PnL after trading costs could not be fully converted to USD.");
             Console.WriteLine(slippageCost.HasValue
                 ? $" - Slippage and missed trade cost (USD): {slippageCost.Value}"
                 : " - Slippage and missed trade cost could not be aggregated to USD.");
@@ -255,7 +258,7 @@ ORDER BY Symbol, BarTimeUtc";
         return new SlippageResult(
             tradingDate,
             theoreticalPnlByCurrency,
-            realPnlByCurrency,
+            realPnlByCurrencyUsd,
             theoreticalUsd,
             realUsd,
             slippageCost,
@@ -311,11 +314,7 @@ ORDER BY Symbol, BarTimeUtc";
 
             if (pnlQuote != 0m)
             {
-                var currency = string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
-                    ? pair.QuoteCurrency
-                    : "USD";
-
-                totals[currency] = totals.TryGetValue(currency, out var existing)
+                totals[pair.QuoteCurrency] = totals.TryGetValue(pair.QuoteCurrency, out var existing)
                     ? existing + pnlQuote
                     : pnlQuote;
             }
@@ -674,6 +673,33 @@ ORDER BY Symbol, BarTimeUtc";
         }
 
         return convertedAny ? total : null;
+    }
+
+    private IReadOnlyDictionary<string, decimal> ConvertPnlsToUsdByCurrency(
+        IReadOnlyDictionary<string, decimal> pnlByCurrency,
+        IReadOnlyDictionary<string, List<(string Target, decimal Rate)>> conversionGraph)
+    {
+        var converted = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (currency, amount) in pnlByCurrency)
+        {
+            if (string.Equals(currency, "USD", StringComparison.OrdinalIgnoreCase))
+            {
+                converted[currency] = amount;
+                continue;
+            }
+
+            if (TryGetConversionRate(currency, "USD", conversionGraph, out var rate) && rate != 0m)
+            {
+                converted[currency] = amount * rate;
+            }
+            else
+            {
+                _logger.LogWarning("Unable to convert {Currency} PnL to USD using close prices.", currency);
+            }
+        }
+
+        return converted;
     }
 
     private static void AddEdge(


### PR DESCRIPTION
## Summary
- compute the real PnL USD aggregate as the sum of all per-currency PnLs converted to USD
- keep trading costs separate from the gross USD PnL while still using net USD values for slippage calculations
- update email wording to match the new real PnL aggregation

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936e45bb4488333958905cb4bf53bb1)