### PR TITLE
Summarize missed trade PnL in USD

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -18,6 +18,7 @@ public sealed class SlippageAndMissedCostService
     private readonly string _fillTable;
     private readonly string _priceBarView;
     private readonly string _timeframeLiteral;
+    private readonly int _timeframeMinutes;
 
     private const decimal TradingCostUsdPerUsdNotional = 5m / 1_000_000m;
 
@@ -62,7 +63,8 @@ ORDER BY Symbol, BarTimeUtc";
         _context = context;
         _logger = logger;
         var options = priceBarOptions?.Value ?? new PriceBarOptions();
-        _timeframeLiteral = Math.Max(1, options.TimeframeMinute).ToString(CultureInfo.InvariantCulture);
+        _timeframeMinutes = Math.Max(1, options.TimeframeMinute);
+        _timeframeLiteral = _timeframeMinutes.ToString(CultureInfo.InvariantCulture);
         _orderTable = databaseObjectNameProvider.GetObjectName(DatabaseObjects.WakettOrder);
         _fillTable = databaseObjectNameProvider.GetObjectName(DatabaseObjects.WakettFill);
         _priceBarView = databaseObjectNameProvider.GetObjectName(DatabaseObjects.IntradayMarketPriceBarView);
@@ -232,6 +234,28 @@ ORDER BY Symbol, BarTimeUtc";
         {
             Console.WriteLine("Price bars were not available; USD aggregation skipped.");
         }
+
+        var missedTrades = IdentifyMissedTrades(orders, fills, barsBySymbol, _timeframeMinutes);
+        Console.WriteLine($"Missed trades for {tradingDate:yyyy-MM-dd}:");
+        if (missedTrades.Count == 0)
+        {
+            Console.WriteLine(" - None");
+        }
+        else
+        {
+            foreach (var trade in missedTrades.OrderBy(m => m.Symbol, StringComparer.OrdinalIgnoreCase)
+                         .ThenBy(m => m.BarTimeUtc))
+            {
+                Console.WriteLine(
+                    $" - {trade.Symbol} at {trade.BarTimeUtc:HH:mm} UTC | Target: {trade.TargetSize}, Filled: {trade.FilledSize}, " +
+                    $"Diff: {trade.SizeDifference}, Price Δ: {trade.PriceDelta}, Missed PnL: {trade.MissedPnl}");
+            }
+        }
+
+        var totalMissedUsd = AggregateMissedPnlUsd(missedTrades, conversionGraph);
+        Console.WriteLine(totalMissedUsd.HasValue
+            ? $"Total missed PnL (USD): {totalMissedUsd.Value}"
+            : "Total missed PnL could not be fully converted to USD.");
 
         return new SlippageResult(
             tradingDate,
@@ -522,6 +546,150 @@ ORDER BY Symbol, BarTimeUtc";
         return result;
     }
 
+    private static IReadOnlyCollection<MissedTrade> IdentifyMissedTrades(
+        IReadOnlyCollection<OrderRow> orders,
+        IReadOnlyCollection<FillRow> fills,
+        IReadOnlyDictionary<string, List<PriceBarRow>> barsBySymbol,
+        int timeframeMinutes)
+    {
+        var missedTrades = new List<MissedTrade>();
+
+        var fillsBySymbol = fills
+            .GroupBy(f => NormalizeSymbol(f.Symbol))
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(f => f.ExecuteTimestamp.UtcDateTime).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        var ordersBySymbol = orders
+            .GroupBy(o => NormalizeSymbol(o.Symbol))
+            .ToDictionary(
+                g => g.Key,
+                g => g.OrderBy(o => o.ScheduledTimestamp.UtcDateTime).ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+        foreach (var orderGroup in ordersBySymbol)
+        {
+            var normalizedSymbol = orderGroup.Key;
+
+            if (!barsBySymbol.TryGetValue(normalizedSymbol, out var bars) || bars.Count == 0)
+            {
+                continue;
+            }
+
+            var symbolFills = fillsBySymbol.TryGetValue(normalizedSymbol, out var fillsList)
+                ? fillsList
+                : new List<FillRow>();
+
+            var cumulativeFilled = 0m;
+            var fillIndex = 0;
+
+            foreach (var order in orderGroup.Value)
+            {
+                var scheduledUtc = order.ScheduledTimestamp.UtcDateTime;
+                var barIndex = bars.FindIndex(b => b.BarTimeUtc == scheduledUtc);
+
+                if (barIndex <= 0 || barIndex >= bars.Count)
+                {
+                    continue;
+                }
+
+                var currentBar = bars[barIndex];
+                var previousBar = bars[barIndex - 1];
+
+                if (currentBar.Close == 0m || previousBar.Close == 0m)
+                {
+                    continue;
+                }
+
+                var barEnd = currentBar.BarTimeUtc.AddMinutes(timeframeMinutes);
+
+                while (fillIndex < symbolFills.Count && symbolFills[fillIndex].ExecuteTimestamp.UtcDateTime < barEnd)
+                {
+                    var fill = symbolFills[fillIndex];
+                    cumulativeFilled += (fill.ExecuteSize ?? 0m) * GetSideMultiplier(fill.Side);
+                    fillIndex++;
+                }
+
+                var targetSize = (order.SizeValue ?? 0m) * (order.Aum ?? 0m) * GetSideMultiplier(order.Side);
+                var filledSize = cumulativeFilled;
+
+                var sizeDifference = targetSize - filledSize;
+
+                if (Math.Abs(sizeDifference) < 1_000m)
+                {
+                    continue;
+                }
+
+                var priceDelta = currentBar.Close - previousBar.Close;
+                var missedPnl = sizeDifference * priceDelta;
+
+                if (!CurrencyPairParser.TryParse(order.Symbol, out var pair))
+                {
+                    continue;
+                }
+
+                missedTrades.Add(new MissedTrade(
+                    order.Symbol,
+                    currentBar.BarTimeUtc,
+                    targetSize,
+                    filledSize,
+                    sizeDifference,
+                    priceDelta,
+                    missedPnl,
+                    pair.QuoteCurrency));
+            }
+        }
+
+        return missedTrades;
+    }
+
+    private decimal? AggregateMissedPnlUsd(
+        IReadOnlyCollection<MissedTrade> missedTrades,
+        IReadOnlyDictionary<string, List<(string Target, decimal Rate)>> conversionGraph)
+    {
+        if (missedTrades.Count == 0)
+        {
+            return 0m;
+        }
+
+        decimal total = 0m;
+        var convertedAny = false;
+
+        foreach (var trade in missedTrades)
+        {
+            if (string.IsNullOrWhiteSpace(trade.PnlCurrency))
+            {
+                continue;
+            }
+
+            decimal conversionRate;
+
+            if (string.Equals(trade.PnlCurrency, "USD", StringComparison.OrdinalIgnoreCase))
+            {
+                conversionRate = 1m;
+            }
+            else if (TryGetConversionRate(trade.PnlCurrency, "USD", conversionGraph, out var rate) && rate != 0m)
+            {
+                conversionRate = rate;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Unable to convert missed trade PnL from {Currency} to USD for {Symbol} at {Timestamp}.",
+                    trade.PnlCurrency,
+                    trade.Symbol,
+                    trade.BarTimeUtc);
+                continue;
+            }
+
+            total += trade.MissedPnl * conversionRate;
+            convertedAny = true;
+        }
+
+        return convertedAny ? total : (decimal?)null;
+    }
+
     private Dictionary<string, List<(string Target, decimal Rate)>> BuildConversionGraph(
         IReadOnlyDictionary<string, decimal> closePrices)
     {
@@ -805,4 +973,14 @@ ORDER BY Symbol, BarTimeUtc";
         DateTimeOffset ExecuteTimestamp);
 
     private sealed record PriceBarRow(string Symbol, DateTime BarTimeUtc, decimal Close);
+
+    private sealed record MissedTrade(
+        string Symbol,
+        DateTime BarTimeUtc,
+        decimal TargetSize,
+        decimal FilledSize,
+        decimal SizeDifference,
+        decimal PriceDelta,
+        decimal MissedPnl,
+        string PnlCurrency);
 }


### PR DESCRIPTION
## Summary
- annotate missed trades with their PnL currency and skip unparseable symbols
- convert each missed trade PnL to USD and log a total USD missed PnL after the per-trade list
- warn when conversion rates are unavailable for missed trade PnL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936dadaea508333be2d4e43109ea967)