### PR TITLE
Fix theoretical PnL order handling

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -173,7 +173,6 @@ ORDER BY Symbol, BarTimeUtc";
             .GroupBy(b => NormalizeSymbol(b.Symbol))
             .ToDictionary(g => g.Key, g => g.OrderBy(b => b.BarTimeUtc).ToList(), StringComparer.OrdinalIgnoreCase);
 
-        var theoreticalPnlByCurrency = CalculateTheoreticalPnlByCurrency(orders, barsBySymbol);
         var lastClosePrices = ExtractLastClosePrices(barsBySymbol);
         var previousClosePrices = ExtractLastClosePricesBeforeTimestamp(barsBySymbol, startUtc);
         var conversionGraph = BuildConversionGraph(lastClosePrices);
@@ -181,6 +180,9 @@ ORDER BY Symbol, BarTimeUtc";
 
         var realPnlFills = AddVirtualStartingFills(fills, startingPositions, previousClosePrices, startUtc);
         var realPnlResult = CalculateRealPnlByCurrency(realPnlFills, lastClosePrices, conversionGraph);
+        var theoreticalFills = ConvertOrdersToTheoreticalFills(orders, barsBySymbol);
+        var theoreticalPnlResult = CalculateRealPnlByCurrency(theoreticalFills, lastClosePrices, conversionGraph);
+        var theoreticalPnlByCurrency = theoreticalPnlResult.Totals;
         var theoreticalPnlByCurrencyUsd = hasConversionPrices
             ? ConvertPnlsToUsdByCurrency(theoreticalPnlByCurrency, conversionGraph)
             : new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
@@ -273,17 +275,21 @@ ORDER BY Symbol, BarTimeUtc";
             hasConversionPrices);
     }
 
-    private Dictionary<string, decimal> CalculateTheoreticalPnlByCurrency(
+    private IReadOnlyCollection<FillRow> ConvertOrdersToTheoreticalFills(
         IReadOnlyCollection<OrderRow> orders,
         IReadOnlyDictionary<string, List<PriceBarRow>> barsBySymbol)
     {
-        var totals = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        var theoreticalFills = new List<FillRow>();
 
-        foreach (var order in orders)
+        var ordersBySymbol = orders
+            .GroupBy(o => NormalizeSymbol(o.Symbol))
+            .ToDictionary(g => g.Key, g => g.OrderBy(o => o.ScheduledTimestamp).ToList(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var (normalizedSymbol, symbolOrders) in ordersBySymbol)
         {
-            if (!CurrencyPairParser.TryParse(order.Symbol, out var pair))
+            if (!CurrencyPairParser.TryParse(normalizedSymbol, out var pair))
             {
-                _logger.LogDebug("Skipping theoretical PnL for unparsable symbol {Symbol}", order.Symbol);
+                _logger.LogDebug("Skipping theoretical PnL for unparsable symbol {Symbol}", normalizedSymbol);
                 continue;
             }
 
@@ -292,43 +298,50 @@ ORDER BY Symbol, BarTimeUtc";
                 continue;
             }
 
-            var normalizedSymbol = NormalizeSymbol(order.Symbol);
-            if (!barsBySymbol.TryGetValue(normalizedSymbol, out var bars) || bars.Count < 2)
+            if (!barsBySymbol.TryGetValue(normalizedSymbol, out var bars) || bars.Count == 0)
             {
-                _logger.LogDebug("No price bars for symbol {Symbol} to compute theoretical PnL", order.Symbol);
+                _logger.LogDebug("No price bars for symbol {Symbol} to compute theoretical PnL", normalizedSymbol);
                 continue;
             }
 
-            var barIndex = bars.FindIndex(b => b.BarTimeUtc == order.ScheduledTimestamp.UtcDateTime);
-            if (barIndex < 0 || barIndex >= bars.Count - 1)
+            decimal targetPosition = 0m;
+
+            foreach (var order in symbolOrders)
             {
-                _logger.LogDebug("No matching bar for order at {Timestamp} ({Symbol})", order.ScheduledTimestamp, pair.FormattedSymbol);
-                continue;
-            }
+                var scheduledUtc = order.ScheduledTimestamp.UtcDateTime;
+                var matchingBar = bars.FirstOrDefault(b => b.BarTimeUtc == scheduledUtc);
+                if (matchingBar is null || matchingBar.Close == 0m)
+                {
+                    _logger.LogDebug("No matching price bar for order at {Timestamp} ({Symbol})", order.ScheduledTimestamp, pair.FormattedSymbol);
+                    continue;
+                }
 
-            var currentBar = bars[barIndex];
-            var nextBar = bars[barIndex + 1];
+                var absoluteSize = (order.SizeValue ?? 0m) * (order.Aum ?? 0m);
+                if (absoluteSize == 0m)
+                {
+                    continue;
+                }
 
-            if (currentBar.Close == 0m)
-            {
-                continue;
-            }
+                var signedTarget = absoluteSize * GetSideMultiplier(order.Side);
+                var delta = signedTarget - targetPosition;
 
-            var priceReturn = (nextBar.Close - currentBar.Close) / currentBar.Close;
-            var sideMultiplier = GetSideMultiplier(order.Side);
-            var notionalUsd = (order.SizeValue ?? 0m) * (order.Aum ?? 0m) * sideMultiplier;
+                if (delta != 0m)
+                {
+                    var side = delta > 0m ? "BUY" : "SELL";
+                    theoreticalFills.Add(new FillRow(
+                        WakettFillId: 0,
+                        Symbol: normalizedSymbol,
+                        Side: side,
+                        ExecuteSize: Math.Abs(delta),
+                        ExecutePrice: matchingBar.Close,
+                        ExecuteTimestamp: order.ScheduledTimestamp));
+                }
 
-            var pnlQuote = notionalUsd * priceReturn;
-
-            if (pnlQuote != 0m)
-            {
-                totals[pair.QuoteCurrency] = totals.TryGetValue(pair.QuoteCurrency, out var existing)
-                    ? existing + pnlQuote
-                    : pnlQuote;
+                targetPosition = signedTarget;
             }
         }
 
-        return totals;
+        return theoreticalFills;
     }
 
     private static IReadOnlyDictionary<string, decimal> CalculatePositionsAtStartOfDay(


### PR DESCRIPTION
## Summary
- compute theoretical trades from order targets without aggregating by symbol or timeframe
- stop seeding theoretical PnL with starting positions so it reflects only scheduled order targets

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693700ea5d848333b6fe8a982f045eba)