### PR TITLE
Use previous available price bar when no exact match

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -309,8 +309,10 @@ ORDER BY Symbol, BarTimeUtc";
             foreach (var order in symbolOrders)
             {
                 var scheduledUtc = order.ScheduledTimestamp.UtcDateTime;
-                var matchingBar = bars.FirstOrDefault(b => b.BarTimeUtc == scheduledUtc);
-                if (matchingBar is null || matchingBar.Close == 0m)
+                var matchingBar = bars.FirstOrDefault(b => b.BarTimeUtc == scheduledUtc && b.Close != 0m)
+                    ?? bars.LastOrDefault(b => b.BarTimeUtc < scheduledUtc && b.Close != 0m);
+
+                if (matchingBar is null)
                 {
                     _logger.LogDebug("No matching price bar for order at {Timestamp} ({Symbol})", order.ScheduledTimestamp, pair.FormattedSymbol);
                     continue;


### PR DESCRIPTION
## Summary
- fall back to the most recent earlier price bar when an order has no matching bar at its scheduled time

## Testing
- dotnet test *(fails: dotnet command not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693705f0fffc833395dc5bf0cbf3ce17)