### PR TITLE
Enhance slippage reporting breakdowns

### DIFF
--- a/src/TradingDaemon/Models/SlippageResult.cs
+++ b/src/TradingDaemon/Models/SlippageResult.cs
@@ -7,4 +7,9 @@ public sealed record SlippageResult(
     decimal? TheoreticalPnlUsd,
     decimal? RealPnlUsd,
     decimal? SlippageAndMissedCostUsd,
-    bool HasFivePmBar);
+    bool HasFivePmBar,
+    decimal? TheoreticalTradingCostUsd,
+    decimal? TheoreticalNetPnlUsd,
+    decimal? MissedTradesPnlUsd,
+    decimal? CommissionsUsd,
+    decimal? ExecutionSlippageUsd);

--- a/src/TradingDaemon/Services/EmailNotificationService.cs
+++ b/src/TradingDaemon/Services/EmailNotificationService.cs
@@ -76,9 +76,14 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
         if (slippageResult is not null)
         {
             sb.AppendLine($"Date: {report.TradingDate:yyyy-MM-dd}");
-            sb.AppendLine($"PnL (USD): {FormatOptionalPnl(slippageResult.RealPnlUsd)}");
-            sb.AppendLine($"Theoretical PnL (USD): {FormatOptionalPnl(slippageResult.TheoreticalPnlUsd)}");
-            sb.AppendLine($"Slippage and missed trade cost (USD): {FormatOptionalPnl(slippageResult.SlippageAndMissedCostUsd)}");
+            sb.AppendLine("Execution summary:");
+            sb.AppendLine($"- Theoretical pnl (gross) = {FormatOptionalPnl(slippageResult.TheoreticalPnlUsd)}");
+            sb.AppendLine($"- Theoretical costs ($10/M) = {FormatOptionalPnl(slippageResult.TheoreticalTradingCostUsd)}");
+            sb.AppendLine($"- Theoretical pnl (net) = {FormatOptionalPnl(slippageResult.TheoreticalNetPnlUsd)}");
+            sb.AppendLine($"- Missed trades pnl = {FormatOptionalPnl(slippageResult.MissedTradesPnlUsd)}");
+            sb.AppendLine($"- Commissions = {FormatOptionalPnl(slippageResult.CommissionsUsd)}");
+            sb.AppendLine($"- Execution slippage = {FormatOptionalPnl(slippageResult.ExecutionSlippageUsd)}");
+            sb.AppendLine($"- Real pnl = {FormatOptionalPnl(slippageResult.RealPnlUsd)}");
             sb.AppendLine();
             sb.AppendLine($"Gross Market Value: {FormatPnl(report.GrossMarketValue)}");
             sb.AppendLine($"Total Net Exposure: {FormatPnl(report.TotalNetExposure)}");
@@ -125,9 +130,39 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
         var sb = new StringBuilder();
         sb.Append("<html><body><h1>Intraday PnL</h1>");
         sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>Date:</strong> {0:yyyy-MM-dd}</p>", report.TradingDate);
-        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>PnL (USD):</strong> {0}</p>", FormatOptionalPnl(slippageResult.RealPnlUsd));
-        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>Theoretical PnL (USD):</strong> {0}</p>", FormatOptionalPnl(slippageResult.TheoreticalPnlUsd));
-        sb.AppendFormat(CultureInfo.InvariantCulture, "<p><strong>TSlippage and missed trade cost (USD):</strong> {0}</p>", FormatOptionalPnl(slippageResult.SlippageAndMissedCostUsd));
+        if (slippageResult is not null)
+        {
+            sb.Append("<h2>Execution summary</h2><ul>");
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Theoretical pnl (gross) = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.TheoreticalPnlUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Theoretical costs ($10/M) = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.TheoreticalTradingCostUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Theoretical pnl (net) = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.TheoreticalNetPnlUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Missed trades pnl = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.MissedTradesPnlUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Commissions = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.CommissionsUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Execution slippage = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.ExecutionSlippageUsd)));
+            sb.AppendFormat(
+                CultureInfo.InvariantCulture,
+                "<li>Real pnl = {0}</li>",
+                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.RealPnlUsd)));
+            sb.Append("</ul>");
+        }
 
         sb.Append("<h2>Positions</h2>");
 
@@ -153,22 +188,7 @@ public class EmailNotificationService : IEmailNotificationService, IDisposable
 
         if (slippageResult is not null)
         {
-            sb.Append("<h2>Slippage and Missed Cost</h2>");
-            sb.Append("<ul>");
-            sb.AppendFormat(
-                CultureInfo.InvariantCulture,
-                "<li>Theoretical PnL (USD aggregate): {0}</li>",
-                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.TheoreticalPnlUsd)));
-            sb.AppendFormat(
-                CultureInfo.InvariantCulture,
-                "<li>Real PnL (USD aggregate): {0}</li>",
-                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.RealPnlUsd)));
-            sb.AppendFormat(
-                CultureInfo.InvariantCulture,
-                "<li>Slippage and missed trade cost (USD): {0}</li>",
-                WebUtility.HtmlEncode(FormatOptionalPnl(slippageResult.SlippageAndMissedCostUsd)));
-            sb.Append("</ul>");
-
+            sb.Append("<h2>PnL by currency</h2>");
             sb.Append("<h3>Theoretical PnL by currency (USD basis)</h3>");
             AppendPnlTable(sb, slippageResult.TheoreticalPnlByCurrency);
 

--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -20,6 +20,7 @@ public sealed class SlippageAndMissedCostService
     private readonly string _timeframeLiteral;
     private readonly int _timeframeMinutes;
 
+    private const decimal TheoreticalTradingCostUsdPerUsdNotional = 10m / 1_000_000m;
     private const decimal TradingCostUsdPerUsdNotional = 5m / 1_000_000m;
 
     private const string OrdersSqlTemplate = @"SELECT
@@ -196,6 +197,23 @@ ORDER BY Symbol, BarTimeUtc";
         var realUsd = realPnlByCurrencyUsd.Count > 0
             ? realPnlByCurrencyUsd.Values.Sum()
             : (decimal?)null;
+        var theoreticalNotionalUsd = CalculateTotalNotionalUsd(theoreticalFills, conversionGraph);
+        var theoreticalTradingCostUsd = theoreticalNotionalUsd.HasValue
+            ? theoreticalNotionalUsd.Value * TheoreticalTradingCostUsdPerUsdNotional
+            : (decimal?)null;
+        var theoreticalNetUsd = theoreticalUsd.HasValue && theoreticalTradingCostUsd.HasValue
+            ? theoreticalUsd.Value - theoreticalTradingCostUsd.Value
+            : (decimal?)null;
+
+        var realNotionalUsd = CalculateTotalNotionalUsd(fills, conversionGraph);
+        var commissionsUsd = realNotionalUsd.HasValue
+            ? realNotionalUsd.Value * TradingCostUsdPerUsdNotional
+            : (decimal?)null;
+        if (!commissionsUsd.HasValue && realPnlResult.TotalTradingCostUsd != 0m)
+        {
+            commissionsUsd = realPnlResult.TotalTradingCostUsd;
+        }
+
         var realUsdAfterTradingCost = realUsd.HasValue
             ? realUsd.Value - realPnlResult.TotalTradingCostUsd
             : (decimal?)null;
@@ -217,32 +235,6 @@ ORDER BY Symbol, BarTimeUtc";
             Console.WriteLine($" - {entry.Key}: {entry.Value}");
         }
 
-        if (slippageCost.HasValue || theoreticalUsd.HasValue || realUsd.HasValue || realPnlResult.TotalTradingCostUsd != 0m)
-        {
-            Console.WriteLine("Aggregated USD values using last available close prices:");
-            Console.WriteLine(theoreticalUsd.HasValue
-                ? $" - Theoretical PnL (USD): {theoreticalUsd.Value}"
-                : " - Theoretical PnL could not be fully converted to USD.");
-            Console.WriteLine(realUsd.HasValue
-                ? $" - Real PnL (USD aggregate): {realUsd.Value}"
-                : " - Real PnL could not be fully converted to USD.");
-            Console.WriteLine($" - Total trading cost (USD): {realPnlResult.TotalTradingCostUsd}");
-            Console.WriteLine(realUsdAfterTradingCost.HasValue
-                ? $" - Real PnL after trading costs (USD): {realUsdAfterTradingCost.Value}"
-                : " - Real PnL after trading costs could not be fully converted to USD.");
-            Console.WriteLine(slippageCost.HasValue
-                ? $" - Slippage and missed trade cost (USD): {slippageCost.Value}"
-                : " - Slippage and missed trade cost could not be aggregated to USD.");
-        }
-        else if (hasConversionPrices)
-        {
-            Console.WriteLine("Conversion rates were partially unavailable; USD aggregation skipped.");
-        }
-        else
-        {
-            Console.WriteLine("Price bars were not available; USD aggregation skipped.");
-        }
-
         var missedTrades = IdentifyMissedTrades(orders, fills, barsBySymbol, _timeframeMinutes);
         Console.WriteLine($"Missed trades for {tradingDate:yyyy-MM-dd}:");
         if (missedTrades.Count == 0)
@@ -261,9 +253,49 @@ ORDER BY Symbol, BarTimeUtc";
         }
 
         var totalMissedUsd = AggregateMissedPnlUsd(missedTrades, conversionGraph);
-        Console.WriteLine(totalMissedUsd.HasValue
-            ? $"Total missed PnL (USD): {totalMissedUsd.Value}"
+        var missedTradesCostUsd = totalMissedUsd.HasValue ? -totalMissedUsd.Value : (decimal?)null;
+        Console.WriteLine(missedTradesCostUsd.HasValue
+            ? $"Total missed PnL (USD as cost): {missedTradesCostUsd.Value}"
             : "Total missed PnL could not be fully converted to USD.");
+
+        var executionSlippageUsd = realUsd.HasValue && theoreticalNetUsd.HasValue && missedTradesCostUsd.HasValue && commissionsUsd.HasValue
+            ? realUsd.Value + missedTradesCostUsd.Value + commissionsUsd.Value - theoreticalNetUsd.Value
+            : (decimal?)null;
+
+        if (hasConversionPrices)
+        {
+            Console.WriteLine("Aggregated USD values using last available close prices:");
+            Console.WriteLine(theoreticalUsd.HasValue
+                ? $" - Theoretical PnL (gross): {theoreticalUsd.Value}"
+                : " - Theoretical PnL could not be fully converted to USD.");
+            Console.WriteLine(theoreticalTradingCostUsd.HasValue
+                ? $" - Theoretical costs ($10/M): {theoreticalTradingCostUsd.Value}"
+                : " - Theoretical costs could not be computed.");
+            Console.WriteLine(theoreticalNetUsd.HasValue
+                ? $" - Theoretical PnL (net): {theoreticalNetUsd.Value}"
+                : " - Theoretical net PnL could not be computed.");
+            Console.WriteLine(realUsd.HasValue
+                ? $" - Real PnL (gross): {realUsd.Value}"
+                : " - Real PnL could not be fully converted to USD.");
+            Console.WriteLine(commissionsUsd.HasValue
+                ? $" - Commissions ($5/M): {commissionsUsd.Value}"
+                : " - Commissions could not be computed.");
+            Console.WriteLine(missedTradesCostUsd.HasValue
+                ? $" - Missed trades PnL (as cost): {missedTradesCostUsd.Value}"
+                : " - Missed trades PnL could not be fully converted to USD.");
+            Console.WriteLine(executionSlippageUsd.HasValue
+                ? $" - Execution slippage: {executionSlippageUsd.Value}"
+                : " - Execution slippage could not be computed.");
+            Console.WriteLine(slippageCost.HasValue
+                ? $" - Legacy slippage and missed trade cost (USD): {slippageCost.Value}"
+                : " - Legacy slippage and missed trade cost could not be aggregated to USD.");
+        }
+        else
+        {
+            Console.WriteLine(hasConversionPrices
+                ? "Conversion rates were partially unavailable; USD aggregation skipped."
+                : "Price bars were not available; USD aggregation skipped.");
+        }
 
         return new SlippageResult(
             tradingDate,
@@ -272,7 +304,12 @@ ORDER BY Symbol, BarTimeUtc";
             theoreticalUsd,
             realUsd,
             slippageCost,
-            hasConversionPrices);
+            hasConversionPrices,
+            theoreticalTradingCostUsd,
+            theoreticalNetUsd,
+            missedTradesCostUsd,
+            commissionsUsd,
+            executionSlippageUsd);
     }
 
     private IReadOnlyCollection<FillRow> ConvertOrdersToTheoreticalFills(
@@ -480,6 +517,42 @@ ORDER BY Symbol, BarTimeUtc";
         }
 
         return augmented;
+    }
+
+    private decimal? CalculateTotalNotionalUsd(
+        IReadOnlyCollection<FillRow> fills,
+        IReadOnlyDictionary<string, List<(string Target, decimal Rate)>> conversionGraph)
+    {
+        if (fills.Count == 0)
+        {
+            return 0m;
+        }
+
+        var totalUsd = 0m;
+        var convertedAny = false;
+
+        foreach (var fill in fills)
+        {
+            if (!fill.ExecutePrice.HasValue || !fill.ExecuteSize.HasValue)
+            {
+                continue;
+            }
+
+            if (!CurrencyPairParser.TryParse(fill.Symbol, out var pair) || string.IsNullOrWhiteSpace(pair.QuoteCurrency))
+            {
+                continue;
+            }
+
+            var notionalQuote = Math.Abs(fill.ExecutePrice.Value * fill.ExecuteSize.Value);
+
+            if (TryConvertToUsd(notionalQuote, pair.QuoteCurrency, conversionGraph, out var notionalUsd))
+            {
+                totalUsd += notionalUsd;
+                convertedAny = true;
+            }
+        }
+
+        return convertedAny ? totalUsd : (decimal?)null;
     }
 
     private static decimal GetCashFlowSideMultiplier(string? side)


### PR DESCRIPTION
## Summary
- extend slippage results with theoretical trading costs, net PnL, commissions, and execution slippage figures
- update console/email reporting to present an accounting-style execution summary and negative missed-trade costs
- compute USD notionals for theoretical and real flows to drive consistent cost calculations

## Testing
- dotnet test *(fails: command not found: dotnet)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e2c1d4e48333b376c97fe5d6a92e)