### PR TITLE
Handle non-USD base currency missed trade sizing

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -702,8 +702,24 @@ ORDER BY Symbol, BarTimeUtc";
                     fillIndex++;
                 }
 
+                if (!CurrencyPairParser.TryParse(order.Symbol, out var pair))
+                {
+                    continue;
+                }
+
                 var targetSize = (order.SizeValue ?? 0m) * (order.Aum ?? 0m) * GetSideMultiplier(order.Side);
                 var filledSize = cumulativeFilled;
+
+                var priceDelta = nextBar.Close - currentBar.Close;
+
+                if (!string.Equals(pair.BaseCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                    && currentBar.Close != 0m)
+                {
+                    targetSize *= currentBar.Close;
+                    filledSize *= currentBar.Close;
+                    priceDelta /= currentBar.Close;
+                }
 
                 var sizeDifference = targetSize - filledSize;
 
@@ -712,13 +728,7 @@ ORDER BY Symbol, BarTimeUtc";
                     continue;
                 }
 
-                var priceDelta = nextBar.Close - currentBar.Close;
                 var missedPnl = sizeDifference * priceDelta;
-
-                if (!CurrencyPairParser.TryParse(order.Symbol, out var pair))
-                {
-                    continue;
-                }
 
                 missedTrades.Add(new MissedTrade(
                     order.Symbol,


### PR DESCRIPTION
## Summary
- parse missed trade symbols before computing size and pricing adjustments
- convert missed trade target and filled sizes to USD when base currency is not USD but quote currency is USD
- keep price delta consistent after conversion to ensure missed PnL stays in USD

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937e76f6cc883339fee55031b82b055)