### PR TITLE
Update PnL email cron schedule

### DIFF
--- a/src/TradingDaemon/Services/SchedulerService.cs
+++ b/src/TradingDaemon/Services/SchedulerService.cs
@@ -34,7 +34,7 @@ public class SchedulerService : IHostedService
 
         var schedulerOptions = _optionsMonitor.CurrentValue;
         var cron = string.IsNullOrWhiteSpace(schedulerOptions.Cron)
-            ? "0 1,16,31,46 9-15 ? * *"
+            ? "0 2,32 9-15 ? * *"
             : schedulerOptions.Cron;
         var timeZoneId = string.IsNullOrWhiteSpace(schedulerOptions.TimeZone)
             ? "Eastern Standard Time"

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -185,7 +185,7 @@
     "SourceId": 1
   },
   "Quartz": {
-    "Cron": "0 1,16,31,46 2-15 ? * *",
+    "Cron": "0 2,32 2-15 ? * *",
     "TimeZone": "Eastern Standard Time"
   },
   "Automation": {


### PR DESCRIPTION
## Summary
- adjust default Quartz cron schedule to run at :02 and :32 past the hour
- update appsettings example to reflect the new schedule

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937f91080e0833382c35d6303700bef)