### PR TITLE
Revert reversed price handling and convert non-USD quote missed PnL

### DIFF
--- a/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
+++ b/src/TradingDaemon/Services/SlippageAndMissedCostService.cs
@@ -713,6 +713,7 @@ ORDER BY Symbol, BarTimeUtc";
                 var filledSize = cumulativeFilled;
 
                 var priceDelta = nextBar.Close - currentBar.Close;
+                var pnlCurrency = pair.QuoteCurrency;
 
                 if (!string.Equals(pair.BaseCurrency, "USD", StringComparison.OrdinalIgnoreCase)
                     && string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
@@ -732,6 +733,14 @@ ORDER BY Symbol, BarTimeUtc";
 
                 var missedPnl = sizeDifference * priceDelta;
 
+                if (!string.Equals(pair.QuoteCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(pair.BaseCurrency, "USD", StringComparison.OrdinalIgnoreCase)
+                    && currentBar.Close != 0m)
+                {
+                    missedPnl /= currentBar.Close;
+                    pnlCurrency = "USD";
+                }
+
                 missedTrades.Add(new MissedTrade(
                     order.Symbol,
                     currentBar.BarTimeUtc,
@@ -740,7 +749,7 @@ ORDER BY Symbol, BarTimeUtc";
                     sizeDifference,
                     priceDelta,
                     missedPnl,
-                    pair.QuoteCurrency));
+                    pnlCurrency));
             }
         }
 


### PR DESCRIPTION
## Summary
- restore missed trade processing to use direct price bars without reversed symbol handling
- convert missed trade PnL to USD when the quote currency is non-USD for USD-base pairs

## Testing
- dotnet test *(fails: command not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6937fb9f42d88333b2140dc91878ad8b)