### PR TITLE
Validate PnL date format

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,6 +1,10 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Dapper;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Logging;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
@@ -24,16 +28,23 @@ public static class FillController
         });
 
 
-        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillEndpointsLogger> logger) =>
+        app.MapGet("/api/pnl", async (string date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillEndpointsLogger> logger) =>
 
         {
+            if (string.IsNullOrWhiteSpace(date) ||
+                !DateTime.TryParseExact(date, "yyyyMMdd", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedDate))
+            {
+                return Results.BadRequest("The date query parameter must be formatted as yyyyMMdd (UTC).");
+            }
+
             using var connection = context.CreateConnection();
             var fillsSql = "SELECT * FROM fills WHERE DATE(timestamp) = @Date";
             logger.LogInformation("Executing SQL: {Sql}", fillsSql);
-            var fills = await connection.QueryAsync<Fill>(fillsSql, new { Date = date.Date });
+            var fills = await connection.QueryAsync<Fill>(fillsSql, new { Date = parsedDate.Date });
             var weightsSql = "SELECT * FROM weights WHERE DATE(asof) = @Date";
             logger.LogInformation("Executing SQL: {Sql}", weightsSql);
-            var weights = await connection.QueryAsync<Weight>(weightsSql, new { Date = date.Date });
+            var weights = await connection.QueryAsync<Weight>(weightsSql, new { Date = parsedDate.Date });
 
             var pnl = (from f in fills
                        join w in weights on f.Symbol equals w.Symbol
@@ -72,7 +83,7 @@ public static class FillController
 
             var grossMarketValue = positions.Sum(p => Math.Abs(p.MarketValueUsd ?? 0m));
             var totalNetExposure = positions.Sum(p => p.MarketValueUsd ?? 0m);
-            var report = new PnlReport(DateOnly.FromDateTime(date.Date), pnl, grossMarketValue, totalNetExposure, positions);
+            var report = new PnlReport(DateOnly.FromDateTime(parsedDate.Date), pnl, grossMarketValue, totalNetExposure, positions);
 
             try
             {
@@ -86,12 +97,45 @@ public static class FillController
 
             return Results.Ok(new
             {
-                Date = date.Date,
+                Date = parsedDate.Date,
                 PnL = pnl,
                 GrossMarketValue = grossMarketValue,
                 TotalNetExposure = totalNetExposure,
                 Positions = positions
             });
+        })
+        .WithName("GetPnlAndSendEmail")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Compute PnL and send notification email.";
+            op.Description = "Calculates PnL for the specified trading date using fills and weights, sends an email report, and returns the computed details.";
+
+            var dateParameter = op.Parameters.SingleOrDefault(p => string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase));
+            if (dateParameter is not null)
+            {
+                dateParameter.Description = "Trading date used to retrieve fills and weights (UTC) in yyyyMMdd format.";
+                dateParameter.Example = new OpenApiString("20240115");
+            }
+
+            op.Responses[StatusCodes.Status200OK.ToString()] = new OpenApiResponse
+            {
+                Description = "PnL calculated and email notification sent successfully."
+            };
+
+            op.Responses[StatusCodes.Status400BadRequest.ToString()] = new OpenApiResponse
+            {
+                Description = "The provided date parameter is missing or not in yyyyMMdd format."
+            };
+
+            op.Responses[StatusCodes.Status500InternalServerError.ToString()] = new OpenApiResponse
+            {
+                Description = "The PnL email notification failed to send."
+            };
+
+            return op;
         });
     }
 }


### PR DESCRIPTION
## Summary
- require the PnL endpoint date query to use yyyyMMdd strings and return a 400 error for invalid input
- update PnL report generation to use parsed dates and document the new format in OpenAPI with an example

## Testing
- Not run (environment missing dotnet CLI)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693861796cc4833396f003ce4b54ac81)