### PR TITLE
Expose automated PnL workflow via Swagger endpoint

### DIFF
--- a/src/TradingDaemon/Controllers/FillController.cs
+++ b/src/TradingDaemon/Controllers/FillController.cs
@@ -1,6 +1,10 @@
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Dapper;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
 using Microsoft.Extensions.Logging;
 using TradingDaemon.Data;
 using TradingDaemon.Models;
@@ -13,27 +17,35 @@ public static class FillController
 {
     public static void MapFillEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapPost("/api/fills", async (Fill fill, DapperContext context) =>
+        app.MapPost("/api/fills", async (Fill fill, DapperContext context, IDatabaseObjectNameProvider databaseObjectNameProvider) =>
         {
             using var connection = context.CreateConnection();
-            var sql = @"INSERT INTO fills (symbol, quantity, price, timestamp)
-                        VALUES (@Symbol, @Quantity, @Price, @Timestamp)";
+            var fillTable = databaseObjectNameProvider.GetObjectName(DatabaseObjects.WakettFill);
+            var sql = $"INSERT INTO {fillTable} (symbol, quantity, price, timestamp)\n                        VALUES (@Symbol, @Quantity, @Price, @Timestamp)";
             Console.WriteLine($"Executing SQL: {sql}");
             await connection.ExecuteAsync(sql, fill);
             return Results.Created($"/api/fills/{fill.Id}", fill);
         });
 
 
-        app.MapGet("/api/pnl", async (DateTime date, DapperContext context, IEmailNotificationService emailNotificationService, ILogger<FillEndpointsLogger> logger) =>
+        app.MapGet("/api/pnl", async (string date, DapperContext context, IDatabaseObjectNameProvider databaseObjectNameProvider, IEmailNotificationService emailNotificationService, ILogger<FillEndpointsLogger> logger) =>
 
         {
+            if (string.IsNullOrWhiteSpace(date) ||
+                !DateTime.TryParseExact(date, "yyyyMMdd", CultureInfo.InvariantCulture,
+                    DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var parsedDate))
+            {
+                return Results.BadRequest("The date query parameter must be formatted as yyyyMMdd (UTC).");
+            }
+
             using var connection = context.CreateConnection();
-            var fillsSql = "SELECT * FROM fills WHERE DATE(timestamp) = @Date";
+            var fillTable = databaseObjectNameProvider.GetObjectName(DatabaseObjects.WakettFill);
+            var fillsSql = $"SELECT * FROM {fillTable} WHERE CAST([timestamp] AS date) = @Date";
             logger.LogInformation("Executing SQL: {Sql}", fillsSql);
-            var fills = await connection.QueryAsync<Fill>(fillsSql, new { Date = date.Date });
-            var weightsSql = "SELECT * FROM weights WHERE DATE(asof) = @Date";
+            var fills = await connection.QueryAsync<Fill>(fillsSql, new { Date = parsedDate.Date });
+            var weightsSql = "SELECT * FROM weights WHERE CAST(asof AS date) = @Date";
             logger.LogInformation("Executing SQL: {Sql}", weightsSql);
-            var weights = await connection.QueryAsync<Weight>(weightsSql, new { Date = date.Date });
+            var weights = await connection.QueryAsync<Weight>(weightsSql, new { Date = parsedDate.Date });
 
             var pnl = (from f in fills
                        join w in weights on f.Symbol equals w.Symbol
@@ -72,7 +84,7 @@ public static class FillController
 
             var grossMarketValue = positions.Sum(p => Math.Abs(p.MarketValueUsd ?? 0m));
             var totalNetExposure = positions.Sum(p => p.MarketValueUsd ?? 0m);
-            var report = new PnlReport(DateOnly.FromDateTime(date.Date), pnl, grossMarketValue, totalNetExposure, positions);
+            var report = new PnlReport(DateOnly.FromDateTime(parsedDate.Date), pnl, grossMarketValue, totalNetExposure, positions);
 
             try
             {
@@ -86,12 +98,45 @@ public static class FillController
 
             return Results.Ok(new
             {
-                Date = date.Date,
+                Date = parsedDate.Date,
                 PnL = pnl,
                 GrossMarketValue = grossMarketValue,
                 TotalNetExposure = totalNetExposure,
                 Positions = positions
             });
+        })
+        .WithName("GetPnlAndSendEmail")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Compute PnL and send notification email.";
+            op.Description = "Calculates PnL for the specified trading date using fills and weights, sends an email report, and returns the computed details.";
+
+            var dateParameter = op.Parameters.SingleOrDefault(p => string.Equals(p.Name, "date", StringComparison.OrdinalIgnoreCase));
+            if (dateParameter is not null)
+            {
+                dateParameter.Description = "Trading date used to retrieve fills and weights (UTC) in yyyyMMdd format.";
+                dateParameter.Example = new OpenApiString("20240115");
+            }
+
+            op.Responses[StatusCodes.Status200OK.ToString()] = new OpenApiResponse
+            {
+                Description = "PnL calculated and email notification sent successfully."
+            };
+
+            op.Responses[StatusCodes.Status400BadRequest.ToString()] = new OpenApiResponse
+            {
+                Description = "The provided date parameter is missing or not in yyyyMMdd format."
+            };
+
+            op.Responses[StatusCodes.Status500InternalServerError.ToString()] = new OpenApiResponse
+            {
+                Description = "The PnL email notification failed to send."
+            };
+
+            return op;
         });
     }
 }

--- a/src/TradingDaemon/Controllers/PnlWorkflowController.cs
+++ b/src/TradingDaemon/Controllers/PnlWorkflowController.cs
@@ -1,0 +1,112 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Microsoft.AspNetCore.OpenApi;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using TradingDaemon.Models;
+using TradingDaemon.Services;
+
+namespace TradingDaemon.Controllers;
+
+public static class PnlWorkflowController
+{
+    public static void MapPnlWorkflowEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapPost("/api/pnl/workflow/run", async Task<Results<Ok<PnlWorkflowResponse>, ProblemHttpResult>> (
+            PnlWorkflowRunner workflowRunner,
+            ILogger<PnlWorkflowEndpointsLogger> logger,
+            CancellationToken cancellationToken) =>
+        {
+            PnlWorkflowResult? result;
+
+            try
+            {
+                result = await workflowRunner.RunAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+
+            if (result is null)
+            {
+                return TypedResults.Problem(
+                    title: "PnL workflow failed.",
+                    detail: "See server logs for additional details.",
+                    statusCode: StatusCodes.Status500InternalServerError);
+            }
+
+            logger.LogInformation(
+                "PnL automation workflow completed for {TradingDate} with PnL {Pnl}.",
+                result.Report.Date,
+                result.Report.Pnl);
+
+            return TypedResults.Ok(new PnlWorkflowResponse(
+                result.Report.Date,
+                result.Report.Pnl,
+                result.Report.GrossMarketValue,
+                result.Report.TotalNetExposure,
+                result.SlippageResult));
+        })
+        .WithName("RunAutomatedPnlWorkflow")
+        .Produces<PnlWorkflowResponse>()
+        .ProducesProblem(StatusCodes.Status500InternalServerError)
+        .WithOpenApi(op =>
+        {
+            op.Summary = "Run the Wakett PnL email automation.";
+            op.Description =
+                "Computes slippage and missed trade costs for the current trading day, recomputes and stores the PnL report, " +
+                "and sends the automated PnL email notification.";
+
+            op.Responses[StatusCodes.Status200OK.ToString()] = new OpenApiResponse
+            {
+                Description = "The PnL workflow finished and the report email was sent.",
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    ["application/json"] = new OpenApiMediaType
+                    {
+                        Schema = new OpenApiSchema
+                        {
+                            Reference = new OpenApiReference
+                            {
+                                Type = ReferenceType.Schema,
+                                Id = nameof(PnlWorkflowResponse)
+                            }
+                        },
+                        Example = new OpenApiObject
+                        {
+                            ["tradingDate"] = new OpenApiString("2024-01-15"),
+                            ["pnl"] = new OpenApiDouble(125000.42),
+                            ["grossMarketValue"] = new OpenApiDouble(3500000.00),
+                            ["totalNetExposure"] = new OpenApiDouble(-150000.25),
+                            ["slippageResult"] = new OpenApiObject
+                            {
+                                ["tradingDate"] = new OpenApiString("2024-01-15"),
+                                ["theoreticalPnl"] = new OpenApiDouble(130000.00),
+                                ["realizedPnl"] = new OpenApiDouble(125000.42),
+                                ["missedTradeCost"] = new OpenApiDouble(2500.00),
+                                ["slippage"] = new OpenApiDouble(4499.58)
+                            }
+                        }
+                    }
+                }
+            };
+
+            op.Responses[StatusCodes.Status500InternalServerError.ToString()] = new OpenApiResponse
+            {
+                Description = "The PnL workflow failed to complete."
+            };
+
+            return op;
+        });
+    }
+}
+
+public sealed record PnlWorkflowResponse(
+    DateOnly TradingDate,
+    decimal Pnl,
+    decimal GrossMarketValue,
+    decimal TotalNetExposure,
+    SlippageResult? SlippageResult);
+
+internal sealed class PnlWorkflowEndpointsLogger;

--- a/src/TradingDaemon/Program.cs
+++ b/src/TradingDaemon/Program.cs
@@ -60,6 +60,7 @@ builder.Services.AddTransient<WeightCalculator>();
 builder.Services.AddTransient<OrderSender>();
 builder.Services.AddTransient<PnlReportService>();
 builder.Services.AddTransient<SlippageAndMissedCostService>();
+builder.Services.AddTransient<PnlWorkflowRunner>();
 
 builder.Services.AddTransient<ReportRunner>();
 
@@ -101,5 +102,6 @@ app.MapReportEndpoints();
 app.MapWakettEndpoints();
 app.MapEmailEndpoints();
 app.MapSlippageEndpoints();
+app.MapPnlWorkflowEndpoints();
 
 app.Run();

--- a/src/TradingDaemon/Services/PnlWorkflowRunner.cs
+++ b/src/TradingDaemon/Services/PnlWorkflowRunner.cs
@@ -1,0 +1,75 @@
+using Microsoft.Extensions.Logging;
+using TradingDaemon.Models;
+
+namespace TradingDaemon.Services;
+
+public sealed record PnlWorkflowResult(PnlReport Report, SlippageResult? SlippageResult);
+
+public sealed class PnlWorkflowRunner
+{
+    private static TimeZoneInfo NewYorkTimeZone
+        => TimeZoneInfo.FindSystemTimeZoneById(
+            OperatingSystem.IsWindows() ? "Eastern Standard Time" : "America/New_York");
+
+    private readonly PnlReportService _pnlReportService;
+    private readonly SlippageAndMissedCostService _slippageAndMissedCostService;
+    private readonly IEmailNotificationService _emailNotificationService;
+    private readonly ILogger<PnlWorkflowRunner> _logger;
+    private readonly TimeProvider _timeProvider;
+
+    public PnlWorkflowRunner(
+        PnlReportService pnlReportService,
+        SlippageAndMissedCostService slippageAndMissedCostService,
+        IEmailNotificationService emailNotificationService,
+        ILogger<PnlWorkflowRunner> logger,
+        TimeProvider? timeProvider = null)
+    {
+        _pnlReportService = pnlReportService;
+        _slippageAndMissedCostService = slippageAndMissedCostService;
+        _emailNotificationService = emailNotificationService;
+        _logger = logger;
+        _timeProvider = timeProvider ?? TimeProvider.System;
+    }
+
+    public async Task<PnlWorkflowResult?> RunAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            var slippageResult = await RunSlippageComputationAsync(cancellationToken);
+            var report = await _pnlReportService.ComputeAndStoreCurrentDayPnlAsync(cancellationToken: cancellationToken);
+            await _emailNotificationService.SendPnLReportAsync(report, slippageResult, cancellationToken);
+            return new PnlWorkflowResult(report, slippageResult);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to compute or send automated Wakett PnL report.");
+            return null;
+        }
+    }
+
+    private async Task<SlippageResult?> RunSlippageComputationAsync(CancellationToken cancellationToken)
+    {
+        var localNow = TimeZoneInfo.ConvertTimeFromUtc(_timeProvider.GetUtcNow().UtcDateTime, NewYorkTimeZone);
+        var tradingDate = DateOnly.FromDateTime(localNow);
+
+        _logger.LogInformation(
+            "Computing slippage and missed trade costs via automation for {TradingDate}.",
+            tradingDate);
+
+        try
+        {
+            return await _slippageAndMissedCostService.ComputeAsync(
+                new SlippageRequest { Date = tradingDate.ToDateTime(TimeOnly.MinValue) },
+                cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to compute slippage or missed trade costs for Wakett automation.");
+            return null;
+        }
+    }
+}

--- a/src/TradingDaemon/Services/WakettAutomationService.cs
+++ b/src/TradingDaemon/Services/WakettAutomationService.cs
@@ -37,9 +37,7 @@ public sealed class WakettAutomationService : BackgroundService
     private readonly WeightCalculator _weightCalculator;
     private readonly OrderSender _orderSender;
     private readonly WakettTradeFetcher _tradeFetcher;
-    private readonly PnlReportService _pnlReportService;
-    private readonly SlippageAndMissedCostService _slippageAndMissedCostService;
-    private readonly IEmailNotificationService _emailNotificationService;
+    private readonly PnlWorkflowRunner _pnlWorkflowRunner;
     private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<WakettAutomationService> _logger;
     private readonly WakettAutomationOptions _options;
@@ -51,9 +49,7 @@ public sealed class WakettAutomationService : BackgroundService
         WeightCalculator weightCalculator,
         OrderSender orderSender,
         WakettTradeFetcher tradeFetcher,
-        PnlReportService pnlReportService,
-        SlippageAndMissedCostService slippageAndMissedCostService,
-        IEmailNotificationService emailNotificationService,
+        PnlWorkflowRunner pnlWorkflowRunner,
         IHostApplicationLifetime applicationLifetime,
         IOptions<WakettAutomationOptions> options,
         ILogger<WakettAutomationService> logger,
@@ -64,9 +60,7 @@ public sealed class WakettAutomationService : BackgroundService
         _weightCalculator = weightCalculator;
         _orderSender = orderSender;
         _tradeFetcher = tradeFetcher;
-        _pnlReportService = pnlReportService;
-        _slippageAndMissedCostService = slippageAndMissedCostService;
-        _emailNotificationService = emailNotificationService;
+        _pnlWorkflowRunner = pnlWorkflowRunner;
         _applicationLifetime = applicationLifetime;
         _logger = logger;
         _options = options?.Value ?? new WakettAutomationOptions();
@@ -210,7 +204,7 @@ public sealed class WakettAutomationService : BackgroundService
                 while (nowUtc >= nextPnlReportUtc)
                 {
                     var scheduledRunUtc = nextPnlReportUtc;
-                    await RunPnlWorkflowAsync(stoppingToken);
+                    await _pnlWorkflowRunner.RunAsync(stoppingToken);
                     nextPnlReportUtc = GetNextSessionEventUtc(
                         scheduledRunUtc.AddSeconds(1),
                         PnlReportOffsets,
@@ -344,46 +338,6 @@ public sealed class WakettAutomationService : BackgroundService
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogError(ex, "Wakett order submission failed.");
-        }
-    }
-
-    private async Task RunPnlWorkflowAsync(CancellationToken stoppingToken)
-    {
-        try
-        {
-            var slippageResult = await RunSlippageComputationAsync(stoppingToken);
-            var report = await _pnlReportService.ComputeAndStoreCurrentDayPnlAsync(cancellationToken: stoppingToken);
-            await _emailNotificationService.SendPnLReportAsync(report, slippageResult, stoppingToken);
-        }
-        catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
-        {
-            throw;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Failed to compute or send automated Wakett PnL report.");
-        }
-    }
-
-    private async Task<SlippageResult?> RunSlippageComputationAsync(CancellationToken stoppingToken)
-    {
-        var localNow = TimeZoneInfo.ConvertTimeFromUtc(_timeProvider.GetUtcNow().UtcDateTime, NewYorkTimeZone);
-        var tradingDate = DateOnly.FromDateTime(localNow);
-
-        _logger.LogInformation(
-            "Computing slippage and missed trade costs via automation for {TradingDate}.",
-            tradingDate);
-
-        try
-        {
-            return await _slippageAndMissedCostService.ComputeAsync(
-                new SlippageRequest { Date = tradingDate.ToDateTime(TimeOnly.MinValue) },
-                stoppingToken);
-        }
-        catch (Exception ex) when (ex is not OperationCanceledException)
-        {
-            _logger.LogError(ex, "Failed to compute slippage and missed trade costs via automation.");
-            return null;
         }
     }
 


### PR DESCRIPTION
## Summary
- add a dedicated PnL workflow runner to encapsulate slippage computation, report generation, and email sending
- expose a Swagger-documented endpoint to trigger the automated PnL workflow and return report details
- reuse the new runner inside the Wakett automation service and register it for DI

## Testing
- Not run (dotnet CLI not available in this environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693861796cc4833396f003ce4b54ac81)