### PR TITLE
Add configurable Wakett order steps

### DIFF
--- a/src/TradingDaemon/Models/WakettModels.cs
+++ b/src/TradingDaemon/Models/WakettModels.cs
@@ -39,12 +39,21 @@ public class WakettOrderItem
     public string side { get; set; } = string.Empty;
     public string code { get; set; } = string.Empty;
     public WakettOrderSize size { get; set; } = new();
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public WakettOrderSteps? steps { get; set; }
 }
 
 public class WakettOrderSize
 {
     public double value { get; set; }
     public string type { get; set; } = string.Empty;
+}
+
+public class WakettOrderSteps
+{
+    public double? start { get; set; }
+    public double? end { get; set; }
+    public double? speed { get; set; }
 }
 
 public class WakettOrderResponse

--- a/src/TradingDaemon/Services/OrderSender.cs
+++ b/src/TradingDaemon/Services/OrderSender.cs
@@ -225,6 +225,14 @@ public class OrderSender
         }
 
         var orders = builtOrders.Select(order => order.Order).ToList();
+        var orderSteps = ResolveOrderSteps();
+        if (orderSteps is not null)
+        {
+            foreach (var order in orders)
+            {
+                order.steps = orderSteps;
+            }
+        }
 
         var request = new WakettOrderRequest
         {
@@ -1947,6 +1955,48 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         }
 
         _logger.LogWarning("Unable to parse Wakett AUM value '{Value}'.", configured);
+        return null;
+    }
+
+    private WakettOrderSteps? ResolveOrderSteps()
+    {
+        var section = _configuration.GetSection("ExternalApis:WakettApi:OrderSteps");
+        if (!section.Exists())
+        {
+            return null;
+        }
+
+        var start = ParseOrderStep(section["Start"], "start");
+        var end = ParseOrderStep(section["End"], "end");
+        var speed = ParseOrderStep(section["Speed"], "speed");
+
+        if (!start.HasValue || !end.HasValue || !speed.HasValue)
+        {
+            return null;
+        }
+
+        return new WakettOrderSteps
+        {
+            start = start.Value,
+            end = end.Value,
+            speed = speed.Value
+        };
+    }
+
+    private double? ParseOrderStep(string? value, string stepName)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            _logger.LogWarning("Wakett order steps value for {StepName} is not configured.", stepName);
+            return null;
+        }
+
+        if (double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        _logger.LogWarning("Unable to parse Wakett order steps value '{Value}' for {StepName}.", value, stepName);
         return null;
     }
 

--- a/src/TradingDaemon/appsettings.json
+++ b/src/TradingDaemon/appsettings.json
@@ -31,6 +31,11 @@
       "BaseUrl": "https://api.qqb.wakett.com/prod/trading/",
       "TradeBaseUrl": "https://api.qqb.wakett.com/prod/history/",
       "Aum": 1000000,
+      "OrderSteps": {
+        "Start": -180,
+        "End": 120,
+        "Speed": 30
+      },
       "PairUsdLimits": {
         "AUDUSD": 30000000,
         "USDCAD": 30000000,
@@ -97,6 +102,11 @@
           "BaseUrl": "https://api.qqb.wakett.com/test/trading/",
           "TradeBaseUrl": "https://api.qqb.wakett.com/test/history/",
           "Aum": 1000000,
+          "OrderSteps": {
+            "Start": -180,
+            "End": 120,
+            "Speed": 30
+          },
           "PairUsdLimits": {
             "AUDUSD": 30000000,
             "USDCAD": 30000000,


### PR DESCRIPTION
### Motivation

- Support the Wakett API's new `steps` parameters (`start`, `end`, `speed`) so orders can be executed in stepped intervals overlapping the end of the bar.
- Make the `steps` values configurable from application configuration so operators can change execution framing without code changes.
- Preserve existing Wakett order response handling so downstream processing and persistence remain compatible.

### Description

- Add a `WakettOrderSteps` model and an optional `steps` property on `WakettOrderItem` that is serialized only when present (`[JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]`).
- Populate `steps` for each outgoing order in `OrderSender` by adding `ResolveOrderSteps()` which reads `ExternalApis:WakettApi:OrderSteps` (`Start`, `End`, `Speed`) from configuration and logs when values are missing or cannot be parsed.
- Attach the resolved `steps` object to every `WakettOrderRequest` order before sending via `WakettApiClient`, and do not change the `WakettOrderResponse` model or `SendOrdersAsync` behavior so the response parsing remains unchanged.
- Add default `OrderSteps` entries to `src/TradingDaemon/appsettings.json` for the base configuration and the `Test` environment (`Start: -180`, `End: 120`, `Speed: 30`).

### Testing

- No automated tests were executed for this change.
- The implementation logs warnings when `OrderSteps` are missing or when individual values cannot be parsed, to aid runtime validation.
- Manual inspection ensured that `WakettOrderResponse` types and `WakettApiClient.SendOrdersAsync` usage were not modified so response handling is preserved.
- Recommend running integration tests that call the Wakett `orders` endpoint to validate end-to-end behavior in a staging/test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6964b5284e648333b0ade3b5225fbe2a)