### PR TITLE
Only fetch Wakett bars when a timestamp has no prices

### DIFF
--- a/src/TradingDaemon/Services/WakettPriceFetcher.cs
+++ b/src/TradingDaemon/Services/WakettPriceFetcher.cs
@@ -122,6 +122,9 @@ public class WakettPriceFetcher
         stageStopwatch.Stop();
         _logger.LogInformation("[Wakett] Cleared staging tables in {ElapsedMs} ms.", stageStopwatch.ElapsedMilliseconds);
 
+        var nowUtc = DateTimeOffset.UtcNow;
+        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow);
+
         var missingBars = new List<(int MinuteOffset, DateTime BarTimeUtc)>();
         var missingDetection = Stopwatch.StartNew();
         foreach (var minuteOffset in PriceMinuteOffsets)
@@ -130,6 +133,8 @@ public class WakettPriceFetcher
             var missingForOffset = await FindMissingBarTimestampsAsync(
                 uploadSecurityIds,
                 minuteOffset,
+                historicalWindowStart.UtcDateTime,
+                nowUtc.UtcDateTime,
                 connection,
                 cancellationToken);
             missingBars.AddRange(missingForOffset.Select(bar => (minuteOffset, bar)));
@@ -145,9 +150,6 @@ public class WakettPriceFetcher
             "[Wakett] Completed missing-bar discovery across {OffsetCount} offsets in {ElapsedMs} ms.",
             PriceMinuteOffsets.Count,
             missingDetection.ElapsedMilliseconds);
-
-        var nowUtc = DateTimeOffset.UtcNow;
-        var historicalWindowStart = nowUtc.Subtract(HistoricalWindow);
 
         var fetchableMissingBars = missingBars
             .Where(entry => entry.BarTimeUtc.AddMinutes(entry.MinuteOffset) >= historicalWindowStart.UtcDateTime)
@@ -946,7 +948,93 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
             var missing = new List<DateTime>();
             foreach (var timestamp in expectedTimestamps)
             {
-                if (!existing.TryGetValue(timestamp, out var set) || set.Count < securityIds.Count)
+                if (!existing.ContainsKey(timestamp))
+                {
+                    missing.Add(timestamp);
+                }
+            }
+
+            return missing;
+        }
+        finally
+        {
+            if (ownsConnection)
+            {
+                connection.Dispose();
+            }
+        }
+    }
+
+    private async Task<IReadOnlyList<DateTime>> FindMissingBarTimestampsAsync(
+        IReadOnlyCollection<int> securityIds,
+        int minuteOffset,
+        DateTime windowStartUtc,
+        DateTime windowEndUtc,
+        IDbConnection? connection,
+        CancellationToken cancellationToken)
+    {
+        if (securityIds.Count == 0)
+            return Array.Empty<DateTime>();
+
+        var normalizedStartUtc = NormalizeToHourUtc(windowStartUtc);
+        var normalizedEndUtc = NormalizeToHourUtc(windowEndUtc);
+        if (normalizedEndUtc < normalizedStartUtc)
+        {
+            return Array.Empty<DateTime>();
+        }
+
+        var expectedTimestamps = BuildExpectedBarHours(normalizedStartUtc, normalizedEndUtc);
+        if (expectedTimestamps.Count == 0)
+        {
+            return Array.Empty<DateTime>();
+        }
+
+        var startHourUtc = expectedTimestamps[0];
+        var endHourUtc = expectedTimestamps[^1];
+        var startUtc = startHourUtc.AddMinutes(minuteOffset);
+        var endUtc = endHourUtc.AddMinutes(minuteOffset);
+
+        var ownsConnection = connection is null;
+        connection ??= await OpenConnectionAsync(cancellationToken);
+
+        try
+        {
+            var rows = await connection.QueryAsync<(int SecurityId, DateTime BarTimeUtc)>(
+                _priceBarWindowQuery,
+                new
+                {
+                    SecurityIds = securityIds.ToArray(),
+                    StartUtc = startUtc,
+                    EndUtc = endUtc,
+                    MinuteOffset = minuteOffset
+                });
+
+            var existing = new Dictionary<DateTime, HashSet<int>>();
+            foreach (var row in rows)
+            {
+                var normalized = DateTime.SpecifyKind(row.BarTimeUtc, DateTimeKind.Utc);
+                normalized = new DateTime(
+                    normalized.Year,
+                    normalized.Month,
+                    normalized.Day,
+                    normalized.Hour,
+                    0,
+                    0,
+                    DateTimeKind.Utc);
+
+                if (!existing.TryGetValue(normalized, out var set))
+                {
+                    set = new HashSet<int>();
+                    existing[normalized] = set;
+                }
+
+                set.Add(row.SecurityId);
+            }
+
+            var missing = new List<DateTime>();
+            foreach (var timestamp in expectedTimestamps)
+            {
+                if (!existing.ContainsKey(timestamp))
                 {
                     missing.Add(timestamp);
                 }
@@ -988,14 +1076,9 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
                     BarTimeUtc = expectedBarTimestampUtc
                 });
 
-            var present = new HashSet<int>();
-            foreach (var securityId in rows)
+            foreach (var _ in rows)
             {
-                present.Add(securityId);
-                if (present.Count == ids.Length)
-                {
-                    return false;
-                }
+                return false;
             }
 
             return true;
@@ -1031,6 +1114,30 @@ WHERE IsActive = 1 AND Symbol IS NOT NULL AND LTRIM(RTRIM(Symbol)) <> ''";
         }
 
         result.Reverse();
+        return result;
+    }
+
+    internal static IReadOnlyList<DateTime> BuildExpectedBarHours(DateTime startHourUtc, DateTime endHourUtc)
+    {
+        var normalizedStart = NormalizeToHourUtc(startHourUtc);
+        var normalizedEnd = NormalizeToHourUtc(endHourUtc);
+        if (normalizedEnd < normalizedStart)
+        {
+            return Array.Empty<DateTime>();
+        }
+
+        var result = new List<DateTime>();
+        var current = normalizedStart;
+        while (current <= normalizedEnd)
+        {
+            if (!IsWeekend(current))
+            {
+                result.Add(current);
+            }
+
+            current = current.AddHours(1);
+        }
+
         return result;
     }
 


### PR DESCRIPTION
### Motivation
- Avoid re-fetching price bars when some prices already exist for a timestamp so partially populated timestamps are not re-queried.
- Restrict missing-bar discovery to the configured historical window to reduce scan scope and improve performance.

### Description
- Treat a bar timestamp as missing only when no prices exist for that timestamp by changing presence checks to return present on any row instead of requiring all securities.
- Add a window-aware overload `FindMissingBarTimestampsAsync(..., windowStartUtc, windowEndUtc, ...)` and a `BuildExpectedBarHours(DateTime startHourUtc, DateTime endHourUtc)` helper to enumerate expected hours inside the window.
- Compute `nowUtc` and `historicalWindowStart` earlier and pass the window into missing-bar discovery, and filter `fetchableMissingBars` by the configured `HistoricalWindow`.
- Update `ArePricesMissingForTimestampAsync` and missing-timestamp aggregation in `WakettPriceFetcher.cs` to skip fetching when any price rows exist for a timestamp.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6967540145448333ab736c338efee628)